### PR TITLE
fix(lix): hydrate sparse root history

### DIFF
--- a/.changenotes/hydrate-sparse-root-history.md
+++ b/.changenotes/hydrate-sparse-root-history.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Root and latest-checkpoint queries now hydrate deferred commit history on sparse sync replicas.
+
+Observers and diff commands transparently retry after fetching a missing commit-graph ancestor instead of failing with an internal error.

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -18,7 +18,10 @@ use lix::server_protocol::{
     LixServerProtocol, ServerProtocolBody, ServerProtocolContext, ServerProtocolPrincipal,
 };
 use lix::storage::Storage;
-use lix::{ExecuteBatchStatement, Lix, Memory, ServerOptions, Value, WireValue, open_lix};
+use lix::{
+    CreateBranchOptions, ExecuteBatchStatement, Lix, Memory, MergeBranchOptions, ServerOptions,
+    SwitchBranchOptions, Value, WireValue, open_lix,
+};
 use lix_storage_filesystem::FilesystemStorage;
 use serde_json::{Value as JsonValue, json};
 use tempfile::TempDir;
@@ -1840,6 +1843,128 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
     );
 
     replica.close().await.expect("close replica");
+    stop_server(server_task).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn sparse_replica_observer_hydrates_root_history_past_a_merge_frontier() {
+    // A bounded bootstrap can retain a recent linear head and a merge in its
+    // jump/base closure while deferring the merge's direct first parent. Root
+    // resolution must expose that absence as a sparse graph demand so observe
+    // hydrates and retries.
+    let (authority_storage, authority) = open_authority().await;
+    let root_commit_id = authority
+        .execute("SELECT lix_root_commit_id() AS commit_id", &[])
+        .await
+        .expect("authority root should resolve")
+        .rows()[0]
+        .get::<String>("commit_id")
+        .expect("authority root id decodes");
+    let main_branch_id = authority
+        .active_branch_id()
+        .await
+        .expect("main branch id should load");
+    let source = authority
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "sparse-root-source".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("source branch should be created");
+
+    put_value(&authority, "main-only", "main").await;
+    authority
+        .switch_branch(SwitchBranchOptions {
+            branch_id: source.id.clone(),
+        })
+        .await
+        .expect("source branch should become active");
+    put_value(&authority, "source-only", "source").await;
+    authority
+        .switch_branch(SwitchBranchOptions {
+            branch_id: main_branch_id,
+        })
+        .await
+        .expect("main branch should become active again");
+    let merge = authority
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: source.id,
+        })
+        .await
+        .expect("diverged source should merge");
+    assert!(
+        merge.created_merge_commit_id.is_some(),
+        "fixture requires a merge commit at the authority head"
+    );
+    for index in 0..3 {
+        put_value(
+            &authority,
+            &format!("after-merge-{index}"),
+            "after-merge",
+        )
+        .await;
+    }
+    authority.close().await.expect("close authority setup");
+
+    let probe = Arc::new(HttpProbe::default());
+    let (url, server_task) = serve(authority_storage, Arc::clone(&probe)).await;
+    let replica_dir = TempDir::new().expect("replica tempdir");
+    let replica = open_replica(replica_dir.path(), &url).await;
+    let bootstrap_history_gets = probe.history_gets.load(Ordering::Acquire);
+
+    let mut roots = replica
+        .observe("SELECT lix_root_commit_id() AS commit_id", &[])
+        .expect("root observer should open");
+    let first = tokio::time::timeout(WAIT_TIMEOUT, roots.next())
+        .await
+        .expect("timed out waiting for hydrated root")
+        .expect("root observer should hydrate sparse history")
+        .expect("root observer should yield a first event");
+    assert_eq!(
+        first.rows.rows()[0]
+            .get::<String>("commit_id")
+            .expect("replica root id decodes"),
+        root_commit_id,
+    );
+    assert_eq!(
+        probe.history_gets.load(Ordering::Acquire),
+        bootstrap_history_gets + 1,
+        "root traversal past the merge frontier should demand one bounded history page"
+    );
+
+    roots.close();
+    replica.close().await.expect("close replica");
+
+    // Write diff commands resolve their source commits in a transaction-local
+    // walker. A separate sparse replica ensures the read observer above has
+    // not already hydrated the missing merge parent for this code path.
+    let command_replica_dir = TempDir::new().expect("command replica tempdir");
+    let command_replica = open_replica(command_replica_dir.path(), &url).await;
+    let command_bootstrap_history_gets = probe.history_gets.load(Ordering::Acquire);
+    let applied = command_replica
+        .execute(
+            "INSERT INTO lix_apply (relation, row_pk) \
+             SELECT 'lix_key_value', lixcol_row_pk \
+             FROM lix_diff(\
+               'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
+             ) \
+             WHERE false",
+            &[],
+        )
+        .await
+        .expect("root-based write diff should hydrate sparse history");
+    assert_eq!(applied.rows_affected(), 0, "empty apply should not mutate");
+    assert_eq!(
+        probe.history_gets.load(Ordering::Acquire),
+        command_bootstrap_history_gets + 1,
+        "write diff root traversal should demand one bounded history page"
+    );
+
+    command_replica
+        .close()
+        .await
+        .expect("close command replica");
     stop_server(server_task).await;
 }
 

