### PR TITLE
Release v0.14.0

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -331,6 +331,9 @@ jobs:
           name: storage-opfs-package-build
           path: packages/storage-opfs/dist
 
+      - name: Restore generated WASM source link
+        run: ln -s ../dist/wasm packages/js-sdk/src/wasm
+
       - name: Test JS SDK package
         working-directory: packages/js-sdk
         run: |


### PR DESCRIPTION
The first v0.14.0 publication attempt correctly stopped before immutable registry uploads because the SDK release test could not resolve generated Wasm files after artifact transfer.

This restores the generated `src/wasm` link from the uploaded `dist/wasm` payload before release tests. Squash-merging with the release title retriggers publication for v0.14.0 from the fixed commit; v0.13 remains intentionally skipped.