--- a/packages/lix/src/checkpoint.rs
+++ b/packages/lix/src/checkpoint.rs
@@ -147,10 +147,7 @@ where
         }
 
         let node = commit_graph.load_node(&candidate).await?.ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("cannot resolve latest checkpoint: commit '{candidate}' is missing"),
-            )
+            crate::commit_graph::missing_commit_graph_error(&candidate)
         })?;
         let Some(first_parent) = node.parent_commit_ids.first().copied() else {
             return Ok(None);

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -881,7 +881,7 @@ fn validate_first_parent_jump(
     Ok(())
 }
 
-pub(super) fn missing_commit_graph_error(commit_id: &CommitId) -> LixError {
+pub(crate) fn missing_commit_graph_error(commit_id: &CommitId) -> LixError {
     LixError::commit_not_found(commit_id.to_string(), "walk_commit_graph", "graph_node")
 }
 

--- a/packages/lix/src/commit_graph/mod.rs
+++ b/packages/lix/src/commit_graph/mod.rs
@@ -4,7 +4,10 @@ pub(crate) mod scope_digest_census;
 mod types;
 mod walker;
 
-pub(crate) use context::{CommitGraphContext, CommitGraphStoreReader, canonical_commit_change};
+pub(crate) use context::{
+    CommitGraphContext, CommitGraphStoreReader, canonical_commit_change,
+    missing_commit_graph_error,
+};
 #[cfg(test)]
 pub(crate) use scope_digest_census::scope_digest_census;
 #[cfg(test)]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -6018,6 +6018,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn latest_checkpoint_reports_a_sparse_graph_miss_for_a_missing_cursor_commit() {
+        let session = open_session().await;
+        let branch_id = session
+            .active_branch_id()
+            .await
+            .expect("active branch should load");
+        let read = session
+            .storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .expect("branch control read should open");
+        let mut control = crate::branch::BranchHeadControlContext::new()
+            .reader(&read)
+            .load(&branch_id)
+            .await
+            .expect("branch control should read")
+            .expect("active branch control should exist");
+        let missing = crate::changelog::CommitId::for_test_label("missing-checkpoint-cursor");
+        control.working_diff_checkpoint_commit_id = Some(missing);
+        drop(read);
+        let mut corrupt = session.storage.new_write_set();
+        crate::branch::stage_branch_head_control(&mut corrupt, &branch_id, control)
+            .expect("missing cursor fixture should stage");
+        session
+            .storage
+            .commit_write_set(corrupt, StorageWriteOptions::default())
+            .await
+            .expect("missing cursor fixture should commit");
+
+        let error = session
+            .execute("SELECT lix_latest_checkpoint_commit_id() AS commit_id", &[])
+            .await
+            .expect_err("missing cursor commit should surface a graph miss");
+        assert_eq!(error.code, LixError::CODE_COMMIT_NOT_FOUND);
+        assert_eq!(
+            error.details.as_ref().expect("graph miss details")["commit_id"],
+            missing.to_string()
+        );
+        assert_eq!(
+            error.details.as_ref().expect("graph miss details")["operation"],
+            "walk_commit_graph"
+        );
+        assert_eq!(
+            error.details.as_ref().expect("graph miss details")["role"],
+            "graph_node"
+        );
+    }
+
+    #[tokio::test]
     async fn exact_registered_schema_point_preserves_typed_public_projection() {
         let session = open_session().await;
         let schema = serde_json::json!({

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -349,10 +349,7 @@ where
     let mut commit_graph = context.commit_graph();
     loop {
         let node = commit_graph.load_node(&current).await?.ok_or_else(|| {
-            LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
-                format!("cannot resolve repository root: commit '{current}' is missing"),
-            )
+            crate::commit_graph::missing_commit_graph_error(&current)
         })?;
         let Some(first_parent) = node.parent_commit_ids.first().copied() else {
             return Ok(Some(node.commit_id.to_string()));

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -9387,10 +9387,7 @@ where
             let mut current = head;
             loop {
                 let node = graph.load_node(&current).await?.ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        format!("cannot resolve repository root: commit '{current}' is missing"),
-                    )
+                    crate::commit_graph::missing_commit_graph_error(&current)
                 })?;
                 let Some(first_parent) = node.parent_commit_ids.first().copied() else {
                     break Some(node.commit_id.to_string());


### PR DESCRIPTION
## Summary

- classify missing root/checkpoint ancestors as the existing structured sparse commit-graph miss
- let sync-mode execute/observe hydrate the deferred history and retry transparently
- cover observed root reads, transaction-local `lix_apply`, and latest-checkpoint resolution

## Production failure

Lixray's deployed sync E2E exposed a fresh sparse replica whose bounded header closure reached a merge but deferred its direct first parent. `resolve_root_commit_id` converted that expected sparse miss into `LIX_INTERNAL_ERROR`, closing the repository-home observer before the sync demand worker could fetch history.

## Verification

- `cargo nextest run -p lix --features all-simulations` (3398 passed)
- `cargo test -p lix --doc` (10 passed)
- `cargo nextest run --manifest-path packages/e2e/Cargo.toml --features sdk-tests,server-protocol --test sync_mode` (21 passed before the final transaction-coverage correction; corrected focused case passes)
- exact CI clippy lanes for the root workspace, tooling workspace, and `lix_e2e`
- two independent final reviews; no remaining findings
