### PR TITLE
refactor(lix): hard cut diff commands to opaque row refs

### DIFF
--- a/.changenotes/row-ref-checkpoint-hard-cut.md
+++ b/.changenotes/row-ref-checkpoint-hard-cut.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added opaque row references and a single SQL checkpoint function for full and scoped checkpoints.
+
+Diff and selection surfaces now use `row_ref`, scoped checkpoints accept arrays of row references, and omitted diff commits default to the latest checkpoint through the active branch head. The former typed checkpoint SDK and two-column JSON row-key selection contract have been removed.

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -84,8 +84,7 @@ If both branches changed the same row after their merge base, the preview includ
 ```ts
 {
 	kind: "sameRowChanged",
-	schemaKey: "acme_section",
-	rowPk: ["s1"],
+	rowRef: "lix_row_ref:v1:…",
 	fileId: null,
 	target: { kind: "modified", beforeChangeId, afterChangeId },
 	source: { kind: "modified", beforeChangeId, afterChangeId },

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -10,15 +10,17 @@ branch head to inspect subsequent changes at the relation level your interface
 uses.
 
 ```ts
-const checkpoint = await lix.createCheckpoint();
-console.log("created checkpoint", checkpoint.commitId);
+const checkpoint = await lix.execute(
+  "SELECT commit_id FROM lix_create_checkpoint()",
+);
+console.log("created checkpoint", checkpoint.rows[0].commit_id);
 ```
 
-`createCheckpoint()` checkpoints the active branch and returns the new checkpoint
-commit ID. The equivalent full SQL checkpoint is a metadata-only operation:
+`lix_create_checkpoint()` checkpoints the active branch and returns the new
+checkpoint commit ID. A full checkpoint is a metadata-only operation:
 
 ```sql
-INSERT INTO lix_create_checkpoint DEFAULT VALUES RETURNING commit_id;
+SELECT commit_id FROM lix_create_checkpoint();
 ```
 
 ## Complete example
@@ -27,7 +29,7 @@ INSERT INTO lix_create_checkpoint DEFAULT VALUES RETURNING commit_id;
 import { openLix } from "@lix-js/sdk";
 
 const lix = await openLix();
-await lix.createCheckpoint();
+await lix.execute("SELECT commit_id FROM lix_create_checkpoint()");
 
 await lix.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
   "checkpoint-demo",
@@ -35,26 +37,18 @@ await lix.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
 ]);
 
 const working = await lix.execute(
-  `SELECT lixcol_row_pk, diff_type, from_value, to_value
-   FROM lix_diff(
-     'lix_key_value',
-     lix_latest_checkpoint_commit_id(),
-     lix_active_branch_commit_id()
-   )`,
+  `SELECT row_ref, key, diff_type, from_value, to_value
+   FROM lix_diff('lix_key_value')`,
 );
 
 for (const row of working.rows) {
-  console.log(row.diff_type, row.lixcol_row_pk);
+  console.log(row.diff_type, row.key, row.row_ref);
 }
 
-await lix.createCheckpoint();
+await lix.execute("SELECT commit_id FROM lix_create_checkpoint()");
 const remaining = await lix.execute(
   `SELECT count(*) AS count
-   FROM lix_diff(
-     'lix_key_value',
-     lix_latest_checkpoint_commit_id(),
-     lix_active_branch_commit_id()
-   )`,
+   FROM lix_diff('lix_key_value')`,
 );
 console.assert(remaining.rows[0].count === 0);
 
@@ -68,7 +62,7 @@ A runnable Rust version lives at
 
 | Surface | Scope | Columns |
 | :-- | :-- | :-- |
-| `lix_diff(relation, from_commit_id, to_commit_id)` | One relation across two explicit commits | `lixcol_row_pk`, `diff_type`, `row_count`, and paired `from_<column>` / `to_<column>` relation columns |
+| `lix_diff(relation[, from_commit_id, to_commit_id])` | One relation, defaulting to latest checkpoint → active head | `row_ref`, typed primary-key columns, `diff_type`, `row_count`, and paired `from_<column>` / `to_<column>` relation columns |
 | `lix_checkpoint` | Repository-global checkpoint markers | `id`, `commit_id`, and standard `lixcol_*` columns |
 | `lix_commit` | Repository-global commit graph | `id`, `parent_commit_ids`, and standard `lixcol_*` columns |
 | `lix_history('lix_checkpoint'[, commit_id])` | Global checkpoint-row authorship history | Checkpoint columns and standard history `lixcol_*` columns |
@@ -91,12 +85,8 @@ when the branch has no checkpoint. Pair it with the active head to inspect
 working changes in one query, including before the first checkpoint:
 
 ```sql
-SELECT lixcol_row_pk, diff_type
-FROM lix_diff(
-  'lix_file',
-  lix_latest_checkpoint_commit_id(),
-  lix_active_branch_commit_id()
-);
+SELECT row_ref, id, diff_type
+FROM lix_diff('lix_file');
 ```
 
 Checkpoint markers in `lix_checkpoint` are repository-global. Querying the
@@ -124,7 +114,6 @@ ORDER BY ancestry.depth, checkpoint.commit_id;
 The anchor has `depth = 0`; direct parents have depth `1`. A commit reachable
 through several merge paths appears once at its shortest depth.
 
-Create a checkpoint for every tracked change through `lix.createCheckpoint()`
-or `INSERT INTO lix_create_checkpoint DEFAULT VALUES`. Select a subset through
-the `(relation, row_pk)` command form described in
-[Diff commands](./diff-commands.md).
+Create a checkpoint for every tracked change through
+`SELECT commit_id FROM lix_create_checkpoint()`. Select a subset by passing an
+array of `row_ref` values as described in [Diff commands](./diff-commands.md).

--- a/docs/comparison-to-git.md
+++ b/docs/comparison-to-git.md
@@ -36,7 +36,7 @@ order_id 1002 status:
 You query that history with SQL:
 
 ```sql
-SELECT created_at, schema_key, row_pk, snapshot_content
+SELECT created_at, schema_key, row_ref, snapshot_content
 FROM lix_change
 ORDER BY created_at DESC
 LIMIT 20;

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -5,9 +5,10 @@ description: Compare typed Lix relations across commits and select rows atomical
 # Diff commands
 
 `lix_diff(relation, from_commit_id, to_commit_id)` compares one relation across
-two explicitly selected commits. A file is one row of `lix_file`; a registered
-schema row is one row of its schema relation. Commands consume that same
-`(relation, row_pk)` identity, so selecting a file also selects its underlying
+two explicitly selected commits. With only the relation argument it defaults
+to latest checkpoint → active head. A file is one row of `lix_file`; a
+registered schema row is one row of its schema relation. Commands consume the
+diff's `row_ref` identity, so selecting a file also selects its underlying
 tracked content.
 
 ## Review changed files
@@ -17,12 +18,8 @@ import { openLix } from "@lix-js/sdk";
 
 const lix = await openLix();
 const changedFiles = await lix.execute(
-  `SELECT lixcol_row_pk, diff_type, from_path, to_path, row_count
-   FROM lix_diff(
-     'lix_file',
-     lix_latest_checkpoint_commit_id(),
-     lix_active_branch_commit_id()
-   )
+  `SELECT row_ref, id, diff_type, from_path, to_path, row_count
+   FROM lix_diff('lix_file')
    ORDER BY coalesce(to_path, from_path)`,
 );
 
@@ -31,16 +28,12 @@ for (const row of changedFiles.rows) {
 }
 
 const reverted = await lix.execute(
-  `INSERT INTO lix_revert (relation, row_pk)
-   SELECT 'lix_file', lixcol_row_pk
-   FROM lix_diff(
-     'lix_file',
-     lix_latest_checkpoint_commit_id(),
-     lix_active_branch_commit_id()
-   )
-   WHERE lixcol_row_pk = $1
+  `INSERT INTO lix_revert (row_ref)
+   SELECT row_ref
+   FROM lix_diff('lix_file')
+   WHERE id = $1
    RETURNING commit_id`,
-  [changedFiles.rows[0].lixcol_row_pk],
+  [changedFiles.rows[0].id],
 );
 
 if (reverted.rows.length > 0) {
@@ -57,8 +50,8 @@ for a new branch.
 
 ## Diff rows
 
-Every relation diff exposes `lixcol_row_pk`, `diff_type`,
-`row_count`, and a
+Every relation diff exposes `row_ref`, the relation's typed primary-key
+columns, `diff_type`, `row_count`, and a
 `from_<column>` / `to_<column>` pair for each column of the compared relation.
 `diff_type` is `added`, `modified`, or `removed`. Added rows have empty `from_`
 values; removed rows have empty `to_` values. Use
@@ -93,46 +86,40 @@ collection-generation marker, not individual row changes. Expanding that marker
 into per-row `lix_diff` results is unsupported; delete selected rows individually
 when row-level history or diff visibility is required.
 
-Both commit IDs are required. `lix_root_commit_id()` returns the repository
-root; comparing it with another commit reports files present in that commit as
-added rows. Genesis comparisons of internal bootstrap schema rows are
-unsupported because those metadata rows already exist in the bootstrap root.
+`lix_root_commit_id()` returns the repository root; comparing it with another
+commit reports files present in that commit as added rows. Genesis comparisons
+of internal bootstrap schema rows are unsupported because those metadata rows
+already exist in the bootstrap root.
 
 ```sql
-SELECT lixcol_row_pk, to_path
+SELECT row_ref, id, to_path
 FROM lix_diff('lix_file', lix_root_commit_id(), $commit_id);
 ```
 
 ## Commands
 
-The insert-only command sinks consume queries selecting `(relation, row_pk)`:
+The insert-only apply and revert command sinks consume queries selecting one
+`row_ref` column:
 
 ```sql
-INSERT INTO lix_revert (relation, row_pk)
-SELECT 'lix_file', lixcol_row_pk
-FROM lix_diff(
-  'lix_file',
-  lix_latest_checkpoint_commit_id(),
-  lix_active_branch_commit_id()
-)
+INSERT INTO lix_revert (row_ref)
+SELECT row_ref
+FROM lix_diff('lix_file')
 WHERE coalesce(to_path, from_path) LIKE '/docs/%';
 
-INSERT INTO lix_apply (relation, row_pk)
-SELECT 'acme_task', lixcol_row_pk
+INSERT INTO lix_apply (row_ref)
+SELECT row_ref
 FROM lix_diff('acme_task', $from_commit_id, $to_commit_id)
 WHERE to_done = true;
 
-INSERT INTO lix_create_checkpoint (relation, row_pk)
-SELECT 'lix_file', lixcol_row_pk
-FROM lix_diff(
-  'lix_file',
-  lix_latest_checkpoint_commit_id(),
-  lix_active_branch_commit_id()
-)
-WHERE to_path LIKE '/docs/%'
-RETURNING commit_id;
+SELECT commit_id
+FROM lix_create_checkpoint(ARRAY(
+  SELECT row_ref
+  FROM lix_diff('lix_file')
+  WHERE to_path LIKE '/docs/%'
+));
 
-INSERT INTO lix_create_checkpoint DEFAULT VALUES RETURNING commit_id;
+SELECT commit_id FROM lix_create_checkpoint();
 ```
 
 Selecting a file includes the tracked rows composing that file. Partial file
@@ -142,12 +129,11 @@ instead of producing an invalid checkpoint. Selecting `lix_directory` rows
 directly is unsupported; select the affected `lix_file` rows instead.
 
 Each statement is atomic. An empty selection succeeds without creating a
-commit, duplicate selected identities are rejected, and every command supports
-`RETURNING commit_id`. A command that creates a commit returns exactly one row,
-regardless of how many relation-row identities it consumes. For relation-row
-selection commands, `rowsAffected` continues to report the number of selected
-identities. Full checkpoints report one affected row, use `DEFAULT VALUES`, and
-structurally reuse the branch state without copying application rows.
+commit and duplicate selected identities are rejected. Apply and revert support
+`RETURNING commit_id`; `lix_create_checkpoint()` returns the commit ID as its
+one result row. For apply and revert, `rowsAffected` reports the number of
+selected identities. Full checkpoints structurally reuse the branch state
+without copying application rows.
 
 Rows written with `lixcol_untracked` are absent from every diff. Untracked
 state belongs to the local repository replica and is not transported through

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -52,7 +52,7 @@ for a new branch.
 
 Every relation diff exposes `row_ref`, the relation's typed primary-key
 columns, `diff_type`, `row_count`, and a
-`from_<column>` / `to_<column>` pair for each column of the compared relation.
+`from_<column>` / `to_<column>` pair for each non-primary-key column of the compared relation.
 `diff_type` is `added`, `modified`, or `removed`. Added rows have empty `from_`
 values; removed rows have empty `to_` values. Use
 `coalesce(to_path, from_path)` when displaying a path that also covers removed
@@ -123,10 +123,9 @@ SELECT commit_id FROM lix_create_checkpoint();
 ```
 
 Selecting a file includes the tracked rows composing that file. Partial file
-checkpoints also include required ancestor directory descriptors. Selections
-outside the supported dependency-closure paths fail with a descriptive error
-instead of producing an invalid checkpoint. Selecting `lix_directory` rows
-directly is unsupported; select the affected `lix_file` rows instead.
+checkpoints also include required ancestor directory descriptors. Directory
+rows and mixed-relation selections use the same dependency planner. A scope
+that cannot be closed into a valid checkpoint fails before commit.
 
 Each statement is atomic. An empty selection succeeds without creating a
 commit and duplicate selected identities are rejected. Apply and revert support

--- a/docs/diffs.md
+++ b/docs/diffs.md
@@ -43,9 +43,9 @@ A text diff sees a line:
 
 Lix sees a row:
 
-| schema_key | row_pk                   | snapshot_content                                                        |
-| ---------- | ------------------------ | ----------------------------------------------------------------------- |
-| `csv_row`  | `["0192f3a1-…-7b2c"]` | `{"id": "0192f3a1-…-7b2c", "order_key": "…", "cells": ["1002", "Widget B", "shipped"]}` |
+| row_ref | schema_key | snapshot_content |
+| --- | --- | --- |
+| `lix_row_ref:v1:…` | `csv_row` | `{"id": "0192f3a1-…-7b2c", "order_key": "…", "cells": ["1002", "Widget B", "shipped"]}` |
 
 The CSV plugin gives each record a stable `id`, so the row keeps its identity
 even when the file is reordered. `cells` holds the decoded record. One cell

--- a/docs/history.md
+++ b/docs/history.md
@@ -52,7 +52,7 @@ columns:
 
 | Column | What it is |
 | :-- | :-- |
-| `lixcol_row_pk` | JSON array of primary-key values in Schema v1 `primary_key` order. |
+| `lixcol_row_ref` | Relation-qualified `lix_row_ref` for the logical row. |
 | `lixcol_schema_key` | The registered schema key. |
 | `lixcol_file_id` | The owning file, or `NULL`. |
 | `lixcol_metadata` | JSON change metadata. |
@@ -136,7 +136,8 @@ Filesystem history describes a composed projection. Renaming, moving,
 deleting, or restoring an ancestor directory creates a revision for every
 affected descendant even when the descendant's own descriptor did not change.
 Each row records all same-commit causes in the structured
-`lixcol_source_changes` JSON array. It deliberately does not expose singular
+`lixcol_source_changes` JSON array. Each source object carries a `row_ref`
+instead of a JSON primary-key tuple. It deliberately does not expose singular
 `lixcol_change_id`, `lixcol_schema_key`, or `lixcol_origin_key` columns.
 
 Lix reconstructs rows through the anchor commit's ancestry. It does not treat
@@ -152,7 +153,7 @@ branch reachability. Ordinary untracked writes do not create change rows.
 | Column | What it is |
 | :-- | :-- |
 | `id` | Unique change ID. |
-| `row_pk` | JSON array of primary-key values in schema order. |
+| `row_ref` | Relation-qualified row reference, or `NULL` for private engine rows. |
 | `schema_key` | Changed Schema v1 key. |
 | `file_id` | Owning file, or `NULL`. |
 | `metadata` | JSON change metadata. |
@@ -161,15 +162,13 @@ branch reachability. Ordinary untracked writes do not create change rows.
 | `origin_key` | Optional origin key attached to the change. |
 | `created_at` | Change timestamp. |
 
-`row_pk` is an ordered JSON array even for a singleton key. Use numeric path
-segments for array indexes:
+Use `lix_row_ref()` to address a public logical row without reconstructing its
+primary-key encoding:
 
 ```sql
 SELECT created_at, id, snapshot_content
 FROM lix_change
-WHERE schema_key = 'acme_issue'
-  AND row_pk ->> 0 = 'launch'
-  AND row_pk ->> 1 = '7'
+WHERE row_ref = lix_row_ref('acme_issue', 'launch', '7')
 ORDER BY created_at, id;
 ```
 

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -274,22 +274,19 @@ const unsubscribe = lix.subscribeActiveBranch(listener);
 Subscribes to successful branch switches made through this Lix handle. The
 `listener` is a function with no arguments. Returns an unsubscribe function.
 
-### createCheckpoint()
+### Checkpoints
+
+Checkpointing uses the canonical SQL surface rather than a separate typed SDK
+method:
 
 ```ts
-const checkpoint = await lix.createCheckpoint();
+const result = await lix.execute(
+  "SELECT commit_id FROM lix_create_checkpoint()",
+);
+const commitId = result.rows[0].commit_id;
 ```
 
-Creates a checkpoint from the pending working changes on the active branch. See
-[Checkpoints](./checkpoints.md).
-
-Result:
-
-```ts
-type CreateCheckpointReceipt = {
-  commitId: string;
-};
-```
+See [Checkpoints](./checkpoints.md) for scoped row-reference selections.
 
 ### undo() / redo()
 

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -422,8 +422,7 @@ type MergeChangeStats = {
 ```ts
 type MergeConflict = {
   kind: "sameRowChanged";
-  schemaKey: string;
-  rowPk: unknown;
+  rowRef: string;
   fileId: string | null;
   target: MergeConflictSide;
   source: MergeConflictSide;

--- a/docs/server-protocol.md
+++ b/docs/server-protocol.md
@@ -92,8 +92,11 @@ being embedded in commit JSON. Upload is one retryable loop: register the
 manifest, PUT only the returned missing chunks, then register the same manifest
 again. There is no separate presence request.
 
-Every commit member and snapshot row encodes `rowPk` losslessly as an ordered
-array of typed components. Each component is an object with `type` equal to
+Every commit member and snapshot row encodes its physical replication identity
+as `(schemaKey, fileId, rowPk)`. This is deliberately not the public SQL/SDK
+`lix_row_ref`: one logical file reference may aggregate several physical rows.
+The sync-only `rowPk` is an ordered array of typed components. Each component is
+an object with `type` equal to
 `uuid`, `integer`, `string`, or `bytes`; `value` is respectively a canonical
 UUID string, a JSON integer, a string, or a base64 string. For example:
 

--- a/docs/server-protocol.md
+++ b/docs/server-protocol.md
@@ -28,14 +28,14 @@ and authentication and forwards requests to it. See [Hosting](./hosting.md).
 
 | Group       | Paths                                                                                         |
 | :---------- | :-------------------------------------------------------------------------------------------- |
-| Handshake   | `/lix/v1/{lix_id}`, `/lix/v1/{lix_id}/session`                                                                  |
-| SQL         | `/lix/v1/{lix_id}/execute`, `/lix/v1/{lix_id}/execute-batch`                                                    |
-| Transaction | `/lix/v1/{lix_id}/transaction/{begin,execute,commit,rollback}`                                         |
-| Files       | `/lix/v1/{lix_id}/file`, `/lix/v1/{lix_id}/file/upsert`, `/lix/v1/{lix_id}/file/upsert-batch`                            |
-| Sync        | `/lix/v1/{lix_id}/sync/{push,pull,history,blob,chunk}`                                                 |
-| Versioning  | `/lix/v1/{lix_id}/branch/{create,switch}`, `/lix/v1/{lix_id}/checkpoint/create`, `/lix/v1/{lix_id}/undo`, `/lix/v1/{lix_id}/redo` |
-| Observation | `/lix/v1/{lix_id}/observe`, `/lix/v1/{lix_id}/observe/multiplex`                                                |
-| Snapshot    | `/lix/v1/{lix_id}/snapshot`                                                                         |
+| Handshake   | `/lix/v1/{lix_id}`, `/lix/v1/{lix_id}/session`                                  |
+| SQL         | `/lix/v1/{lix_id}/execute`, `/lix/v1/{lix_id}/execute-batch`                    |
+| Transaction | `/lix/v1/{lix_id}/transaction/{begin,execute,commit,rollback}`                  |
+| Files       | `/lix/v1/{lix_id}/file`, `/lix/v1/{lix_id}/file/upsert{,-batch}`               |
+| Sync        | `/lix/v1/{lix_id}/sync/{push,pull,history,blob,chunk}`                          |
+| Versioning  | `/lix/v1/{lix_id}/branch/{create,switch}`, `/lix/v1/{lix_id}/{undo,redo}`       |
+| Observation | `/lix/v1/{lix_id}/observe`, `/lix/v1/{lix_id}/observe/multiplex`                |
+| Snapshot    | `/lix/v1/{lix_id}/snapshot`                                                     |
 
 SDK users pass the complete stable locator `https://host/lix/{lix_id}`.
 `openLix()` rewrites that terminal locator to `/lix/v1/{lix_id}`, opens a

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -63,7 +63,7 @@ no checkpoint, it returns `lix_root_commit_id()`. Use both branch-scoped
 accessors to read working changes in one query:
 
 ```sql
-SELECT lixcol_row_pk, diff_type
+SELECT row_ref, id, diff_type
 FROM lix_diff(
   'lix_file',
   lix_latest_checkpoint_commit_id(),

--- a/docs/sql-functions.md
+++ b/docs/sql-functions.md
@@ -14,8 +14,15 @@ operators; there are no public `lix_json_*` functions.
 | `lix_active_branch_commit_id()` | text | Active branch head pinned for the statement. |
 | `lix_latest_checkpoint_commit_id()` | text | Active branch's latest checkpoint, or the repository root if it has none. |
 | `lix_root_commit_id()` | text | Repository bootstrap root. |
+| `lix_row_ref(relation, primary_key...)` | row_ref | Opaque address of one relation row, including composite keys. |
 | `uuidv7()` | uuid | Generate a UUIDv7 value. |
 | `CURRENT_TIMESTAMP` | timestamptz | Transaction-start instant at microsecond precision. |
+
+`lix_row_ref` takes the relation's typed primary-key values in declared order:
+
+```sql
+SELECT lix_row_ref('json_object_member', $1, $2) AS row_ref;
+```
 
 ## JSONB
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -111,7 +111,7 @@ schema contributes another `RELATION` / `BASE` surface.
 | Relation / view | `lix_branch`, `lix_change`, `lix_directory`, `lix_file` |
 | Table function | `lix_commit_ancestry`, `lix_create_checkpoint` (mutating), `lix_diff`, `lix_history` |
 | Command sink | `lix_apply`, `lix_restore`, `lix_revert` |
-| Scalar function | `lix_active_account_id`, `lix_active_branch_commit_id`, `lix_active_branch_id`, `lix_latest_checkpoint_commit_id`, `lix_root_commit_id`, `uuidv7` |
+| Scalar function | `lix_active_account_id`, `lix_active_branch_commit_id`, `lix_active_branch_id`, `lix_latest_checkpoint_commit_id`, `lix_root_commit_id`, `lix_row_ref`, `uuidv7` |
 
 Standard SQL value expressions such as `CURRENT_TIMESTAMP` are supported SQL
 syntax, not Lix-owned scalar-function surfaces, and are therefore omitted from

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -42,10 +42,10 @@ case-fold, or Unicode-normalize paths. Filesystem adapters diagnose names that
 the target host cannot represent.
 
 The checkpoint and diff relations are read-only. `lix_diff()` exposes
-`lixcol_row_pk`, `diff_type`, `row_count`, and paired
-`from_<column>` / `to_<column>` relation
-columns. Pass `(relation, row_pk)` to the `lix_revert`, `lix_apply`, and
-`lix_create_checkpoint` command sinks. See [Checkpoints](./checkpoints.md) and
+`row_ref`, the relation's typed primary-key columns, `diff_type`, `row_count`,
+and paired `from_<column>` / `to_<column>` relation columns. Pass `row_ref` to
+the `lix_revert` and `lix_apply` command sinks or to the
+`lix_create_checkpoint()` function. See [Checkpoints](./checkpoints.md) and
 [Diff commands](./diff-commands.md).
 
 For branch-scoped working changes, use `lix_latest_checkpoint_commit_id()` and
@@ -109,8 +109,8 @@ schema contributes another `RELATION` / `BASE` surface.
 | --- | --- |
 | Relation / base | `lix_account`, `lix_checkpoint`, `lix_commit`, `lix_key_value`, `lix_registered_schema` |
 | Relation / view | `lix_branch`, `lix_change`, `lix_directory`, `lix_file` |
-| Table function | `lix_commit_ancestry`, `lix_diff`, `lix_history` |
-| Command sink | `lix_apply`, `lix_create_checkpoint`, `lix_restore`, `lix_revert` |
+| Table function | `lix_commit_ancestry`, `lix_create_checkpoint` (mutating), `lix_diff`, `lix_history` |
+| Command sink | `lix_apply`, `lix_restore`, `lix_revert` |
 | Scalar function | `lix_active_account_id`, `lix_active_branch_commit_id`, `lix_active_branch_id`, `lix_latest_checkpoint_commit_id`, `lix_root_commit_id`, `uuidv7` |
 
 Standard SQL value expressions such as `CURRENT_TIMESTAMP` are supported SQL
@@ -119,10 +119,9 @@ syntax, not Lix-owned scalar-function surfaces, and are therefore omitted from
 
 Classify by SQL shape, not merely by whether data is computed dynamically.
 Unparameterized, table-shaped projections are views. Row producers invoked in
-the `FROM` clause with function syntax are table functions. Side-effecting
-operations are command sinks and use `INSERT`; they are not table functions.
-This keeps commands out of relation and function discovery even when a command
-supports `RETURNING`.
+the `FROM` clause with function syntax are table functions. Apply, restore, and
+revert are command sinks and use `INSERT`. Checkpoint creation is the one narrow
+mutating table function so full and scoped checkpoints share one SQL surface.
 
 JSON-backed columns are SQL `TEXT` and are marked with
 `lix_value_kind = 'JSONB'`. `is_nullable` describes values returned by reads;
@@ -141,8 +140,8 @@ omitted on insert, and rejects an explicit `NULL`.
 | `CONDITIONAL` | Whether the column is required depends on the row's other inputs. |
 
 `CONDITIONAL` covers deliberate alternative forms: filesystem rows can use a
-`path` or their directory/name fields, and typed rows can derive
-`lixcol_row_pk` from their public primary-key columns. These policies
+`path` or their directory/name fields, and typed rows derive identity from
+their public primary-key columns. These policies
 describe omission only; `is_nullable` still describes read values.
 
 ## Typed schema surfaces

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -444,11 +444,12 @@ where
         let checkpoint_ms = if checkpoint_every.is_some_and(|interval| (index + 1) % interval == 0)
         {
             let checkpoint_started = Instant::now();
-            db::block_on(lix.create_checkpoint()).map_err(|error| {
-                CliError::msg(format!(
-                    "failed to checkpoint after replay commit {commit_sha}: {error}"
-                ))
-            })?;
+            db::block_on(lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[]))
+                .map_err(|error| {
+                    CliError::msg(format!(
+                        "failed to checkpoint after replay commit {commit_sha}: {error}"
+                    ))
+                })?;
             let elapsed_ms = duration_to_ms(checkpoint_started.elapsed());
             phase_totals.checkpoint_ms += elapsed_ms;
             Some(elapsed_ms)

--- a/packages/cli/src/commands/exp/git_replay.rs
+++ b/packages/cli/src/commands/exp/git_replay.rs
@@ -3370,7 +3370,7 @@ mod tests {
             "initialization plus four replayed commits should publish five checkpoints"
         );
         let text_rows = db::block_on(lix.execute(
-            "SELECT lixcol_row_pk FROM text_line WHERE lixcol_file_id = $1",
+            "SELECT id FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"docs/renamed.txt")))],
         ))
         .expect("Git text rows should be queryable after replay");
@@ -3379,7 +3379,7 @@ mod tests {
             "renamed text file must derive Git-text semantic rows at its new path"
         );
         let csv_rows = db::block_on(lix.execute(
-            "SELECT lixcol_row_pk FROM csv_row WHERE lixcol_file_id = $1",
+            "SELECT id FROM csv_row WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"table.csv")))],
         ))
         .expect("CSV rows should be queryable after replay");
@@ -3389,7 +3389,7 @@ mod tests {
             "CSV replay must eagerly materialize both records"
         );
         let binary_rows = db::block_on(lix.execute(
-            "SELECT lixcol_row_pk FROM text_line WHERE lixcol_file_id = $1",
+            "SELECT id FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"binary.bin")))],
         ))
         .expect("Git text rows should query for binary fixture");
@@ -3478,7 +3478,7 @@ mod tests {
         let lix = db::block_on(open_lix().with_storage(storage))
             .expect("replay Lix should reopen cleanly");
         let rows = db::block_on(lix.execute(
-            "SELECT lixcol_row_pk FROM csv_row WHERE lixcol_file_id = $1",
+            "SELECT id FROM csv_row WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"table.csv")))],
         ))
         .expect("CSV rows should be queryable after replay");
@@ -3657,7 +3657,7 @@ mod tests {
             );
 
             let semantic_rows = db::block_on(lix.execute(
-                "SELECT lixcol_row_pk FROM text_line WHERE lixcol_file_id = $1",
+                "SELECT id FROM text_line WHERE lixcol_file_id = $1",
                 &[Value::Text(stable_file_id(&git_path(
                     path.trim_start_matches('/').as_bytes(),
                 )))],
@@ -3754,7 +3754,7 @@ mod tests {
         assert_eq!(rendered, Some(b"a\na\n".as_slice()));
 
         let semantic_rows = db::block_on(lix.execute(
-            "SELECT lixcol_row_pk FROM text_line WHERE lixcol_file_id = $1",
+            "SELECT id FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(stable_file_id(&git_path(b"src/index.ts")))],
         ))
         .expect("replayed Git-text rows should query");

--- a/packages/cli/src/output/mod.rs
+++ b/packages/cli/src/output/mod.rs
@@ -73,6 +73,7 @@ fn value_to_text(value: &Value) -> String {
         Value::Real(v) => v.to_string(),
         Value::Text(v) => v.clone(),
         Value::Jsonb(v) => v.to_string(),
+        Value::RowRef(v) => v.as_str().to_string(),
         Value::Timestamptz(v) => timestamp_text(*v),
         Value::Blob(bytes) => bytes_to_hex(bytes),
     }
@@ -88,6 +89,7 @@ fn value_to_json(value: &Value) -> JsonValue {
             .unwrap_or(JsonValue::Null),
         Value::Text(v) => JsonValue::String(v.clone()),
         Value::Jsonb(v) => v.to_value(),
+        Value::RowRef(v) => JsonValue::String(v.as_str().to_string()),
         Value::Timestamptz(v) => JsonValue::String(timestamp_text(*v)),
         Value::Blob(bytes) => serde_json::json!({
             "$blob": base64::engine::general_purpose::STANDARD.encode(bytes),

--- a/packages/e2e/benches/checkpoint_history_scale.rs
+++ b/packages/e2e/benches/checkpoint_history_scale.rs
@@ -366,7 +366,7 @@ where
         .expect("open checkpoint-query setup session");
     for _ in 0..additional_checkpoints {
         session
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("create checkpoint-query fixture checkpoint");
     }

--- a/packages/e2e/benches/tracked_state_crud/sql_session.rs
+++ b/packages/e2e/benches/tracked_state_crud/sql_session.rs
@@ -106,6 +106,7 @@ fn fold_value(accumulator: u64, value: &Value) -> u64 {
         Value::Jsonb(value) => fold_bytes(accumulator, 5, value.as_bytes()),
         Value::Blob(value) => fold_bytes(accumulator, 6, value.as_bytes()),
         Value::Timestamptz(value) => fold_bytes(accumulator, 7, &value.to_le_bytes()),
+        Value::RowRef(value) => fold_bytes(accumulator, 8, value.as_str().as_bytes()),
     }
 }
 

--- a/packages/e2e/benches/tracked_working_diff.rs
+++ b/packages/e2e/benches/tracked_working_diff.rs
@@ -51,9 +51,9 @@ const DEFAULT_UNRELATED_HISTORY_WIDTH: usize = 1;
 const UNRELATED_HISTORY_STORAGE_BATCH: usize = 100_000;
 const INSERT_BATCH_SIZE: usize = 500;
 const MERGE_PREVIEW_SOURCE_BRANCH_ID: &str = "01920000-0000-7000-8000-000000000901";
-const WORKING_DIFF_SQL: &str = "SELECT lixcol_row_pk, diff_type, row_count \
+const WORKING_DIFF_SQL: &str = "SELECT row_ref, key, diff_type, row_count \
     FROM lix_diff('working_diff_row', $1, lix_active_branch_commit_id()) \
-    ORDER BY lixcol_row_pk";
+    ORDER BY key";
 
 #[derive(Clone, Copy)]
 enum Shape {

--- a/packages/e2e/benches/tracked_working_diff.rs
+++ b/packages/e2e/benches/tracked_working_diff.rs
@@ -418,9 +418,12 @@ async fn setup<StorageImpl>(
     let seed_elapsed = seed_start.elapsed();
     let initial_checkpoint_start = Instant::now();
     let initial_checkpoint = session
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
-        .expect("create tracked-working-diff initial checkpoint");
+        .expect("create tracked-working-diff initial checkpoint")
+        .rows()[0]
+        .get::<String>("commit_id")
+        .expect("checkpoint commit id decodes");
     let initial_checkpoint_elapsed = initial_checkpoint_start.elapsed();
 
     let writes_start = Instant::now();
@@ -458,7 +461,7 @@ async fn setup<StorageImpl>(
          base_commit_id={} head_commit_id={} seed_ms={:.3} initial_checkpoint_ms={:.3} writes_ms={:.3}",
         backend.name(),
         shape_name(shape),
-        initial_checkpoint.commit_id,
+        initial_checkpoint,
         head_commit_id,
         millis(seed_elapsed),
         millis(initial_checkpoint_elapsed),
@@ -594,7 +597,7 @@ where
     assert!(before > 0, "fixture has no populated working diffs");
     let start = Instant::now();
     session
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint populated working-diff fixture");
     let elapsed = start.elapsed();
@@ -639,7 +642,7 @@ async fn measure_merge_preview<StorageImpl>(
     register_schema(&target).await;
     seed_rows(&target, row_count).await;
     target
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint merge-preview base");
     target
@@ -739,7 +742,7 @@ async fn measure_merge_commit<StorageImpl>(
     register_schema(&target).await;
     seed_rows(&target, row_count).await;
     target
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint merge-commit base");
 

--- a/packages/e2e/benches/working_diff_file_scope.rs
+++ b/packages/e2e/benches/working_diff_file_scope.rs
@@ -164,7 +164,7 @@ async fn run<StorageImpl>(
     seed_rows(&session, &file_ids, rows_per_file).await;
 
     session
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("create working-diff file-scope checkpoint");
 

--- a/packages/e2e/benches/working_diff_file_scope.rs
+++ b/packages/e2e/benches/working_diff_file_scope.rs
@@ -212,25 +212,25 @@ async fn run<StorageImpl>(
         .get::<String>("commit_id")
         .expect("benchmark checkpoint ID");
     let file_sql = format!(
-        "SELECT lixcol_row_pk, diff_type, row_count \
+        "SELECT row_ref, id, diff_type, row_count \
          FROM lix_diff('lix_file', '{checkpoint}', lix_active_branch_commit_id()) \
-         WHERE lixcol_row_pk ->> 0 = $1"
+         WHERE id = $1"
     );
     let full_sql = format!(
-        "SELECT lixcol_row_pk, diff_type, row_count \
+        "SELECT row_ref, id, diff_type, row_count \
          FROM lix_diff('lix_file', '{checkpoint}', lix_active_branch_commit_id())"
     );
     let file_schema_sql = format!(
-        "SELECT lixcol_row_pk, diff_type, row_count \
+        "SELECT row_ref, id, diff_type, row_count \
          FROM lix_diff('{SCHEMA_KEY}', '{checkpoint}', lix_active_branch_commit_id()) \
          WHERE to_lixcol_file_id = $1"
     );
     // Finite identity + file id: takes the existing bypass and resolves as a
     // point read. This is the floor a seekable file-scoped read aims at.
     let point_sql = format!(
-        "SELECT lixcol_row_pk, diff_type, row_count \
+        "SELECT row_ref, id, diff_type, row_count \
          FROM lix_diff('{SCHEMA_KEY}', '{checkpoint}', lix_active_branch_commit_id()) \
-         WHERE lixcol_row_pk = CAST($1 AS JSONB)"
+         WHERE id = $1"
     );
     // Live-state read of the same file. HOT_ROW is keyed
     // `schema_key ++ file_id ++ row_pk` and `hot_scan_entries` owns a

--- a/packages/e2e/examples/branch_merge_benchmark.rs
+++ b/packages/e2e/examples/branch_merge_benchmark.rs
@@ -894,8 +894,8 @@ where
     let expected_diff = map_diff_oracle(&base, &target_before_preview);
     let diff_measure = measure_async(|| async {
         lix.execute(
-            "SELECT lixcol_row_pk, diff_type, from_id, to_id \
-             FROM lix_diff('branch_bench_row', $1, $2) ORDER BY lixcol_row_pk",
+            "SELECT id, diff_type \
+             FROM lix_diff('branch_bench_row', $1, $2) ORDER BY id",
             &[
                 Value::Text(preview.base_commit_id.clone()),
                 Value::Text(preview.target_head_commit_id.clone()),
@@ -910,36 +910,11 @@ where
         .rows()
         .iter()
         .map(|row| {
-            let row_pk = row
-                .get::<serde_json::Value>("lixcol_row_pk")
-                .expect("diff row identity");
-            let id = row_pk
-                .as_array()
-                .and_then(|parts| parts.first())
-                .and_then(serde_json::Value::as_str)
-                .expect("single-string diff identity")
-                .to_owned();
+            let id = row.get::<String>("id").expect("diff row identity");
             let kind = row
                 .get::<String>("diff_type")
                 .expect("diff type");
-            let side_id = |column| match row.value(column).expect("diff side identity column") {
-                Value::Null => None,
-                Value::Text(id) => Some(id.clone()),
-                other => panic!("unexpected {column} value {other:?}"),
-            };
-            let before = side_id("from_id");
-            let after = side_id("to_id");
-            match kind.as_str() {
-                "added" => assert!(before.is_none() && after.is_some()),
-                "modified" => assert!(before.is_some() && after.is_some()),
-                "removed" => assert!(before.is_some() && after.is_none()),
-                other => panic!("unexpected diff kind {other:?}"),
-            }
-            assert!(
-                before.as_deref().is_none_or(|id| !id.is_empty())
-                    && after.as_deref().is_none_or(|id| !id.is_empty()),
-                "diff row identities must be non-empty"
-            );
+            assert!(!id.is_empty(), "diff row identities must be non-empty");
             (id, kind)
         })
         .collect::<Vec<_>>();

--- a/packages/e2e/examples/cas_gc_qualification.rs
+++ b/packages/e2e/examples/cas_gc_qualification.rs
@@ -475,7 +475,7 @@ where
             .await
             .expect("publish retention commit");
         session
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("publish retention checkpoint");
     }

--- a/packages/e2e/examples/e1_json_leak.rs
+++ b/packages/e2e/examples/e1_json_leak.rs
@@ -169,7 +169,7 @@ async fn run_cell(shape: &str, cadence: usize, edits: usize) {
         }
         if cadence > 0 && revision % cadence == 0 {
             session
-                .create_checkpoint()
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("create a checkpoint");
         }
@@ -180,7 +180,7 @@ async fn run_cell(shape: &str, cadence: usize, edits: usize) {
         // one needs a successor before its predecessors are provably retirable.
         checkpoints = edits / cadence + 1;
         session
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("create the releasing checkpoint");
     }

--- a/packages/e2e/examples/e29_locator_leak.rs
+++ b/packages/e2e/examples/e29_locator_leak.rs
@@ -182,7 +182,7 @@ async fn main() {
             }
             if checkpoint_every > 0 && revision % checkpoint_every == 0 {
                 session
-                    .create_checkpoint()
+                    .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                     .await
                     .expect("create a checkpoint");
             }
@@ -192,7 +192,7 @@ async fn main() {
             // last one needs a successor before its predecessors are provably
             // retirable.
             session
-                .create_checkpoint()
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("create the releasing checkpoint");
         }

--- a/packages/e2e/examples/e3_cas_reclaim_scan.rs
+++ b/packages/e2e/examples/e3_cas_reclaim_scan.rs
@@ -119,7 +119,7 @@ fn main() {
                 .await
                 .expect("delete reclaim scan payloads");
             session
-                .create_checkpoint()
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("checkpoint reclaim scan deletion");
         }

--- a/packages/e2e/examples/expaa_replay_scope.rs
+++ b/packages/e2e/examples/expaa_replay_scope.rs
@@ -79,7 +79,7 @@ async fn main() {
         latencies.push(start.elapsed());
         if checkpoint_every > 0 && (index + 1) % checkpoint_every == 0 {
             session
-                .create_checkpoint()
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("checkpoint should publish");
             checkpoints += 1;

--- a/packages/e2e/examples/expab_plan_load.rs
+++ b/packages/e2e/examples/expab_plan_load.rs
@@ -150,7 +150,7 @@ where
     let _ = take_plan_load_attribution();
     let checkpoint_start = Instant::now();
     session
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint should publish");
     let checkpoint_wall = checkpoint_start.elapsed();

--- a/packages/e2e/examples/expv_blind_space_growth.rs
+++ b/packages/e2e/examples/expv_blind_space_growth.rs
@@ -191,7 +191,7 @@ async fn checkpoints_scenario(samples: &[usize], rows_per_commit: usize) {
             commit_batch(&fixture.session, created, rows_per_commit).await;
             fixture
                 .session
-                .create_checkpoint()
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("create checkpoint");
             created += 1;
@@ -284,7 +284,7 @@ async fn checkpoint_then_gc_scenario(commits: usize, rows_per_commit: usize, gc_
     );
     fixture
         .session
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("create checkpoint");
     report(

--- a/packages/e2e/tests/certified_replacement_delete_reopen.rs
+++ b/packages/e2e/tests/certified_replacement_delete_reopen.rs
@@ -111,7 +111,7 @@ async fn replacement_delete_checkpoint_reopens<S: ReopenStorage>() {
                 .rows_affected(),
             ROW_COUNT as u64
         );
-        lix.create_checkpoint()
+        lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("checkpoint deleted replacement collection");
         assert_collection_empty(&lix).await;

--- a/packages/e2e/tests/checkpoint_branch_merge_reopen.rs
+++ b/packages/e2e/tests/checkpoint_branch_merge_reopen.rs
@@ -83,10 +83,12 @@ async fn checkpoint_preserves_branch_merge_base_after_reopen<S: ReopenStorage>()
         .expect("insert shared rows");
         fork_commit_id = active_commit_id(&main).await;
         checkpoint_commit_id = main
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("checkpoint target branch")
-            .commit_id;
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("checkpoint commit id decodes");
         assert_eq!(
             commit_parent_edges(&main, &checkpoint_commit_id).await,
             vec![(initial_commit_id.clone(), 0)],

--- a/packages/e2e/tests/checkpoint_gc_replay_reopen.rs
+++ b/packages/e2e/tests/checkpoint_gc_replay_reopen.rs
@@ -103,12 +103,14 @@ async fn checkpoint_gc_retains_replay_and_selected_owners_after_reopen<S: Reopen
         assert_generation(&lix, 2, true).await;
 
         let compacted_owner = lix
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("create compacting checkpoint")
-            .commit_id;
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("checkpoint commit id decodes");
         for _ in 1..CHECKPOINT_GC_INTERVAL {
-            lix.create_checkpoint()
+            lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("advance production checkpoint-GC cadence");
         }

--- a/packages/e2e/tests/corruption_recovery_qualification.rs
+++ b/packages/e2e/tests/corruption_recovery_qualification.rs
@@ -186,7 +186,9 @@ async fn qualify_healthy_reopen_undo_diff_and_branch_control<B: DurableBackend>(
     )
     .await
     .expect("insert healthy probe");
-    lix.create_checkpoint().await.expect("create checkpoint");
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .expect("create checkpoint");
     let checkpoint_head = active_head(&lix).await;
     lix.execute(
         "UPDATE lix_key_value SET value = 'after' WHERE key = 'corruption-probe'",
@@ -266,7 +268,7 @@ async fn qualify_tracked_tree_chunk<B: DurableBackend>() {
         .await
         .expect("insert tracked-tree fixture row");
     }
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint tracked-tree fixture");
     let checkpoint_head = active_head(&lix).await;
@@ -276,7 +278,7 @@ async fn qualify_tracked_tree_chunk<B: DurableBackend>() {
     )
     .await
     .expect("update tracked-tree fixture row");
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint updated tracked-tree fixture");
     let updated_head = active_head(&lix).await;

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -1749,7 +1749,7 @@ where
         .await
         .expect("main Markdown branch should reactivate");
     }
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("Markdown checkpoint should commit");
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -1882,7 +1882,7 @@ async fn v3_markdown_byte_roundtrip_slatedb_server_style_runtime_stack_guard() {
         Some(expected.clone())
     );
     qualify_markdown_server_style_branch(&lix, &expected).await;
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("server-style SlateDB branch checkpoint");
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -1914,7 +1914,7 @@ async fn v3_markdown_byte_roundtrip_slatedb_server_style_checkpoint_guard() {
     write_file(&lix, "/company/competitors.md", expected.clone())
         .await
         .expect("server-style SlateDB Markdown write");
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("server-style SlateDB Markdown checkpoint");
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -5525,7 +5525,13 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
     )
     .await
     .unwrap();
-    let baseline_checkpoint = lix.create_checkpoint().await.unwrap();
+    let baseline_checkpoint = lix
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<String>("commit_id")
+        .unwrap();
     let selected_file_id = file_id_at_path(&lix, "/selected.csv").await;
     let remaining_file_id = file_id_at_path(&lix, "/remaining.csv").await;
 
@@ -5550,7 +5556,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
              WHERE id = $1",
             &[
                 Value::Text(selected_file_id.clone()),
-                Value::Text(baseline_checkpoint.commit_id),
+                Value::Text(baseline_checkpoint),
             ],
         )
         .await

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -5547,7 +5547,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
         .execute(
             "SELECT coalesce(sum(row_count), 0) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-             WHERE lixcol_row_pk ->> 0 = $1",
+             WHERE id = $1",
             &[
                 Value::Text(selected_file_id.clone()),
                 Value::Text(baseline_checkpoint.commit_id),
@@ -5560,11 +5560,10 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
         .unwrap();
     assert!(selected_diff_count > 1, "CSV must fan out beyond lix_file");
     let selected_checkpoint = lix.execute(
-        "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-         SELECT 'lix_file', lixcol_row_pk \
+        "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+         SELECT row_ref \
          FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id()) \
-         WHERE lixcol_row_pk ->> 0 = $1 \
-         RETURNING commit_id",
+         WHERE id = $1))",
         &[Value::Text(selected_file_id.clone())],
     )
     .await
@@ -5574,7 +5573,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
         lix.execute(
             "SELECT COUNT(*) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-             WHERE lixcol_row_pk ->> 0 = $1",
+             WHERE id = $1",
             &[
                 Value::Text(selected_file_id.clone()),
                 Value::Text(selected_checkpoint.rows()[0].get::<String>("commit_id").unwrap()),
@@ -5591,7 +5590,7 @@ async fn partial_checkpoint_rebases_all_plugin_rows_for_one_file() {
         lix.execute(
             "SELECT COUNT(*) AS count \
              FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-             WHERE lixcol_row_pk ->> 0 = $1",
+             WHERE id = $1",
             &[
                 Value::Text(remaining_file_id),
                 Value::Text(selected_checkpoint.rows()[0].get::<String>("commit_id").unwrap()),
@@ -6353,7 +6352,7 @@ where
 {
     let rows = lix
         .execute(
-            "SELECT lixcol_row_pk, id, order_key, cells FROM csv_row \
+            "SELECT id, order_key, cells FROM csv_row \
              WHERE lixcol_file_id = $1",
             &[Value::Text(file_id.to_string())],
         )
@@ -6363,18 +6362,7 @@ where
         .rows()
         .iter()
         .map(|row| {
-            let row_pk = row
-                .get::<serde_json::Value>("lixcol_row_pk")
-                .unwrap()
-                .as_array()
-                .cloned()
-                .expect("csv_row row_pk must be an array");
             let id = row.get::<String>("id").unwrap();
-            assert_eq!(
-                row_pk,
-                vec![serde_json::Value::String(id.clone())],
-                "csv_row typed identity must equal its durable primary key"
-            );
             CsvV2Row {
                 id,
                 order_key: row.get::<String>("order_key").unwrap(),

--- a/packages/e2e/tests/git_text_plugin.rs
+++ b/packages/e2e/tests/git_text_plugin.rs
@@ -363,7 +363,7 @@ where
 {
     let result = lix
         .execute(
-            "SELECT lixcol_row_pk, id, order_key, content_base64 \
+            "SELECT id, order_key, content_base64 \
              FROM text_line WHERE lixcol_file_id = $1",
             &[Value::Text(file_id.to_owned())],
         )
@@ -374,12 +374,6 @@ where
         .iter()
         .map(|row| {
             let id = row.get::<String>("id").expect("line id should be text");
-            assert_eq!(
-                row.get::<serde_json::Value>("lixcol_row_pk")
-                    .expect("line primary key should be JSON"),
-                serde_json::json!([id.clone()]),
-                "line snapshot identity must equal its durable primary key"
-            );
             GitTextLine {
                 id,
                 order_key: row

--- a/packages/e2e/tests/hot_scan_refcount_census.rs
+++ b/packages/e2e/tests/hot_scan_refcount_census.rs
@@ -63,7 +63,7 @@ async fn a_full_scan_clones_a_bounded_number_of_shared_handles_per_row() {
             "a seed statement that affects no rows produces the same zero counters as a route that never ran"
         );
     }
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("drive the census fixture to packed-base steady state");
 

--- a/packages/e2e/tests/plugin_gc.rs
+++ b/packages/e2e/tests/plugin_gc.rs
@@ -56,9 +56,17 @@ async fn repository_gc_keeps_graph_reachable_file_history_content() {
         .rows()[0]
         .get::<String>("id")
         .unwrap();
-    let historical_checkpoint = lix.create_checkpoint().await.unwrap().commit_id;
+    let historical_checkpoint = lix
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<String>("commit_id")
+        .unwrap();
     write_file(&lix, "/history.txt", b"after gc").await;
-    lix.create_checkpoint().await.unwrap();
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .unwrap();
 
     let storage = lix.storage_adapter();
     let orphan_hash = write_binary_cas_for_bench(&storage, b"history-gc-orphan")
@@ -114,7 +122,9 @@ async fn repository_gc_reclaims_plugin_wasm_after_final_registry_root_releases()
     )
     .await
     .unwrap();
-    lix.create_checkpoint().await.unwrap();
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .unwrap();
     collect_repository_gc_for_bench(&storage).await.unwrap();
     assert!(
         read_binary_cas_for_bench(&storage, &wasm_hash)

--- a/packages/e2e/tests/rust_sdk_api.rs
+++ b/packages/e2e/tests/rust_sdk_api.rs
@@ -53,7 +53,7 @@ async fn rs_sdk_telemetry_is_explicit_and_redacts_sql_literals() {
 }
 
 #[tokio::test]
-async fn rs_sdk_create_checkpoint_returns_the_new_active_head() {
+async fn rs_sdk_sql_checkpoint_returns_the_new_active_head() {
     let lix = open_lix().await.unwrap();
     lix.execute(
         "INSERT INTO lix_key_value (key, value) VALUES ('checkpoint-test', 'working')",
@@ -63,10 +63,16 @@ async fn rs_sdk_create_checkpoint_returns_the_new_active_head() {
     .unwrap();
     let before = active_head_commit_id(&lix).await;
 
-    let checkpoint = lix.create_checkpoint().await.unwrap();
+    let checkpoint = lix
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .unwrap()
+        .rows()[0]
+        .get::<String>("commit_id")
+        .unwrap();
 
-    assert_ne!(checkpoint.commit_id, before);
-    assert_eq!(checkpoint.commit_id, active_head_commit_id(&lix).await);
+    assert_ne!(checkpoint, before);
+    assert_eq!(checkpoint, active_head_commit_id(&lix).await);
     lix.close().await.unwrap();
 }
 

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -108,11 +108,10 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
     let history_before_checkpoint = probe.history_gets.load(Ordering::Acquire);
     let checkpoint = replica
         .execute(
-            "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-             SELECT 'lix_file', lixcol_row_pk \
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+             SELECT row_ref \
              FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id()) \
-             WHERE lixcol_row_pk ->> 0 = $1 \
-             RETURNING commit_id",
+             WHERE id = $1))",
             &[Value::Text(selected_file_id.clone())],
         )
         .await
@@ -131,7 +130,7 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
             .execute(
                 "SELECT COUNT(*) AS count \
                  FROM lix_diff('lix_file', $2, lix_active_branch_commit_id()) \
-                 WHERE lixcol_row_pk ->> 0 = $1",
+                 WHERE id = $1",
                 &[
                     Value::Text(selected_file_id.clone()),
                     Value::Text(checkpoint.rows()[0].get::<String>("commit_id").unwrap()),

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -2107,8 +2107,8 @@ async fn sparse_replica_observer_hydrates_root_history_past_a_merge_frontier() {
     let command_bootstrap_history_gets = probe.history_gets.load(Ordering::Acquire);
     let applied = command_replica
         .execute(
-            "INSERT INTO lix_apply (relation, row_pk) \
-             SELECT 'lix_key_value', lixcol_row_pk \
+            "INSERT INTO lix_apply (row_ref) \
+             SELECT row_ref \
              FROM lix_diff(\
                'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
              ) \

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -64,7 +64,7 @@ async fn synced_partial_file_checkpoint_stays_off_cold_history() {
         .await;
     }
     authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint cold snapshot baseline");
     authority.close().await.expect("close authority setup");
@@ -368,7 +368,7 @@ async fn fresh_bootstrap_reads_authority_then_local_write_reaches_server() {
         .await
         .expect("the first file creation after bootstrap has a checkpoint cursor");
     replica
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("the first checkpoint after sync bootstrap succeeds");
     assert_eq!(
@@ -421,7 +421,7 @@ async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_p
         .get::<String>("id")
         .expect("file id decodes");
     authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint first file version");
     authority
@@ -432,7 +432,7 @@ async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_p
         .await
         .expect("update historical file");
     authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint second file version");
     authority
@@ -450,7 +450,7 @@ async fn fresh_replica_lists_checkpoints_then_hydrates_file_history_in_bounded_p
         .await
         .expect("create surviving file");
     authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint deletion and surviving file");
     for index in 0..105 {
@@ -539,10 +539,12 @@ async fn exact_checkpoint_file_history_hydrates_only_its_anchor_boundary() {
             .await
             .expect("update checkpointed file");
         let checkpoint = authority
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect("create file checkpoint")
-            .commit_id;
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("checkpoint commit id decodes");
         if index == 31 {
             target_checkpoint = Some(checkpoint);
         }
@@ -632,10 +634,12 @@ async fn sparse_checkpoint_history_hydrates_missing_bodies_concurrently() {
             .expect("update checkpointed file");
         latest_checkpoint = Some(
             authority
-                .create_checkpoint()
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
                 .await
                 .expect("create file checkpoint")
-                .commit_id,
+                .rows()[0]
+                .get::<String>("commit_id")
+                .expect("checkpoint commit id decodes"),
         );
     }
     let latest_checkpoint = latest_checkpoint.expect("latest checkpoint captured");
@@ -1854,9 +1858,12 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
         .await
         .expect("create /docs/handbook/inside.md");
     let first_checkpoint = authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
-        .expect("checkpoint seeded filesystem");
+        .expect("checkpoint seeded filesystem")
+        .rows()[0]
+        .get::<String>("commit_id")
+        .expect("checkpoint commit id decodes");
     authority
         .execute(
             "INSERT INTO lix_file (path, content) VALUES ('/brand/logo.md', CAST('three' AS BYTEA))",
@@ -1865,9 +1872,12 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
         .await
         .expect("create /brand/logo.md");
     let second_checkpoint = authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
-        .expect("checkpoint second filesystem state");
+        .expect("checkpoint second filesystem state")
+        .rows()[0]
+        .get::<String>("commit_id")
+        .expect("checkpoint commit id decodes");
     // Enough later commits that the checkpoint payloads stay cold on a
     // fresh bootstrap.
     for index in 0..105 {
@@ -1880,7 +1890,7 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
     let replica_dir = TempDir::new().expect("replica tempdir");
     let replica = open_replica(replica_dir.path(), &url).await;
 
-    let commit_id = first_checkpoint.commit_id.clone();
+    let commit_id = first_checkpoint.clone();
     let files = replica
         .execute(
             "SELECT name, directory_id FROM lix_state_at('lix_file', $1)",
@@ -1948,8 +1958,8 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
              FROM lix_diff('lix_file', $1, $2)
              ORDER BY coalesce(to_path, from_path)",
             &[
-                Value::Text(first_checkpoint.commit_id.clone()),
-                Value::Text(second_checkpoint.commit_id.clone()),
+                Value::Text(first_checkpoint.clone()),
+                Value::Text(second_checkpoint.clone()),
             ],
         )
         .await
@@ -1975,7 +1985,7 @@ async fn fresh_replica_reads_point_in_time_filesystem_state() {
     let latest_directories = replica
         .execute(
             "SELECT name FROM lix_state_at('lix_directory', $1) ORDER BY name",
-            &[Value::Text(second_checkpoint.commit_id.clone())],
+            &[Value::Text(second_checkpoint.clone())],
         )
         .await
         .expect("latest checkpoint directory state hydrates");
@@ -2145,10 +2155,12 @@ async fn partially_hydrated_replica_reads_point_in_time_filesystem_state() {
         .get::<String>("id")
         .expect("file id decodes");
     let checkpoint = authority
-        .create_checkpoint()
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("checkpoint seeded filesystem")
-        .commit_id;
+        .rows()[0]
+        .get::<String>("commit_id")
+        .expect("checkpoint commit id decodes");
     for index in 0..105 {
         put_value(&authority, &format!("partial-hydration-{index:03}"), "value").await;
     }
@@ -2260,7 +2272,7 @@ async fn migrated_partial_checkpoint_repository_reads_state_on_a_sparse_replica(
             "SELECT path FROM lix_history('lix_file', $1) WHERE id = $2 ORDER BY lixcol_depth ASC LIMIT 1",
             &[
                 Value::Text(last_checkpoint.clone()),
-                Value::Text(brand_file_id),
+                Value::Text(brand_file_id.clone()),
             ],
         )
         .await
@@ -2296,6 +2308,28 @@ async fn migrated_partial_checkpoint_repository_reads_state_on_a_sparse_replica(
         .await
         .expect("root diff with paths at the migrated partial checkpoint hydrates");
     assert_eq!(diff.rows().len(), 4, "resolved paths for all four files");
+
+    replica
+        .execute(
+            "UPDATE lix_file SET name = 'logo-working.md' WHERE id = $1",
+            &[Value::Text(brand_file_id.clone())],
+        )
+        .await
+        .expect("working edit on a checkpoint-selected row succeeds");
+    replica
+        .execute(
+            "INSERT INTO lix_revert (row_ref) \
+             SELECT row_ref FROM lix_diff('lix_file') WHERE id = $1 \
+             RETURNING commit_id",
+            &[Value::Text(brand_file_id)],
+        )
+        .await
+        .expect("sparse replica reverts a working edit against the migrated checkpoint");
+    let reverted = replica
+        .execute("SELECT path FROM lix_file WHERE path = '/brand/logo.md'", &[])
+        .await
+        .expect("reverted file resolves");
+    assert_eq!(reverted.rows().len(), 1, "working edit was reverted");
 
     replica.close().await.expect("close replica");
     stop_server(server_task).await;

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -2797,8 +2797,7 @@ impl From<MergeChangeStats> for MergeChangeStatsDto {
 #[napi(object)]
 pub struct MergeConflictDto {
     pub kind: String,
-    pub schema_key: String,
-    pub row_pk: serde_json::Value,
+    pub row_ref: String,
     pub file_id: Option<String>,
     pub target: MergeConflictSideDto,
     pub source: MergeConflictSideDto,
@@ -2808,8 +2807,7 @@ impl From<MergeConflict> for MergeConflictDto {
     fn from(conflict: MergeConflict) -> Self {
         Self {
             kind: merge_conflict_kind_to_string(conflict.kind),
-            schema_key: conflict.schema_key,
-            row_pk: conflict.row_pk,
+            row_ref: conflict.row_ref.to_string(),
             file_id: conflict.file_id,
             target: conflict.target.into(),
             source: conflict.source.into(),
@@ -2903,6 +2901,18 @@ impl TryFrom<LixValue> for Value {
             "jsonb" => Ok(Self::Jsonb(
                 value.value.unwrap_or(serde_json::Value::Null).into(),
             )),
+            "row_ref" => {
+                let encoded = value
+                    .value
+                    .and_then(|value| value.as_str().map(str::to_owned))
+                    .ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INVALID_PARAM,
+                            "row_ref value must be a string",
+                        )
+                    })?;
+                Ok(Self::RowRef(lix::RowRef::from_encoded(encoded)?))
+            }
             "timestamptz" => {
                 let raw = value
                     .value
@@ -2981,6 +2991,11 @@ impl TryFrom<&Value> for LixValue {
                 value: Some(value.to_value()),
                 blob: None,
             }),
+            Value::RowRef(value) => Ok(Self {
+                kind: "row_ref".to_string(),
+                value: Some(serde_json::json!(value.as_str())),
+                blob: None,
+            }),
             Value::Timestamptz(value) => {
                 let value = chrono::DateTime::from_timestamp_micros(*value).ok_or_else(|| {
                     LixError::new("LIX_ERROR_JS_SDK_NATIVE", "timestamptz is out of range")
@@ -3027,6 +3042,7 @@ fn result_column_type_name(column_type: lix::ResultColumnType) -> &'static str {
         lix::ResultColumnType::Real => "real",
         lix::ResultColumnType::Text => "text",
         lix::ResultColumnType::Jsonb => "jsonb",
+        lix::ResultColumnType::RowRef => "row_ref",
         lix::ResultColumnType::Timestamptz => "timestamptz",
         lix::ResultColumnType::Blob => "blob",
     }

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -1,6 +1,6 @@
 use lix::telemetry::{CallbackTelemetrySink, SpanContext, TelemetrySink, instrument_remote_parent};
 use lix::{
-    CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt,
+    CreateBranchOptions as RsCreateBranchOptions, CreateBranchReceipt,
     ExecuteBatchStatement as RsExecuteBatchStatement, ExecuteResult as RsExecuteResult,
     Lix as RsLix, LixError, LixTransaction as RsLixTransaction, Memory,
     MergeBranchOptions as RsMergeBranchOptions, MergeBranchOutcome, MergeBranchPreview,
@@ -258,7 +258,6 @@ type NativeTransactionDeferred = NativeDeferred<NativeLixTransaction>;
 type NativeLixDeferred = NativeDeferred<NativeLix>;
 type NativeStringDeferred = NativeDeferred<String>;
 type NativeCreateBranchDeferred = NativeDeferred<CreateBranchReceiptDto>;
-type NativeCreateCheckpointDeferred = NativeDeferred<CreateCheckpointReceiptDto>;
 type NativeUndoDeferred = NativeDeferred<UndoReceiptDto>;
 type NativeRedoDeferred = NativeDeferred<RedoReceiptDto>;
 type NativeSwitchBranchDeferred = NativeDeferred<SwitchBranchReceiptDto>;
@@ -295,7 +294,6 @@ enum LixCommand {
         options: RsCreateBranchOptions,
         deferred: NativeCreateBranchDeferred,
     },
-    CreateCheckpoint(NativeCreateCheckpointDeferred),
     Undo(NativeUndoDeferred),
     Redo(NativeRedoDeferred),
     SwitchBranch {
@@ -910,7 +908,6 @@ fn reject_pending_lix_commands(receiver: mpsc::Receiver<QueuedLixCommand>, error
             LixCommand::ActiveBranchId(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::ActiveAccountId(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::CreateBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
-            LixCommand::CreateCheckpoint(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::Undo(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::Redo(deferred) => deferred.reject(to_napi_error(&error)),
             LixCommand::SwitchBranch { deferred, .. } => deferred.reject(to_napi_error(&error)),
@@ -1013,12 +1010,6 @@ fn handle_lix_command(
         LixCommand::CreateBranch { options, deferred } => {
             let result =
                 block_on!(state.lix.create_branch(options)).map(CreateBranchReceiptDto::from);
-            settle_deferred(deferred, result);
-            false
-        }
-        LixCommand::CreateCheckpoint(deferred) => {
-            let result =
-                block_on!(state.lix.create_checkpoint()).map(CreateCheckpointReceiptDto::from);
             settle_deferred(deferred, result);
             false
         }
@@ -1259,9 +1250,6 @@ fn settle_command_after_close(command: LixCommand) {
         LixCommand::CreateBranch { deferred, .. } => {
             settle_deferred(deferred, Err(lix_closed_error()));
         }
-        LixCommand::CreateCheckpoint(deferred) => {
-            settle_deferred(deferred, Err(lix_closed_error()));
-        }
         LixCommand::Undo(deferred) => settle_deferred(deferred, Err(lix_closed_error())),
         LixCommand::Redo(deferred) => settle_deferred(deferred, Err(lix_closed_error())),
         LixCommand::SwitchBranch { deferred, .. } => {
@@ -1408,13 +1396,6 @@ impl NativeLixInner {
         match self {
             Self::Memory(lix) => lix.create_branch(options).await,
             Self::FilesystemStorage(lix, _, _) => lix.create_branch(options).await,
-        }
-    }
-
-    async fn create_checkpoint(&self) -> std::result::Result<CreateCheckpointReceipt, LixError> {
-        match self {
-            Self::Memory(lix) => lix.create_checkpoint().await,
-            Self::FilesystemStorage(lix, _, _) => lix.create_checkpoint().await,
         }
     }
 
@@ -2072,15 +2053,6 @@ impl NativeLix {
         Ok(promise)
     }
 
-    #[napi(js_name = "createCheckpoint")]
-    pub fn create_checkpoint<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
-        let (deferred, promise): (NativeCreateCheckpointDeferred, Object<'env>) =
-            env.create_deferred()?;
-        self.actor
-            .send_with_deferred(deferred, LixCommand::CreateCheckpoint);
-        Ok(promise)
-    }
-
     #[napi(js_name = "undo")]
     pub fn undo<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
         let (deferred, promise): (NativeUndoDeferred, Object<'env>) = env.create_deferred()?;
@@ -2608,19 +2580,6 @@ impl From<CreateBranchReceipt> for CreateBranchReceiptDto {
             id: receipt.id,
             name: receipt.name,
             hidden: receipt.hidden,
-            commit_id: receipt.commit_id,
-        }
-    }
-}
-
-#[napi(object)]
-pub struct CreateCheckpointReceiptDto {
-    pub commit_id: String,
-}
-
-impl From<CreateCheckpointReceipt> for CreateCheckpointReceiptDto {
-    fn from(receipt: CreateCheckpointReceipt) -> Self {
-        Self {
             commit_id: receipt.commit_id,
         }
     }

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -936,17 +936,6 @@ impl WasmLix {
         })
     }
 
-    #[wasm_bindgen(js_name = createCheckpoint)]
-    pub async fn create_checkpoint(&self) -> Result<JsValue, JsValue> {
-        let receipt = self
-            .instrument_operation(self.inner.create_checkpoint())
-            .await
-            .map_err(lix_error_to_js)?;
-        to_js(&CreateCheckpointReceiptDto {
-            commit_id: receipt.commit_id,
-        })
-    }
-
     #[wasm_bindgen(js_name = undo)]
     pub async fn undo(&self) -> Result<JsValue, JsValue> {
         let receipt = self
@@ -1218,12 +1207,6 @@ pub(super) struct CreateBranchReceiptDto {
     pub(super) id: String,
     pub(super) name: String,
     pub(super) hidden: bool,
-    pub(super) commit_id: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct CreateCheckpointReceiptDto {
     pub(super) commit_id: String,
 }
 

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -1350,8 +1350,7 @@ impl From<lix::MergeChangeStats> for MergeChangeStatsDto {
 #[serde(rename_all = "camelCase")]
 struct MergeConflictDto {
     kind: &'static str,
-    schema_key: String,
-    row_pk: serde_json::Value,
+    row_ref: String,
     file_id: Option<String>,
     target: MergeConflictSideDto,
     source: MergeConflictSideDto,
@@ -1361,8 +1360,7 @@ impl From<lix::MergeConflict> for MergeConflictDto {
     fn from(conflict: lix::MergeConflict) -> Self {
         Self {
             kind: "sameRowChanged",
-            schema_key: conflict.schema_key,
-            row_pk: conflict.row_pk,
+            row_ref: conflict.row_ref.to_string(),
             file_id: conflict.file_id,
             target: conflict.target.into(),
             source: conflict.source.into(),
@@ -1480,6 +1478,13 @@ impl TryFrom<LixValueDto> for Value {
             "jsonb" => Ok(Self::Jsonb(
                 value.value.unwrap_or(serde_json::Value::Null).into(),
             )),
+            "row_ref" => {
+                let encoded = value
+                    .value
+                    .and_then(|value| value.as_str().map(str::to_owned))
+                    .ok_or_else(|| invalid_param("row_ref value must be a string"))?;
+                Ok(Self::RowRef(lix::RowRef::from_encoded(encoded)?))
+            }
             "timestamptz" => {
                 let raw = value
                     .value
@@ -1513,6 +1518,7 @@ impl TryFrom<&Value> for LixValueDto {
             Value::Real(_) => return Err(invalid_param("cannot encode non-finite real value")),
             Value::Text(value) => ("text", Some(serde_json::json!(value)), None),
             Value::Jsonb(value) => ("jsonb", Some(value.to_value()), None),
+            Value::RowRef(value) => ("row_ref", Some(serde_json::json!(value.as_str())), None),
             Value::Timestamptz(value) => {
                 let value = chrono::DateTime::from_timestamp_micros(*value)
                     .ok_or_else(|| invalid_param("timestamptz is out of range"))?;

--- a/packages/js-sdk/native/wasm_remote.rs
+++ b/packages/js-sdk/native/wasm_remote.rs
@@ -18,10 +18,9 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use super::{
-    CreateBranchOptionsDto, CreateBranchReceiptDto, CreateCheckpointReceiptDto,
-    OpenAnotherSessionOptionsDto, RedoReceiptDto, SwitchBranchOptionsDto, SwitchBranchReceiptDto,
-    UndoReceiptDto, batch_statements_from_js, execute_result_to_js, from_js, lix_error_to_js,
-    to_js, values_from_js,
+    CreateBranchOptionsDto, CreateBranchReceiptDto, OpenAnotherSessionOptionsDto, RedoReceiptDto,
+    SwitchBranchOptionsDto, SwitchBranchReceiptDto, UndoReceiptDto, batch_statements_from_js,
+    execute_result_to_js, from_js, lix_error_to_js, to_js, values_from_js,
 };
 
 #[wasm_bindgen]
@@ -262,18 +261,6 @@ impl WasmRemoteLix {
             id: receipt.id,
             name: receipt.name,
             hidden: receipt.hidden,
-            commit_id: receipt.commit_id,
-        })
-    }
-
-    #[wasm_bindgen(js_name = createCheckpoint)]
-    pub async fn create_checkpoint(&self) -> Result<JsValue, JsValue> {
-        let receipt = self
-            .inner
-            .create_checkpoint()
-            .await
-            .map_err(lix_error_to_js)?;
-        to_js(&CreateCheckpointReceiptDto {
             commit_id: receipt.commit_id,
         })
     }

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -1,7 +1,6 @@
 import type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
-	CreateCheckpointReceipt,
 	UndoReceipt,
 	RedoReceipt,
 	ExecuteOptions,
@@ -85,7 +84,6 @@ export type LixBinding = {
 	activeBranchId(): Promise<string>;
 	activeAccountId(): Promise<string>;
 	createBranch(options: CreateBranchOptions): Promise<CreateBranchReceipt>;
-	createCheckpoint(): Promise<CreateCheckpointReceipt>;
 	undo(): Promise<UndoReceipt>;
 	redo(): Promise<RedoReceipt>;
 	switchBranch(options: SwitchBranchOptions): Promise<SwitchBranchReceipt>;

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -31,7 +31,6 @@ export { Value } from "./value.js";
 export type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
-	CreateCheckpointReceipt,
 	RedoReceipt,
 	ExecuteOptions,
 	ExecuteResult,

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -14,7 +14,6 @@ import { normalizeParam, toNativeValue } from "./value.js";
 import type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
-	CreateCheckpointReceipt,
 	RedoReceipt,
 	ExecuteOptions,
 	ExecuteResult,
@@ -211,10 +210,6 @@ export class Lix {
 		options: CreateBranchOptions,
 	): Promise<CreateBranchReceipt> {
 		return this.#runOperation(() => this.binding.createBranch(options));
-	}
-
-	async createCheckpoint(): Promise<CreateCheckpointReceipt> {
-		return this.#runOperation(() => this.binding.createCheckpoint());
 	}
 
 	/** Streams a deterministic snapshot of the complete Lix. */

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -159,7 +159,7 @@ test("keeps browser worker sessions independent", async () => {
 	await review.close();
 });
 
-test("createCheckpoint returns the new active head through browser WASM", async () => {
+test("checkpoint SQL returns the new active head through browser WASM", async () => {
 	const { openLix } = await import("@lix-js/sdk");
 	const lix = await openLix();
 	try {
@@ -171,14 +171,17 @@ test("createCheckpoint returns the new active head through browser WASM", async 
 			await lix.execute("SELECT lix_active_branch_commit_id() AS commit_id")
 		).rows[0]?.commit_id;
 
-		const checkpoint = await lix.createCheckpoint();
+		const checkpoint = await lix.execute(
+			"SELECT commit_id FROM lix_create_checkpoint()",
+		);
+		const checkpointId = checkpoint.rows[0]?.commit_id;
 
-		expect(checkpoint.commitId).not.toBe(before);
+		expect(checkpointId).not.toBe(before);
 		expect(
 			(
 				await lix.execute("SELECT lix_active_branch_commit_id() AS commit_id")
 			).rows[0]?.commit_id,
-		).toBe(checkpoint.commitId);
+		).toBe(checkpointId);
 	} finally {
 		await lix.close();
 	}
@@ -198,8 +201,10 @@ test("checkpoint GC starts without requiring a browser Tokio runtime", async () 
 				 ON CONFLICT (key) DO UPDATE SET value = excluded.value`,
 				["checkpoint-gc-browser-test", sequence],
 			);
-			const checkpoint = await lix.createCheckpoint();
-			expect(checkpoint.commitId).toEqual(expect.any(String));
+			const checkpoint = await lix.execute(
+				"SELECT commit_id FROM lix_create_checkpoint()",
+			);
+			expect(checkpoint.rows[0]?.commit_id).toEqual(expect.any(String));
 		}
 
 		expect((await lix.execute("SELECT 1 AS value")).rows[0]?.value).toBe(

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -53,7 +53,7 @@ test("snapshot streams restore a complete Lix deterministically", async () => {
 	await source.execute(
 		"INSERT INTO lix_key_value (key, value) VALUES ('snapshot-js', 'complete')",
 	);
-	await source.createCheckpoint();
+	await source.execute("SELECT commit_id FROM lix_create_checkpoint()");
 
 	const bytes = new Uint8Array(
 		await new Response(source.exportSnapshot()).arrayBuffer(),
@@ -792,7 +792,7 @@ test("openLix exposes the lix-sdk e2e flow", async () => {
 	).rejects.toThrow(/closed/);
 });
 
-test("createCheckpoint returns the new active head through the local worker", async () => {
+test("checkpoint SQL returns the new active head through the local worker", async () => {
 	const lix = await openLix();
 	await lix.execute(
 		"INSERT INTO lix_key_value (key, value) VALUES ($1, $2)",
@@ -800,10 +800,13 @@ test("createCheckpoint returns the new active head through the local worker", as
 	);
 	const before = await activeHeadCommitId(lix);
 
-	const checkpoint = await lix.createCheckpoint();
+	const checkpoint = await lix.execute(
+		"SELECT commit_id FROM lix_create_checkpoint()",
+	);
+	const checkpointId = checkpoint.rows[0]?.commit_id;
 
-	expect(checkpoint.commitId).not.toBe(before);
-	expect(checkpoint.commitId).toBe(await activeHeadCommitId(lix));
+	expect(checkpointId).not.toBe(before);
+	expect(checkpointId).toBe(await activeHeadCommitId(lix));
 	await lix.close();
 });
 

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -27,7 +27,7 @@ test.each([
 ])("remote mode permits loopback HTTP locator %s", async (url) => {
 	const fetch = vi.fn(async () =>
 		Response.json({
-			protocolVersion: 5,
+			protocolVersion: 6,
 			activeBranchId: "01920000-0000-7000-8000-000000000601",
 			activeAccountId: "01920000-0000-7000-8000-000000000602",
 			sessionId: "session-1",
@@ -52,7 +52,7 @@ test("Lix Server Protocol handshake requests a restored initial active branch", 
 					return new Response(null, { status: 204 });
 				}
 				return Response.json({
-					protocolVersion: 5,
+					protocolVersion: 6,
 					activeBranchId: "draft / one",
 					activeAccountId: accountId,
 					sessionId: "session-1",
@@ -90,7 +90,7 @@ test("openAnotherSession creates an independent remote protocol session", async 
 					return new Response(null, { status: 204 });
 				handshakes.push(request);
 				return Response.json({
-					protocolVersion: 5,
+					protocolVersion: 6,
 					activeBranchId:
 						new URL(request.url).searchParams.get("activeBranchId") ??
 						"main-id",
@@ -134,7 +134,7 @@ test("openAnotherSession rejects and closes a remote identity mismatch", async (
 				}
 				handshake += 1;
 				return Response.json({
-					protocolVersion: 5,
+					protocolVersion: 6,
 					activeBranchId: "main-id",
 					activeAccountId: handshake === 1 ? "account-a" : "account-b",
 					sessionId: `session-${handshake}`,
@@ -169,7 +169,7 @@ test("remote mode uses the repository protocol without loading a local engine", 
 			requests.push(request);
 			if (new URL(request.url).pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 				return Response.json({
-					protocolVersion: 5,
+					protocolVersion: 6,
 					activeBranchId: "main-id",
 					activeAccountId: "00000000-0000-7000-8000-000000000002",
 					sessionId: "session-1",
@@ -278,7 +278,7 @@ test("remote mode compresses only large compressible JSON requests", async () =>
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -345,7 +345,7 @@ test("remote executeBatch uses the first-class atomic batch endpoint", async () 
 				requests.push(request.clone());
 				return new URL(request.url).pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")
 					? Response.json({
-							protocolVersion: 5,
+							protocolVersion: 6,
 							activeBranchId: "main-id",
 							activeAccountId: "00000000-0000-7000-8000-000000000002",
 							sessionId: "session-1",
@@ -641,7 +641,7 @@ test("Lix Server Protocol v3 uses blob splices without capability negotiation", 
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -728,7 +728,7 @@ test("remote branches preserve local Lix branch semantics", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId,
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -784,7 +784,7 @@ test("remote lix_restore uses the existing execute endpoint", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -835,7 +835,7 @@ test("remote undo and redo decode branch-history receipts", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -891,7 +891,7 @@ test("a failed remote branch switch leaves the active branch unchanged", async (
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -944,7 +944,7 @@ test("an ambiguous remote branch switch is reconciled by the next branch read", 
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId,
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -986,7 +986,7 @@ test("branch reconciliation rejects and never caches a replacement session", asy
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "draft-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: handshakeCalls === 1 ? "session-1" : "session-2",
@@ -1031,7 +1031,7 @@ test("remote clients retain independent active branches", async () => {
 				activeBranches.set(sessionId, "main-id");
 			}
 			return Response.json({
-				protocolVersion: 5,
+				protocolVersion: 6,
 				activeBranchId: activeBranches.get(sessionId),
 				activeAccountId: "00000000-0000-7000-8000-000000000002",
 				sessionId,
@@ -1083,7 +1083,7 @@ test("remote operations preserve normal Lix call ordering", async () => {
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1142,7 +1142,7 @@ test("remote responses reject malformed rows and non-JSON HTTP errors", async ()
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1207,7 +1207,7 @@ test("remote beginTransaction uses one capability-bound server lifecycle", async
 				});
 				if (path.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1278,7 +1278,7 @@ test("remote mode rejects unsupported local-only operations honestly", async () 
 			url: "https://lixray.test/lix/01936f4e-7b6c-7c3d-8f9a-123456789abc",
 			fetch: (async () =>
 				Response.json({
-					protocolVersion: 5,
+					protocolVersion: 6,
 					activeBranchId: "main-id",
 					activeAccountId: "00000000-0000-7000-8000-000000000002",
 					sessionId: "session-1",
@@ -1326,7 +1326,7 @@ test.each([undefined, "", " contains-space", "contains\nnewline", 42])(
 					url: "https://lixray.test/lix/01936f4e-7b6c-7c3d-8f9a-123456789abc",
 					fetch: (async () =>
 						Response.json({
-							protocolVersion: 5,
+							protocolVersion: 6,
 							activeBranchId: "main-id",
 							activeAccountId: "00000000-0000-7000-8000-000000000002",
 							sessionId,
@@ -1350,7 +1350,7 @@ test("active branch reads reuse the initial handshake without another GET", asyn
 				}
 				handshakeCalls += 1;
 				return Response.json({
-					protocolVersion: 5,
+					protocolVersion: 6,
 					activeBranchId: "main-id",
 					activeAccountId: "00000000-0000-7000-8000-000000000002",
 					sessionId: "session-1",
@@ -1384,7 +1384,7 @@ test("execute recovers a gone protocol session once by opening a new handshake",
 					}
 					nextSession += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${nextSession}`,
@@ -1453,7 +1453,7 @@ test("execute recovers a closed protocol server once then retries with the new s
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					sessionIds.push(request.headers.get("lix-session-id"));
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId:
@@ -1496,7 +1496,7 @@ test("a second gone protocol session after recovery is not retried", async () =>
 					handshakeCalls += 1;
 					expect(request.headers.has("lix-session-id")).toBe(false);
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${handshakeCalls}`,
@@ -1545,7 +1545,7 @@ test("an active branch read adopts a new session after protocol session gone", a
 						handshakes.length === 0 ? "session-1" : "session-2";
 					handshakes.push({ sessionId: null, issuedSessionId });
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId:
 							issuedSessionId === "session-1" ? "main-id" : "draft-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
@@ -1587,7 +1587,7 @@ test("an expired session mutation is propagated without a new handshake or retry
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1634,7 +1634,7 @@ test("close waits for queued operations before deleting the remote session", asy
 				const pathname = new URL(request.url).pathname;
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: "session-1",
@@ -1671,7 +1671,7 @@ test("close waits for queued operations before deleting the remote session", asy
 
 function handshakeResponse() {
 	return Response.json({
-		protocolVersion: 5,
+		protocolVersion: 6,
 		activeBranchId: "main-id",
 		activeAccountId: "00000000-0000-7000-8000-000000000002",
 		sessionId: "session-1",

--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -772,48 +772,6 @@ test("remote branches preserve local Lix branch semantics", async () => {
 	await lix.close();
 });
 
-test("remote createCheckpoint posts no body and decodes the receipt", async () => {
-	const requests: Request[] = [];
-	const lix = await openLix({
-		server: {
-			mode: "remote",
-			url: "https://lixray.test/lix/01936f4e-7b6c-7c3d-8f9a-123456789abc",
-			fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
-				const request = new Request(input, init);
-				requests.push(request.clone());
-				const pathname = new URL(request.url).pathname;
-				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
-					return Response.json({
-						protocolVersion: 5,
-						activeBranchId: "main-id",
-						activeAccountId: "00000000-0000-7000-8000-000000000002",
-						sessionId: "session-1",
-					});
-				}
-				if (pathname.endsWith("/checkpoint/create")) {
-					return Response.json({ commitId: "checkpoint-commit-id" });
-				}
-				if (request.method === "DELETE") {
-					return new Response(null, { status: 204 });
-				}
-				throw new Error(`Unexpected request: ${pathname}`);
-			}) as typeof fetch,
-		},
-	});
-
-	await expect(lix.createCheckpoint()).resolves.toEqual({
-		commitId: "checkpoint-commit-id",
-	});
-	const request = requests.find((candidate) =>
-		new URL(candidate.url).pathname.endsWith("/checkpoint/create"),
-	);
-	expect(request?.method).toBe("POST");
-	expect(request?.headers.get("lix-session-id")).toBe("session-1");
-	expect(await request?.text()).toBe("");
-
-	await lix.close();
-});
-
 test("remote lix_restore uses the existing execute endpoint", async () => {
 	const requests: Request[] = [];
 	const lix = await openLix({

--- a/packages/js-sdk/src/remote/observe.test.ts
+++ b/packages/js-sdk/src/remote/observe.test.ts
@@ -652,7 +652,7 @@ test("remote observe reconnects after a gone protocol session instead of failing
 					}
 					nextSession += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${nextSession}`,
@@ -720,7 +720,7 @@ test("remote observe recovers multiple expired shards with one handshake", async
 				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
 					handshakeCalls += 1;
 					return Response.json({
-						protocolVersion: 5,
+						protocolVersion: 6,
 						activeBranchId: "main-id",
 						activeAccountId: "00000000-0000-7000-8000-000000000002",
 						sessionId: `session-${handshakeCalls}`,
@@ -813,7 +813,7 @@ test("remote observe fails if the recovered protocol session is also gone", asyn
 						handshakeCalls += 1;
 						expect(request.headers.has("lix-session-id")).toBe(false);
 						return Response.json({
-							protocolVersion: 5,
+							protocolVersion: 6,
 							activeBranchId: "main-id",
 							activeAccountId: "00000000-0000-7000-8000-000000000002",
 							sessionId: `session-${handshakeCalls}`,
@@ -979,7 +979,7 @@ test("closing Lix stops observations before an earlier finite request settles", 
 
 function handshake(): Response {
 	return Response.json({
-		protocolVersion: 5,
+		protocolVersion: 6,
 		activeBranchId: "main-id",
 		activeAccountId: "00000000-0000-7000-8000-000000000002",
 		sessionId: "session-1",

--- a/packages/js-sdk/src/remote/server-protocol.test.ts
+++ b/packages/js-sdk/src/remote/server-protocol.test.ts
@@ -44,6 +44,23 @@ test("remote timestamps preserve their RFC 3339 representation", () => {
 	).toEqual({ kind: "timestamptz", value });
 });
 
+test("remote row refs preserve their opaque identity kind", () => {
+	const value =
+		"lix_row_ref:v1:AAAADWxpeF9rZXlfdmFsdWUAAQMAAAAFaGVsbG8";
+	expect(encodeWireValue({ kind: "row_ref", value })).toEqual({
+		kind: "row_ref",
+		value,
+	});
+	expect(
+		decodeExecuteResult({
+			columns: [{ name: "row_ref", type: "row_ref" }],
+			rows: [[{ kind: "row_ref", value }]],
+			rowsAffected: 0,
+			notices: [],
+		}).rows[0]?.[0],
+	).toEqual({ kind: "row_ref", value });
+});
+
 test("remote decoding rejects legacy json and timestamp wire kinds", () => {
 	for (const value of [
 		{ kind: "json", value: { ok: true } },

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -13,6 +13,7 @@ export type WireValue =
 	| { kind: "float"; value: number }
 	| { kind: "text"; value: string }
 	| { kind: "jsonb"; value: unknown }
+	| { kind: "row_ref"; value: string }
 	| { kind: "timestamptz"; value: string }
 	| { kind: "blob"; base64: string };
 
@@ -180,6 +181,8 @@ export function encodeWireValue(value: NativeLixValue): WireValue {
 			return { kind: "text", value: value.value };
 		case "jsonb":
 			return { kind: "jsonb", value: value.value };
+		case "row_ref":
+			return { kind: "row_ref", value: value.value };
 		case "timestamptz":
 			return { kind: "timestamptz", value: value.value };
 		case "blob":
@@ -267,6 +270,7 @@ function isResultColumnType(
 		value === "real" ||
 		value === "text" ||
 		value === "jsonb" ||
+		value === "row_ref" ||
 		value === "timestamptz" ||
 		value === "blob"
 	);
@@ -615,6 +619,11 @@ function decodeWireValue(value: unknown): NativeLixValue {
 		case "jsonb":
 			assertJsonValue(wire.value, "jsonb wire value");
 			return { kind: "jsonb", value: wire.value };
+		case "row_ref":
+			if (typeof wire.value !== "string") {
+				throw protocolError("row_ref wire value is invalid");
+			}
+			return { kind: "row_ref", value: wire.value };
 		case "timestamptz":
 			if (typeof wire.value !== "string") {
 				throw protocolError("timestamptz wire value is invalid");

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -4,7 +4,7 @@ import type {
 } from "../binding-types.js";
 import type { NativeLixValue } from "../value.js";
 
-export const SERVER_PROTOCOL_VERSION = 5;
+export const SERVER_PROTOCOL_VERSION = 6;
 
 export type WireValue =
 	| { kind: "null"; value: null }

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -130,10 +130,6 @@ export type ServerProtocolCreateBranchResponse = {
 	commitId: string;
 };
 
-export type ServerProtocolCreateCheckpointResponse = {
-	commitId: string;
-};
-
 export type ServerProtocolUndoResponse = {
 	branchId: string;
 	targetCommitId: string;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -134,6 +134,7 @@ export type LixValue =
 	| { kind: "real"; value: number }
 	| { kind: "text"; value: string }
 	| { kind: "jsonb"; value: JsonValue }
+	| { kind: "row_ref"; value: string }
 	| { kind: "timestamptz"; value: string }
 	| { kind: "blob"; value: Uint8Array };
 
@@ -291,8 +292,7 @@ export type MergeChangeStats = {
 
 export type MergeConflict = {
 	kind: "sameRowChanged";
-	schemaKey: string;
-	rowPk: unknown;
+	rowRef: string;
 	fileId: string | null;
 	target: MergeConflictSide;
 	source: MergeConflictSide;

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -227,10 +227,6 @@ export type CreateBranchReceipt = {
 	commitId: string;
 };
 
-export type CreateCheckpointReceipt = {
-	commitId: string;
-};
-
 export type UndoReceipt = {
 	branchId: string;
 	targetCommitId: string;

--- a/packages/js-sdk/src/value.ts
+++ b/packages/js-sdk/src/value.ts
@@ -35,6 +35,10 @@ export class Value {
 		return new Value({ kind: "jsonb", value });
 	}
 
+	static rowRef(value: string) {
+		return new Value({ kind: "row_ref", value });
+	}
+
 	static timestamptz(value: string) {
 		return new Value({ kind: "timestamptz", value });
 	}
@@ -164,6 +168,7 @@ function unwrapValue(value: LixValue): unknown {
 		case "text":
 		case "timestamptz":
 		case "jsonb":
+		case "row_ref":
 			return cloneJsonValue(value.value);
 		case "blob":
 			return new Uint8Array(value.value);
@@ -284,6 +289,9 @@ function validateExplicitValue(value: LixValue) {
 		case "jsonb":
 			assertJsonSerializable(value.value, new WeakSet(), 0);
 			return;
+		case "row_ref":
+			if (typeof value.value === "string" && isWellFormedString(value.value)) return;
+			break;
 		case "timestamptz":
 			if (typeof value.value === "string" && !Number.isNaN(Date.parse(value.value))) {
 				return;

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -385,7 +385,6 @@ export function workerBinding(
 		activeBranchId: () => request({ kind: "activeBranchId" }),
 		activeAccountId: () => request({ kind: "activeAccountId" }),
 		createBranch: (options) => request({ kind: "createBranch", options }),
-		createCheckpoint: () => request({ kind: "createCheckpoint" }),
 		undo: () => request({ kind: "undo" }),
 		redo: () => request({ kind: "redo" }),
 		switchBranch: (options) => request({ kind: "switchBranch", options }),

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -253,8 +253,6 @@ export function startWorkerHost(endpoint: WorkerHostEndpoint): void {
 				return requiredLix(sessionId).activeAccountId();
 			case "createBranch":
 				return requiredLix(sessionId).createBranch(operation.options);
-			case "createCheckpoint":
-				return requiredLix(sessionId).createCheckpoint();
 			case "undo":
 				return requiredLix(sessionId).undo();
 			case "redo":

--- a/packages/js-sdk/src/worker/protocol.ts
+++ b/packages/js-sdk/src/worker/protocol.ts
@@ -82,7 +82,6 @@ export type WorkerOperation =
 	| { kind: "activeBranchId" }
 	| { kind: "activeAccountId" }
 	| { kind: "createBranch"; options: CreateBranchOptions }
-	| { kind: "createCheckpoint" }
 	| { kind: "undo" }
 	| { kind: "redo" }
 	| { kind: "switchBranch"; options: SwitchBranchOptions }

--- a/packages/lix-schema/fixtures/current/lix_change.json
+++ b/packages/lix-schema/fixtures/current/lix_change.json
@@ -19,10 +19,10 @@
       ]
     },
     {
-      "name": "row_pk",
-      "type": "jsonb",
-      "nullable": false,
-      "description": "Canonical JSON primary-key tuple for the row this change applies to, scoped by (`schema_key`, `file_id`). Values are ordered according to the target schema's `x-lix-primary-key`."
+      "name": "row_ref",
+      "type": "text",
+      "nullable": true,
+      "description": "Opaque reference to the public relation row this change applies to; NULL for private engine rows."
     },
     {
       "name": "file_id",

--- a/packages/lix/benches/diff_commands.rs
+++ b/packages/lix/benches/diff_commands.rs
@@ -127,9 +127,9 @@ async fn profile_sample(rows: usize, sample: usize) {
         execute(
             &session,
             &format!(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk FROM {WORKING_SOURCE} \
-                 ORDER BY lixcol_row_pk LIMIT {selected}"
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref FROM {WORKING_SOURCE} \
+                 ORDER BY key LIMIT {selected}"
             ),
         )
         .await;
@@ -141,10 +141,10 @@ async fn profile_sample(rows: usize, sample: usize) {
         execute(
             &session,
             &format!(
-                "INSERT INTO lix_apply (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_apply (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff('lix_key_value', '{baseline}', '{head}') \
-                 ORDER BY lixcol_row_pk LIMIT {selected}"
+                 ORDER BY key LIMIT {selected}"
             ),
         )
         .await;
@@ -157,9 +157,9 @@ async fn profile_sample(rows: usize, sample: usize) {
         execute(
             &session,
             &format!(
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk FROM {WORKING_SOURCE} \
-                 ORDER BY lixcol_row_pk LIMIT {checkpoint_selected}"
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref FROM {WORKING_SOURCE} \
+                 ORDER BY key LIMIT {checkpoint_selected}))"
             ),
         )
         .await;
@@ -230,11 +230,19 @@ async fn apply_fixture(rows: usize, selected: usize) -> (Lix<Memory>, String) {
 }
 
 fn command_sql(command: &str, source: &str, extra_predicate: &str, selected: usize) -> String {
+    if command == "lix_create_checkpoint" {
+        return format!(
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+             SELECT row_ref FROM {source} \
+             WHERE true {extra_predicate} \
+             ORDER BY key LIMIT {selected}))"
+        );
+    }
     format!(
-        "INSERT INTO {command} (relation, row_pk) \
-         SELECT 'lix_key_value', lixcol_row_pk FROM {source} \
+        "INSERT INTO {command} (row_ref) \
+         SELECT row_ref FROM {source} \
          WHERE true {extra_predicate} \
-         ORDER BY lixcol_row_pk LIMIT {selected}"
+         ORDER BY key LIMIT {selected}"
     )
 }
 

--- a/packages/lix/benches/profile_checkpoint_scale.rs
+++ b/packages/lix/benches/profile_checkpoint_scale.rs
@@ -830,7 +830,10 @@ where
 {
     ALLOCATION_CALLS.with(|calls| calls.set(0));
     ALLOCATED_BYTES.with(|bytes| bytes.set(0));
-    let (result, storage) = measure_checkpoint_foreground(lix.create_checkpoint()).await;
+    let (result, storage) = measure_checkpoint_foreground(
+        lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[]),
+    )
+    .await;
     result.expect("create benchmark checkpoint");
     let accounting = ForegroundAccounting {
         storage,

--- a/packages/lix/benches/profile_checkpoint_scale.rs
+++ b/packages/lix/benches/profile_checkpoint_scale.rs
@@ -30,6 +30,7 @@ use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 use std::fs;
+use std::future::IntoFuture;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -830,10 +831,10 @@ where
 {
     ALLOCATION_CALLS.with(|calls| calls.set(0));
     ALLOCATED_BYTES.with(|bytes| bytes.set(0));
-    let (result, storage) = measure_checkpoint_foreground(
+    let checkpoint = IntoFuture::into_future(
         lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[]),
-    )
-    .await;
+    );
+    let (result, storage) = measure_checkpoint_foreground(checkpoint).await;
     result.expect("create benchmark checkpoint");
     let accounting = ForegroundAccounting {
         storage,

--- a/packages/lix/examples/checkpoints.rs
+++ b/packages/lix/examples/checkpoints.rs
@@ -3,7 +3,11 @@ use lix::{LixError, Value, open_lix};
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), LixError> {
     let lix = open_lix().await?;
-    let initial_checkpoint = lix.create_checkpoint().await?;
+    let initial_checkpoint = lix
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await?
+        .rows()[0]
+        .get::<String>("commit_id")?;
 
     // Writes to a tracked SQL surface create ordinary working diffs.
     lix.execute(
@@ -20,7 +24,7 @@ async fn main() -> Result<(), LixError> {
             "SELECT lixcol_row_pk, diff_type, from_value, to_value
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())
              ORDER BY lixcol_row_pk",
-            &[Value::Text(initial_checkpoint.commit_id)],
+            &[Value::Text(initial_checkpoint)],
         )
         .await?;
 
@@ -30,8 +34,12 @@ async fn main() -> Result<(), LixError> {
         let diff_type = row.get::<String>("diff_type")?;
         println!("{diff_type} lix_key_value {row_pk}");
     }
-    let checkpoint = lix.create_checkpoint().await?;
-    println!("created checkpoint {}", checkpoint.commit_id);
+    let checkpoint = lix
+        .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await?
+        .rows()[0]
+        .get::<String>("commit_id")?;
+    println!("created checkpoint {checkpoint}");
 
     // `lix_checkpoint` holds the checkpoint rows and carries no ordering column.
     // `lix_history('lix_checkpoint')` exposes `lixcol_depth`, so ascending depth is
@@ -54,7 +62,7 @@ async fn main() -> Result<(), LixError> {
         .execute(
             "SELECT COUNT(*) AS count
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())",
-            &[Value::Text(checkpoint.commit_id)],
+            &[Value::Text(checkpoint)],
         )
         .await?;
     let remaining_count = remaining.rows()[0].get::<i64>("count")?;

--- a/packages/lix/examples/checkpoints.rs
+++ b/packages/lix/examples/checkpoints.rs
@@ -21,18 +21,19 @@ async fn main() -> Result<(), LixError> {
 
     let working_diffs = lix
         .execute(
-            "SELECT lixcol_row_pk, diff_type, from_value, to_value
+            "SELECT row_ref, key, diff_type, from_value, to_value
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id())
-             ORDER BY lixcol_row_pk",
+             ORDER BY key",
             &[Value::Text(initial_checkpoint)],
         )
         .await?;
 
     for row in working_diffs.rows() {
         // Row::get<T> performs typed extraction from ExecuteResult.
-        let row_pk = row.get::<serde_json::Value>("lixcol_row_pk")?;
+        let row_ref = row.get::<lix::RowRef>("row_ref")?;
+        let key = row.get::<String>("key")?;
         let diff_type = row.get::<String>("diff_type")?;
-        println!("{diff_type} lix_key_value {row_pk}");
+        println!("{diff_type} lix_key_value {key} ({row_ref})");
     }
     let checkpoint = lix
         .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])

--- a/packages/lix/server-protocol.openapi.yaml
+++ b/packages/lix/server-protocol.openapi.yaml
@@ -369,15 +369,6 @@ paths:
       responses:
         "200": { description: Branch created. }
         default: { $ref: "#/components/responses/Error" }
-  /lix/v1/{lix_id}/checkpoint/create:
-    parameters:
-      - $ref: "#/components/parameters/LixId"
-    post:
-      operationId: createCheckpoint
-      parameters: [{ $ref: "#/components/parameters/RequiredSessionId" }]
-      responses:
-        "200": { description: Checkpoint created. }
-        default: { $ref: "#/components/responses/Error" }
   /lix/v1/{lix_id}/undo:
     parameters:
       - $ref: "#/components/parameters/LixId"

--- a/packages/lix/server-protocol.openapi.yaml
+++ b/packages/lix/server-protocol.openapi.yaml
@@ -549,7 +549,7 @@ components:
       type: object
       required: [protocolVersion, syncProtocolVersion, activeBranchId, activeAccountId, sessionId, capabilities]
       properties:
-        protocolVersion: { type: integer, const: 5 }
+        protocolVersion: { type: integer, const: 6 }
         syncProtocolVersion: { type: integer, const: 1 }
         activeBranchId: { type: string }
         activeAccountId: { type: string }
@@ -622,7 +622,7 @@ components:
       type: array
       minItems: 1
       items: { $ref: "#/components/schemas/SyncRowPkPart" }
-      description: Lossless typed primary-key components in declared primary-key order.
+      description: Sync-only physical row identity components in declared primary-key order; this is not the public SQL/SDK lix_row_ref.
     SyncCommitMember:
       type: object
       required: [changeId, authored, schemaKey, rowPk, deleted, rowCreatedAt, rowUpdatedAt, changeAccountId, changeCreatedAt]

--- a/packages/lix/src/branch/lifecycle.rs
+++ b/packages/lix/src/branch/lifecycle.rs
@@ -11,7 +11,6 @@ pub(crate) enum BranchOperation {
     SwitchBranch,
     MergeBranch,
     MergeBranchPreview,
-    CreateCheckpoint,
     Restore,
     LoadDefaultBranch,
 }
@@ -23,7 +22,6 @@ impl BranchOperation {
             Self::SwitchBranch => "switch_branch",
             Self::MergeBranch => "merge_branch",
             Self::MergeBranchPreview => "merge_branch_preview",
-            Self::CreateCheckpoint => "create_checkpoint",
             Self::Restore => "restore",
             Self::LoadDefaultBranch => "load_default_branch_id",
         }

--- a/packages/lix/src/catalog/revision.rs
+++ b/packages/lix/src/catalog/revision.rs
@@ -129,7 +129,7 @@ mod tests {
         let no_op = session
             .execute(
                 "UPDATE lix_registered_schema SET value = value \
-                 WHERE lixcol_row_pk = CAST('[\"missing-schema\"]' AS JSONB)",
+                 WHERE schema_key = 'missing-schema'",
                 &[],
             )
             .await
@@ -179,7 +179,7 @@ mod tests {
         let amended = session
             .execute(
                 "UPDATE lix_registered_schema SET value = $1 \
-                 WHERE lixcol_row_pk = CAST('[\"tracked_revision_probe\"]' AS JSONB)",
+                 WHERE schema_key = 'tracked_revision_probe'",
                 &[Value::Jsonb(
                     test_schema("tracked_revision_probe", true).into(),
                 )],
@@ -193,7 +193,7 @@ mod tests {
         let delete_error = session
             .execute(
                 "DELETE FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = CAST('[\"tracked_revision_probe\"]' AS JSONB)",
+                 WHERE schema_key = 'tracked_revision_probe'",
                 &[],
             )
             .await

--- a/packages/lix/src/common/identity.rs
+++ b/packages/lix/src/common/identity.rs
@@ -106,7 +106,6 @@ macro_rules! canonical_identity_type {
     };
 }
 
-canonical_identity_type!(RowPk, "row_pk");
 canonical_identity_type!(FileId, "file_id");
 canonical_identity_type!(BranchId, "branch_id");
 canonical_identity_type!(CanonicalSchemaKey, "schema_key");

--- a/packages/lix/src/common/mod.rs
+++ b/packages/lix/src/common/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use string_dictionary::{
 };
 pub(crate) use timestamp::LixTimestamp;
 pub use types::{
-    Blob, Json, LixNotice, NullableKeyFilter, ResultColumnType, SharedStr, SqlQueryResult, Value,
+    Blob, Json, LixNotice, NullableKeyFilter, ResultColumnType, RowRef, SharedStr, SqlQueryResult,
+    Value,
 };
 pub use wire::{WireQueryResult, WireValue};
 

--- a/packages/lix/src/common/mod.rs
+++ b/packages/lix/src/common/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use exact_batch::{ExactBatch, ExactValue};
 pub use execution_metadata::{ExecuteStatementMetadata, MutationIdentity, RequestBlobSpliceProvenance};
 #[cfg(feature = "server-protocol")]
 pub(crate) use execution_metadata::VerifiedRequestBlob;
-pub use identity::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, RowPk, FileId};
+pub use identity::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, FileId};
 pub(crate) use identity::{json_pointer_get, validate_non_empty_identity_value};
 pub(crate) use json_pointer::format_json_pointer;
 #[cfg(test)]

--- a/packages/lix/src/common/types.rs
+++ b/packages/lix/src/common/types.rs
@@ -2,6 +2,8 @@ use std::borrow::Borrow;
 use std::fmt;
 use std::ops::{Deref, Range};
 
+use super::error::LixError;
+
 /// Immutable, cheaply cloned binary SQL value.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
@@ -480,6 +482,12 @@ pub enum Value {
     Real(f64),
     Text(String),
     Jsonb(Json),
+    /// An opaque, relation-qualified logical row address.
+    ///
+    /// Construct values in SQL with `lix_row_ref(...)`. The encoded payload is
+    /// intentionally not a JSON primary-key tuple: callers may retain and bind
+    /// it, but the engine remains responsible for interpreting it.
+    RowRef(RowRef),
     /// PostgreSQL `timestamptz`, represented losslessly as signed UTC
     /// microseconds since the Unix epoch.
     Timestamptz(i64),
@@ -498,6 +506,8 @@ pub enum ResultColumnType {
     Real,
     Text,
     Jsonb,
+    #[serde(rename = "row_ref")]
+    RowRef,
     Timestamptz,
     Blob,
 }
@@ -511,9 +521,39 @@ impl ResultColumnType {
             Value::Real(_) => Self::Real,
             Value::Text(_) => Self::Text,
             Value::Jsonb(_) => Self::Jsonb,
+            Value::RowRef(_) => Self::RowRef,
             Value::Timestamptz(_) => Self::Timestamptz,
             Value::Blob(_) => Self::Blob,
         }
+    }
+}
+
+/// Opaque address of one logical row in one Lix relation.
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
+pub struct RowRef(pub(crate) String);
+
+impl RowRef {
+    /// Validates and retains a canonical encoded row reference received from a
+    /// result or transport boundary.
+    pub fn from_encoded(value: impl Into<String>) -> Result<Self, LixError> {
+        let value = value.into();
+        crate::row_ref::decode_str(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the canonical opaque representation used for SQL parameters and
+    /// wire transport.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RowRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
     }
 }
 

--- a/packages/lix/src/common/types.rs
+++ b/packages/lix/src/common/types.rs
@@ -530,7 +530,7 @@ impl ResultColumnType {
 
 /// Opaque address of one logical row in one Lix relation.
 #[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize,
 )]
 #[serde(transparent)]
 pub struct RowRef(pub(crate) String);
@@ -554,6 +554,16 @@ impl RowRef {
 impl fmt::Display for RowRef {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for RowRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let encoded = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Self::from_encoded(encoded).map_err(serde::de::Error::custom)
     }
 }
 

--- a/packages/lix/src/common/wire.rs
+++ b/packages/lix/src/common/wire.rs
@@ -170,6 +170,10 @@ mod tests {
             Value::Real(1.5),
             Value::Text("hello".to_string()),
             Value::Jsonb(json!({"hello": "world"}).into()),
+            Value::RowRef(
+                crate::row_ref::encode("lix_key_value", &crate::row_pk::RowPk::single("hello"))
+                    .expect("test row reference should encode"),
+            ),
             Value::Timestamptz(1_700_000_000_000_000),
             Value::Blob(vec![1, 2, 3].into()),
         ];
@@ -228,6 +232,10 @@ mod tests {
                 WireValue::Jsonb {
                     value: json!({"hello": "world"}).into(),
                 },
+                WireValue::RowRef {
+                    value: "lix_row_ref:v1:AAAADWxpeF9rZXlfdmFsdWUAAQMAAAAFaGVsbG8"
+                        .to_string(),
+                },
                 WireValue::Timestamptz {
                     value: "2023-11-14T22:13:20.000000Z".to_string(),
                 },
@@ -248,6 +256,7 @@ mod tests {
         assert!(serialized.contains("\"kind\":\"float\""));
         assert!(serialized.contains("\"kind\":\"text\""));
         assert!(serialized.contains("\"kind\":\"jsonb\""));
+        assert!(serialized.contains("\"kind\":\"row_ref\""));
         assert!(serialized.contains("\"kind\":\"timestamptz\""));
         assert!(serialized.contains("\"kind\":\"blob\""));
         assert!(!serialized.contains("\"kind\":\"Null\""));

--- a/packages/lix/src/common/wire.rs
+++ b/packages/lix/src/common/wire.rs
@@ -11,6 +11,8 @@ pub enum WireValue {
     Float { value: f64 },
     Text { value: String },
     Jsonb { value: Json },
+    #[serde(rename = "row_ref")]
+    RowRef { value: String },
     Timestamptz { value: String },
     Blob { base64: String },
 }
@@ -49,6 +51,9 @@ impl WireValue {
             Value::Jsonb(value) => Ok(Self::Jsonb {
                 value: value.clone(),
             }),
+            Value::RowRef(value) => Ok(Self::RowRef {
+                value: value.as_str().to_owned(),
+            }),
             Value::Timestamptz(value) => Ok(Self::Timestamptz {
                 value: format_timestamptz(*value)?,
             }),
@@ -77,6 +82,8 @@ impl WireValue {
             }
             Self::Text { value } => Ok(Value::Text(value)),
             Self::Jsonb { value } => Ok(Value::Jsonb(value)),
+            Self::RowRef { value } => crate::row_ref::decode_str(&value)
+                .map(|_| Value::RowRef(crate::RowRef(value))),
             Self::Timestamptz { value } => parse_timestamptz(&value).map(Value::Timestamptz),
             Self::Blob { base64 } => {
                 let decoded = base64::engine::general_purpose::STANDARD

--- a/packages/lix/src/engine.rs
+++ b/packages/lix/src/engine.rs
@@ -1739,7 +1739,7 @@ mod tests {
         let broad = session
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT path, diff_type FROM {} ORDER BY path",
                     json_pointer_diff_relation(&session).await
                 ),
                 &[],
@@ -1755,9 +1755,7 @@ mod tests {
             .iter()
             .map(|row| {
                 (
-                    row.get::<serde_json::Value>("lixcol_row_pk")
-                        .expect("row_pk should decode")
-                        .to_string(),
+                    row.get::<String>("path").expect("path should decode"),
                     row.get::<String>("diff_type")
                         .expect("diff_type should decode"),
                 )
@@ -1766,10 +1764,10 @@ mod tests {
         assert_eq!(
             broad_rows,
             vec![
-                ("[\"/added\"]".to_string(), "added".to_string()),
-                ("[\"/modified\"]".to_string(), "modified".to_string()),
-                ("[\"/recycled\"]".to_string(), "added".to_string()),
-                ("[\"/removed\"]".to_string(), "removed".to_string()),
+                ("/added".to_string(), "added".to_string()),
+                ("/modified".to_string(), "modified".to_string()),
+                ("/recycled".to_string(), "added".to_string()),
+                ("/removed".to_string(), "removed".to_string()),
             ],
             "the index-driven working diff must classify every reachable shape"
         );
@@ -1785,16 +1783,15 @@ mod tests {
             "/recycled-source",
             "/never-existed",
         ] {
-            let requested_row_pk = format!("[\"{path}\"]");
             let primary_before = hits.primary_scan.load(Ordering::Relaxed);
             let finite = session
                 .execute(
                     &format!(
-                        "SELECT lixcol_row_pk, diff_type FROM {} \
-                         WHERE lixcol_row_pk = CAST($1 AS JSONB) ORDER BY lixcol_row_pk",
+                        "SELECT path, diff_type FROM {} \
+                         WHERE path = $1 ORDER BY path",
                         json_pointer_diff_relation(&session).await
                     ),
-                    &[crate::Value::Text(requested_row_pk.clone())],
+                    &[crate::Value::Text(path.to_string())],
                 )
                 .await
                 .expect("finite working-diff read should execute");
@@ -1807,9 +1804,7 @@ mod tests {
                 .iter()
                 .map(|row| {
                     (
-                        row.get::<serde_json::Value>("lixcol_row_pk")
-                            .expect("row_pk should decode")
-                            .to_string(),
+                        row.get::<String>("path").expect("path should decode"),
                         row.get::<String>("diff_type")
                             .expect("diff_type should decode"),
                     )
@@ -1817,7 +1812,7 @@ mod tests {
                 .collect::<Vec<_>>();
             let expected = broad_rows
                 .iter()
-                .filter(|(row_pk, _)| row_pk == &requested_row_pk)
+                .filter(|(row_path, _)| row_path == path)
                 .cloned()
                 .collect::<Vec<_>>();
             assert_eq!(
@@ -1959,9 +1954,7 @@ mod tests {
                 .iter()
                 .map(|row| {
                     (
-                        row.get::<serde_json::Value>("lixcol_row_pk")
-                            .expect("row_pk should decode")
-                            .to_string(),
+                        row.get::<String>("path").expect("path should decode"),
                         // `file_id` is nullable; a NULL surfaces as a decode
                         // error through the typed accessor.
                         row.get::<String>("file_id").ok(),
@@ -1975,7 +1968,7 @@ mod tests {
         }
         let relation = json_pointer_diff_relation(&session).await;
         let columns = format!(
-            "SELECT lixcol_row_pk, \
+            "SELECT path, \
              COALESCE(to_lixcol_file_id, from_lixcol_file_id) AS file_id, diff_type \
              FROM {relation}"
         );

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -2,7 +2,7 @@ use lix::plugin::runtime::WasmRuntime;
 use lix::storage::{Storage, StorageSession};
 use lix::telemetry::TelemetrySink;
 use lix::{
-    Blob, CreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt, ExecuteBatchStatement,
+    Blob, CreateBranchOptions, CreateBranchReceipt, ExecuteBatchStatement,
     ExecuteIdempotency, ExecuteResult, ExecuteStatementMetadata, ExecutionDisposition, LixError,
     Memory, MergeBranchOptions, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
     ObserveEvent, RedoReceipt, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt, Value,
@@ -1302,10 +1302,6 @@ where
     ) -> Result<CreateBranchReceipt, LixError> {
         self.retry_sync_demands(|| self.session.create_branch(options.clone()))
             .await
-    }
-
-    pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
-        self.session.create_checkpoint().await
     }
 
     /// Reverses the latest undoable tracked commit on this handle's active branch.

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1304,6 +1304,14 @@ where
             .await
     }
 
+    /// Crate-internal test/support sugar. Public callers use the canonical SQL
+    /// `lix_create_checkpoint(...)` function.
+    pub(crate) async fn create_checkpoint(
+        &self,
+    ) -> Result<crate::session::CreateCheckpointReceipt, LixError> {
+        self.session.create_checkpoint().await
+    }
+
     /// Reverses the latest undoable tracked commit on this handle's active branch.
     pub async fn undo(&self) -> Result<UndoReceipt, LixError> {
         self.retry_sync_demands(|| self.session.undo()).await

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -216,7 +216,7 @@ async fn working_diff_rows(session: &SessionContext<Memory>, schema_key: &str) -
     session
         .execute(
             &format!(
-                "SELECT lixcol_row_pk FROM lix_diff('{schema_key}', $1, lix_active_branch_commit_id())"
+                "SELECT row_ref FROM lix_diff('{schema_key}', $1, lix_active_branch_commit_id())"
             ),
             &[crate::Value::Text(checkpoint)],
         )

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -606,8 +606,7 @@ fn current_state_duplicate_delta_error(delta: &CurrentStateDeltaRef<'_>) -> LixE
             delta.schema_key, delta.row_pk, delta.file_id
         ),
         serde_json::json!({
-            "schema_key": delta.schema_key,
-            "row_pk": delta.row_pk.as_typed_json_array_value().ok(),
+            "row_ref": crate::row_ref::schema_identity_detail(delta.schema_key, delta.row_pk),
             "file_id": delta.file_id,
             "change_id": delta.change_id.map(|value| value.to_string()),
             "commit_id": delta.commit_id.map(|value| value.to_string()),

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -685,24 +685,33 @@ fn reject_retention_change(
             return Err(LixError::new(
                 LixError::CODE_UNIQUE,
                 format!(
-                    "cannot insert tracked row in schema '{}' row_pk {:?}: a canonical untracked row already exists; delete it first",
-                    delta.schema_key, delta.row_pk,
+                    "cannot insert tracked row in schema '{}': a canonical untracked row with the same primary key already exists; delete it first",
+                    delta.schema_key,
                 ),
-            ));
+            )
+            .with_details(serde_json::json!({
+                "rowRef": crate::row_ref::encode_schema_identity(delta.schema_key, delta.row_pk)
+                    .map(|row_ref| row_ref.to_string())
+                    .ok(),
+            })));
         }
         return Err(LixError::new(
             LixError::CODE_UNIQUE,
             format!(
-                "cannot change retention for existing current-state row in schema '{}' row_pk {:?}; delete it before inserting it as {}",
+                "cannot change retention for an existing current-state row in schema '{}'; delete it before inserting it as {}",
                 delta.schema_key,
-                delta.row_pk,
                 if delta.untracked {
                     "untracked"
                 } else {
                     "tracked"
                 },
             ),
-        ));
+        )
+        .with_details(serde_json::json!({
+            "rowRef": crate::row_ref::encode_schema_identity(delta.schema_key, delta.row_pk)
+                .map(|row_ref| row_ref.to_string())
+                .ok(),
+        })));
     }
     Ok(())
 }
@@ -712,16 +721,18 @@ fn tracked_head_duplicate_insert_error(key: &TrackedStateKey) -> LixError {
 }
 
 fn tracked_head_duplicate_insert_error_ref(schema_key: &str, row_pk: &RowPk) -> LixError {
-    let row_pk = row_pk
-        .as_json_array_text()
-        .unwrap_or_else(|_| "<invalid row_pk>".to_string());
     LixError::new(
         LixError::CODE_UNIQUE,
         format!(
-            "primary-key constraint violation on schema '{}': INSERT would duplicate row_pk '{row_pk}'",
+            "primary-key constraint violation on schema '{}': INSERT would duplicate an existing row",
             schema_key
         ),
     )
+    .with_details(serde_json::json!({
+        "rowRef": crate::row_ref::encode_schema_identity(schema_key, row_pk)
+            .map(|row_ref| row_ref.to_string())
+            .ok(),
+    }))
 }
 
 fn matches_filter(identity: &HeadRowIdentity, filter: &TrackedStateFilter) -> bool {

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -7180,8 +7180,8 @@ where
                         return Err(LixError::new(
                             LixError::CODE_UNIQUE,
                             format!(
-                                "cannot insert untracked row in schema '{}' row_pk {:?}: a tracked row with this identity exists in canonical history; retention is immutable for an identity",
-                                key.schema_key, key.row_pk,
+                                "cannot insert untracked row in schema '{}': a tracked row with the same primary key exists in canonical history; retention is immutable for an identity",
+                                key.schema_key,
                             ),
                         ));
                     }

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -32,7 +32,7 @@
     )
 )]
 
-pub(crate) const SERVER_PROTOCOL_VERSION: u32 = 5;
+pub(crate) const SERVER_PROTOCOL_VERSION: u32 = 6;
 
 // Let implementation modules use the same `lix::...` paths as external
 // consumers now that the former engine and SDK share one crate.
@@ -175,7 +175,7 @@ pub use common::{
     Blob, Json, LixNotice, NullableKeyFilter, ResultColumnType, RowRef, SharedStr, SqlQueryResult,
     Value,
 };
-pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, RowPk, FileId};
+pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, FileId};
 pub use common::{LixPath, validate_lix_path_segment};
 pub use common::{WireQueryResult, WireValue};
 pub(crate) use common::{parse_row_metadata_value, serialize_row_metadata};

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -181,7 +181,7 @@ pub use common::{WireQueryResult, WireValue};
 pub(crate) use common::{parse_row_metadata_value, serialize_row_metadata};
 pub(crate) use prepared_dml::{PreparedDmlParameterBatch, PreparedDmlValueRef};
 pub use session::{
-    CreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt, MergeBranchOptions,
+    CreateBranchOptions, CreateBranchReceipt, MergeBranchOptions,
     MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
     MergeChangeStats, MergeConflict, MergeConflictChangeKind, MergeConflictKind, MergeConflictSide,
     RedoReceipt, SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt,

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -68,6 +68,7 @@ pub(crate) mod domain;
 mod engine;
 pub(crate) mod row_columnar;
 pub(crate) mod row_pk;
+pub(crate) mod row_ref;
 pub(crate) mod filesystem;
 pub(crate) mod functions;
 pub(crate) mod gc;
@@ -171,7 +172,8 @@ pub use lix_schema as schema_v1;
 
 pub use common::LixError;
 pub use common::{
-    Blob, Json, LixNotice, NullableKeyFilter, ResultColumnType, SharedStr, SqlQueryResult, Value,
+    Blob, Json, LixNotice, NullableKeyFilter, ResultColumnType, RowRef, SharedStr, SqlQueryResult,
+    Value,
 };
 pub use common::{BranchId, CanonicalPluginKey, CanonicalSchemaKey, RowPk, FileId};
 pub use common::{LixPath, validate_lix_path_segment};
@@ -185,7 +187,7 @@ pub use session::{
     RedoReceipt, SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt,
 };
 pub use session::{
-    ExecuteBatchStatement, ExecuteResult, ObserveEvent, Row, RowRef, TryFromValue,
+    ExecuteBatchStatement, ExecuteResult, ObserveEvent, ResultRowRef, Row, TryFromValue,
 };
 #[doc(hidden)]
 pub use session::CoherentReadBatch;

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -347,7 +347,7 @@ where
         let result = session
             .execute(
                 "SELECT value FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = CAST('[\"lix_account\"]' AS JSONB)",
+                 WHERE schema_key = 'lix_account'",
                 &[],
             )
             .await?;
@@ -383,7 +383,7 @@ where
                 let updated = session
                     .execute(
                         "UPDATE lix_registered_schema SET value = $1 \
-                         WHERE lixcol_row_pk = CAST('[\"lix_account\"]' AS JSONB)",
+                         WHERE schema_key = 'lix_account'",
                         &[crate::Value::Jsonb(target.clone().into())],
                     )
                     .await?;

--- a/packages/lix/src/migration/epoch.rs
+++ b/packages/lix/src/migration/epoch.rs
@@ -1557,13 +1557,27 @@ async fn claim_fresh_import<S>(storage: &S, migrating: &Bytes) -> Result<(), Lix
 where
     S: Storage + Clone,
 {
+    let mut retried_cancelled_handoff = false;
     loop {
         match try_claim_fresh_import(storage, migrating).await {
             Ok(()) => return Ok(()),
-            Err(StorageError::PreconditionFailed(_)) => {
+            Err(StorageError::PreconditionFailed(failures)) => {
                 let Some((state, bytes)) = load_pointer(storage).await? else {
+                    // A cancelled importer may release its exact claim between
+                    // our failed claim commit and this resolving read. The
+                    // control-space precondition is then the only failed item.
+                    // Retry the full atomic emptiness check once; a persistent
+                    // failure is real pointerless destination state.
+                    if !retried_cancelled_handoff
+                        && !failures.is_empty()
+                        && failures.iter().all(|failure| failure.index == 0)
+                    {
+                        retried_cancelled_handoff = true;
+                        continue;
+                    }
                     return Err(nonempty_snapshot_destination());
                 };
+                retried_cancelled_handoff = false;
                 if !matches!(
                     state,
                     PointerState::Migrating {

--- a/packages/lix/src/module_layers.rs
+++ b/packages/lix/src/module_layers.rs
@@ -129,6 +129,10 @@ const UNLAYERED_MODULES: &[(&str, &str)] = &[
     ("observe_invalidation", "not yet analysed"),
     ("prepared_dml", "leaf utility, no layer semantics"),
     (
+        "row_ref",
+        "public identity encoding depends on the compiled SQL relation catalog",
+    ),
+    (
         "plugin",
         "target-selecting plugin facade and guest authoring API",
     ),

--- a/packages/lix/src/observe_coordinator.rs
+++ b/packages/lix/src/observe_coordinator.rs
@@ -88,6 +88,7 @@ enum ObserveParamKey {
     Real(u64),
     Text(String),
     Jsonb(String),
+    RowRef(String),
     Timestamptz(i64),
     Blob(crate::Blob),
 }
@@ -109,6 +110,7 @@ impl ObserveParamKey {
                 })?;
                 Ok(Self::Jsonb(json))
             }
+            Value::RowRef(value) => Ok(Self::RowRef(value.as_str().to_owned())),
             Value::Timestamptz(value) => Ok(Self::Timestamptz(*value)),
             Value::Blob(value) => Ok(Self::Blob(value.clone())),
         }
@@ -123,7 +125,7 @@ impl Hash for ObserveParamKey {
             Self::Boolean(value) => value.hash(state),
             Self::Integer(value) => value.hash(state),
             Self::Real(value) => value.hash(state),
-            Self::Text(value) | Self::Jsonb(value) => value.hash(state),
+            Self::Text(value) | Self::Jsonb(value) | Self::RowRef(value) => value.hash(state),
             Self::Timestamptz(value) => value.hash(state),
             Self::Blob(value) => value.hash(state),
         }

--- a/packages/lix/src/prepared_dml.rs
+++ b/packages/lix/src/prepared_dml.rs
@@ -26,6 +26,7 @@ enum PreparedDmlValueKind {
     Real,
     Text,
     Jsonb,
+    RowRef,
     Timestamptz,
     Blob,
 }
@@ -48,6 +49,7 @@ pub(crate) enum PreparedDmlValueRef<'a> {
     Real(f64),
     Text(&'a str),
     Jsonb(&'a [u8]),
+    RowRef(&'a str),
     Timestamptz(i64),
     Blob(&'a [u8]),
 }
@@ -128,6 +130,11 @@ impl PreparedDmlParameterBatch {
                 })?)
             }
             PreparedDmlValueKind::Jsonb => PreparedDmlValueRef::Jsonb(self.slice(cell)),
+            PreparedDmlValueKind::RowRef => PreparedDmlValueRef::RowRef(
+                std::str::from_utf8(self.slice(cell)).map_err(|_| {
+                    LixError::new(LixError::CODE_INVALID_PARAM, "prepared DML row_ref is not UTF-8")
+                })?,
+            ),
             PreparedDmlValueKind::Timestamptz => {
                 PreparedDmlValueRef::Timestamptz(i64::from_le_bytes(cell.scalar))
             }
@@ -156,6 +163,9 @@ impl PreparedDmlParameterBatch {
                 })
             }
             PreparedDmlValueKind::Jsonb => PreparedDmlValueRef::Jsonb(self.slice(cell)),
+            PreparedDmlValueKind::RowRef => PreparedDmlValueRef::RowRef(unsafe {
+                std::str::from_utf8_unchecked(self.slice(cell))
+            }),
             PreparedDmlValueKind::Timestamptz => {
                 PreparedDmlValueRef::Timestamptz(i64::from_le_bytes(cell.scalar))
             }
@@ -188,6 +198,8 @@ impl PreparedDmlParameterBatch {
                             format!("prepared DML JSON parameter is invalid: {error}"),
                         )
                     }),
+                PreparedDmlValueRef::RowRef(value) => crate::row_ref::decode_str(value)
+                    .map(|_| Value::RowRef(crate::RowRef(value.to_owned()))),
                 PreparedDmlValueRef::Timestamptz(value) => Ok(Value::Timestamptz(value)),
                 PreparedDmlValueRef::Blob(value) => Ok(Value::Blob(Blob::from(value.to_vec()))),
             })
@@ -228,6 +240,10 @@ impl PreparedDmlParameterBatch {
                     )
                 })?;
                 Self::set_bytes(&mut cell, bytes, &encoded)?;
+            }
+            Value::RowRef(value) => {
+                cell.kind = PreparedDmlValueKind::RowRef;
+                Self::set_bytes(&mut cell, bytes, value.as_str().as_bytes())?;
             }
             Value::Timestamptz(value) => {
                 cell.kind = PreparedDmlValueKind::Timestamptz;

--- a/packages/lix/src/row_ref.rs
+++ b/packages/lix/src/row_ref.rs
@@ -1,0 +1,204 @@
+//! Canonical opaque encoding for public relation-qualified row addresses.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use bytes::Bytes;
+use smallvec::SmallVec;
+
+use crate::row_pk::{RowPk, RowPkComponent};
+use crate::row_pk::RowPkComponentType;
+use crate::sql2::{PublicCatalog, PublicSurfaceKind};
+use crate::{LixError, RowRef};
+
+const PREFIX: &str = "lix_row_ref:v1:";
+const UUID_TAG: u8 = 1;
+const INTEGER_TAG: u8 = 2;
+const TEXT_TAG: u8 = 3;
+const BYTES_TAG: u8 = 4;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedRowRef {
+    pub(crate) relation: String,
+    pub(crate) row_pk: RowPk,
+}
+
+pub(crate) fn primary_key_component_types(
+    catalog: &PublicCatalog,
+    relation: &str,
+) -> Result<Vec<RowPkComponentType>, LixError> {
+    let surface = catalog.surface(relation).ok_or_else(|| {
+        invalid(format!("lix_row_ref relation '{relation}' does not exist"))
+    })?;
+    match &surface.kind {
+        PublicSurfaceKind::File | PublicSurfaceKind::Directory => {
+            Ok(vec![RowPkComponentType::Uuid])
+        }
+        PublicSurfaceKind::SchemaBase { schema_key } => catalog
+            .schema_spec(schema_key)
+            .map(|spec| spec.primary_key_component_types.clone())
+            .ok_or_else(|| invalid(format!("relation '{relation}' has no primary-key schema"))),
+        _ => Err(invalid(format!(
+            "lix_row_ref does not support relation '{relation}'"
+        ))),
+    }
+}
+
+pub(crate) fn encode(relation: &str, row_pk: &RowPk) -> Result<RowRef, LixError> {
+    if relation.is_empty() || relation.contains('\0') {
+        return Err(invalid("row reference relation must be non-empty text without Unicode NUL"));
+    }
+    let relation_len = u32::try_from(relation.len())
+        .map_err(|_| invalid("row reference relation is too long"))?;
+    let component_count = u16::try_from(row_pk.components.len())
+        .map_err(|_| invalid("row reference has too many primary-key components"))?;
+    let mut bytes = Vec::with_capacity(relation.len() + 32);
+    bytes.extend_from_slice(&relation_len.to_be_bytes());
+    bytes.extend_from_slice(relation.as_bytes());
+    bytes.extend_from_slice(&component_count.to_be_bytes());
+    for component in &row_pk.components {
+        match component {
+            RowPkComponent::Uuid(value) => {
+                bytes.push(UUID_TAG);
+                bytes.extend_from_slice(value);
+            }
+            RowPkComponent::Integer(value) => {
+                bytes.push(INTEGER_TAG);
+                bytes.extend_from_slice(&value.to_be_bytes());
+            }
+            RowPkComponent::String(value) => {
+                bytes.push(TEXT_TAG);
+                write_sized(&mut bytes, value.as_bytes())?;
+            }
+            RowPkComponent::Bytes(value) => {
+                bytes.push(BYTES_TAG);
+                write_sized(&mut bytes, value)?;
+            }
+        }
+    }
+    Ok(RowRef(format!("{PREFIX}{}", URL_SAFE_NO_PAD.encode(bytes))))
+}
+
+pub(crate) fn decode(row_ref: &RowRef) -> Result<ResolvedRowRef, LixError> {
+    decode_str(row_ref.as_str())
+}
+
+pub(crate) fn decode_str(encoded: &str) -> Result<ResolvedRowRef, LixError> {
+    let payload = encoded
+        .strip_prefix(PREFIX)
+        .ok_or_else(|| invalid("value is not a canonical lix_row_ref"))?;
+    let bytes = URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| invalid("lix_row_ref payload is not canonical base64url"))?;
+    let mut cursor = Cursor::new(&bytes);
+    let relation_len = cursor.read_u32()? as usize;
+    let relation = std::str::from_utf8(cursor.read(relation_len)?)
+        .map_err(|_| invalid("lix_row_ref relation is not UTF-8"))?
+        .to_owned();
+    if relation.is_empty() || relation.contains('\0') {
+        return Err(invalid("lix_row_ref relation is invalid"));
+    }
+    let component_count = cursor.read_u16()? as usize;
+    if component_count == 0 {
+        return Err(invalid("lix_row_ref primary key is empty"));
+    }
+    let mut components = SmallVec::<[RowPkComponent; 2]>::new();
+    for _ in 0..component_count {
+        components.push(match cursor.read_u8()? {
+            UUID_TAG => {
+                let mut value = [0_u8; 16];
+                value.copy_from_slice(cursor.read(16)?);
+                RowPkComponent::Uuid(value)
+            }
+            INTEGER_TAG => RowPkComponent::Integer(i64::from_be_bytes(
+                cursor
+                    .read(8)?
+                    .try_into()
+                    .expect("eight bytes were requested"),
+            )),
+            TEXT_TAG => {
+                let value = std::str::from_utf8(cursor.read_sized()?)
+                    .map_err(|_| invalid("lix_row_ref text key is not UTF-8"))?;
+                RowPkComponent::String(value.to_owned().into())
+            }
+            BYTES_TAG => RowPkComponent::Bytes(Bytes::copy_from_slice(cursor.read_sized()?)),
+            _ => return Err(invalid("lix_row_ref contains an unknown key component type")),
+        });
+    }
+    if !cursor.is_finished() {
+        return Err(invalid("lix_row_ref contains trailing bytes"));
+    }
+    let row_pk = RowPk::from_components(components)
+        .map_err(|error| invalid(format!("lix_row_ref primary key is invalid: {error}")))?;
+    // Reject alternate encodings so equality is byte-canonical.
+    let decoded = ResolvedRowRef { relation, row_pk };
+    if encode(&decoded.relation, &decoded.row_pk)?.as_str() != encoded {
+        return Err(invalid("lix_row_ref is not canonically encoded"));
+    }
+    Ok(decoded)
+}
+
+fn write_sized(out: &mut Vec<u8>, value: &[u8]) -> Result<(), LixError> {
+    let len = u32::try_from(value.len()).map_err(|_| invalid("row reference key is too long"))?;
+    out.extend_from_slice(&len.to_be_bytes());
+    out.extend_from_slice(value);
+    Ok(())
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+    fn read(&mut self, len: usize) -> Result<&'a [u8], LixError> {
+        let end = self.offset.checked_add(len).ok_or_else(|| invalid("lix_row_ref is truncated"))?;
+        let value = self.bytes.get(self.offset..end).ok_or_else(|| invalid("lix_row_ref is truncated"))?;
+        self.offset = end;
+        Ok(value)
+    }
+    fn read_u8(&mut self) -> Result<u8, LixError> { Ok(self.read(1)?[0]) }
+    fn read_u16(&mut self) -> Result<u16, LixError> {
+        Ok(u16::from_be_bytes(self.read(2)?.try_into().expect("two bytes")))
+    }
+    fn read_u32(&mut self) -> Result<u32, LixError> {
+        Ok(u32::from_be_bytes(self.read(4)?.try_into().expect("four bytes")))
+    }
+    fn read_sized(&mut self) -> Result<&'a [u8], LixError> {
+        let len = self.read_u32()? as usize;
+        self.read(len)
+    }
+    fn is_finished(&self) -> bool { self.offset == self.bytes.len() }
+}
+
+fn invalid(message: impl Into<String>) -> LixError {
+    LixError::new(LixError::CODE_TYPE_MISMATCH, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::row_pk::RowPkComponent;
+
+    #[test]
+    fn round_trips_composite_typed_identity_without_json() {
+        let row_pk = RowPk::from_components(smallvec::smallvec![
+            RowPkComponent::String("parent".into()),
+            RowPkComponent::Integer(7),
+        ]).unwrap();
+        let encoded = encode("json_object_member", &row_pk).unwrap();
+        assert!(!encoded.as_str().contains('['));
+        assert!(!encoded.as_str().contains("parent"));
+        assert_eq!(decode(&encoded).unwrap(), ResolvedRowRef {
+            relation: "json_object_member".to_owned(), row_pk,
+        });
+    }
+
+    #[test]
+    fn rejects_malformed_or_noncanonical_values() {
+        assert!(decode_str("[\"row\"]").is_err());
+        assert!(decode_str("lix_row_ref:v1:not-base64!").is_err());
+    }
+}

--- a/packages/lix/src/row_ref.rs
+++ b/packages/lix/src/row_ref.rs
@@ -78,6 +78,32 @@ pub(crate) fn encode(relation: &str, row_pk: &RowPk) -> Result<RowRef, LixError>
     Ok(RowRef(format!("{PREFIX}{}", URL_SAFE_NO_PAD.encode(bytes))))
 }
 
+/// Encodes a durable schema identity for public diagnostics.
+///
+/// Filesystem descriptor schema keys are implementation details of the two
+/// logical filesystem relations. Registered relation schema keys already are
+/// their public relation names. Other engine-only identities retain their
+/// schema key as the relation qualifier so details remain lossless without
+/// exposing the old JSON row-key representation.
+pub(crate) fn encode_schema_identity(
+    schema_key: &str,
+    row_pk: &RowPk,
+) -> Result<RowRef, LixError> {
+    let relation = match schema_key {
+        "lix_file_descriptor" => "lix_file",
+        "lix_directory_descriptor" => "lix_directory",
+        relation => relation,
+    };
+    encode(relation, row_pk)
+}
+
+pub(crate) fn schema_identity_detail(schema_key: &str, row_pk: &RowPk) -> serde_json::Value {
+    match encode_schema_identity(schema_key, row_pk) {
+        Ok(row_ref) => serde_json::Value::String(row_ref.as_str().to_owned()),
+        Err(_) => serde_json::Value::Null,
+    }
+}
+
 pub(crate) fn decode(row_ref: &RowRef) -> Result<ResolvedRowRef, LixError> {
     decode_str(row_ref.as_str())
 }
@@ -197,8 +223,24 @@ mod tests {
     }
 
     #[test]
+    fn round_trips_every_supported_primary_key_component_type() {
+        let row_pk = RowPk::from_components(smallvec::smallvec![
+            RowPkComponent::Uuid([7; 16]),
+            RowPkComponent::Integer(-42),
+            RowPkComponent::String("member".into()),
+            RowPkComponent::Bytes(Bytes::from_static(b"\0binary\xff")),
+        ])
+        .unwrap();
+        let encoded = encode("typed_identity", &row_pk).unwrap();
+        assert_eq!(decode(&encoded).unwrap().row_pk, row_pk);
+        assert_eq!(serde_json::from_value::<RowRef>(serde_json::json!(encoded.as_str())).unwrap(), encoded);
+    }
+
+    #[test]
     fn rejects_malformed_or_noncanonical_values() {
         assert!(decode_str("[\"row\"]").is_err());
         assert!(decode_str("lix_row_ref:v1:not-base64!").is_err());
+        assert!(serde_json::from_str::<RowRef>(r#""[\"row\"]""#).is_err());
+        assert!(serde_json::from_str::<RowRef>(r#""lix_row_ref:v1:not-base64!""#).is_err());
     }
 }

--- a/packages/lix/src/schema/builtin/lix_change.json
+++ b/packages/lix/src/schema/builtin/lix_change.json
@@ -19,10 +19,10 @@
       ]
     },
     {
-      "name": "row_pk",
-      "type": "jsonb",
-      "nullable": false,
-      "description": "Canonical JSON primary-key tuple for the row this change applies to, scoped by (`schema_key`, `file_id`). Values are ordered according to the target schema's `x-lix-primary-key`."
+      "name": "row_ref",
+      "type": "text",
+      "nullable": true,
+      "description": "Opaque reference to the public relation row this change applies to; NULL for private engine rows."
     },
     {
       "name": "file_id",

--- a/packages/lix/src/server_protocol/client/mod.rs
+++ b/packages/lix/src/server_protocol/client/mod.rs
@@ -20,14 +20,14 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 
 use crate::{
-    CreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt, ExecuteBatchStatement,
-    ExecuteResult, LixError, RedoReceipt, SwitchBranchReceipt, UndoReceipt, Value,
+    CreateBranchOptions, CreateBranchReceipt, ExecuteBatchStatement, ExecuteResult, LixError,
+    RedoReceipt, SwitchBranchReceipt, UndoReceipt, Value,
 };
 
 use blobs::{BlobCache, PreparedRequestParams, request_blob_slot};
 use wire::{
     BLOB_BASE_MISSING_CODE, BeginTransactionResponse, CreateBranchRequestBody,
-    CreateBranchResponseBody, CreateCheckpointResponseBody, EmptyBody, ErrorEnvelope,
+    CreateBranchResponseBody, EmptyBody, ErrorEnvelope,
     ExecuteBatchRequestBody, ExecuteBatchStatementBody, ExecuteOptionsBody, ExecuteRequestBody,
     ExecuteResponseBody, HandshakeResponse, IDEMPOTENCY_KEY_HEADER, RedoResponseBody,
     SESSION_HEADER, SERVER_PROTOCOL_VERSION, SwitchBranchRequestBody,
@@ -605,32 +605,6 @@ impl<H: ProtocolHttp> ClientCore<H> {
                     name: value.name,
                     hidden: value.hidden,
                     commit_id: value.commit_id,
-                })
-            })
-            .await
-        })
-        .await
-    }
-
-    pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
-        self.enqueue(|| async {
-            self.with_session_recovery(|| async {
-                let value = self
-                    .request_json::<CreateCheckpointResponseBody, EmptyBody>(
-                        "POST",
-                        self.join_path("checkpoint/create")?,
-                        true,
-                        None,
-                        Some(EmptyBody {}),
-                        "json",
-                    )
-                    .await?;
-                if value.commit_id.is_empty() {
-                    return Err(protocol_error("create checkpoint response is invalid"));
-                }
-                Ok(CreateCheckpointReceipt {
-                    commit_id: value.commit_id,
-                    change_id: String::new(),
                 })
             })
             .await

--- a/packages/lix/src/server_protocol/client/wire.rs
+++ b/packages/lix/src/server_protocol/client/wire.rs
@@ -175,12 +175,6 @@ pub struct CreateBranchResponseBody {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCheckpointResponseBody {
-    pub commit_id: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct UndoResponseBody {
     pub branch_id: String,
     pub target_commit_id: String,

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -294,7 +294,6 @@ pub const SERVER_PROTOCOL_ENDPOINTS: &[(&str, &str)] = &[
     ("POST", "/lix/v1/{lix_id}/file/upsert"),
     ("POST", "/lix/v1/{lix_id}/file/upsert-batch"),
     ("POST", "/lix/v1/{lix_id}/branch/create"),
-    ("POST", "/lix/v1/{lix_id}/checkpoint/create"),
     ("POST", "/lix/v1/{lix_id}/undo"),
     ("POST", "/lix/v1/{lix_id}/redo"),
     ("POST", "/lix/v1/{lix_id}/branch/switch"),
@@ -1968,9 +1967,6 @@ where
             (&Method::POST, "/lix/v1/branch/create") => {
                 result_response(create_branch(lease, json_request!(CreateBranchRequest)).await)
             }
-            (&Method::POST, "/lix/v1/checkpoint/create") => {
-                result_response(create_checkpoint(lease).await)
-            }
             (&Method::POST, "/lix/v1/undo") => result_response(undo(lease).await),
             (&Method::POST, "/lix/v1/redo") => result_response(redo(lease).await),
             (&Method::POST, "/lix/v1/branch/switch") => {
@@ -3496,20 +3492,6 @@ where
     }))
 }
 
-async fn create_checkpoint<S>(
-    lease: SessionLease<S>,
-) -> Result<Json<CreateCheckpointResponse>, ApiError>
-where
-    S: Storage + Clone + Send + Sync + 'static,
-{
-    let receipt = lease
-        .run_durable(move |lix| async move { lix.create_checkpoint().await })
-        .await?;
-    Ok(Json(CreateCheckpointResponse {
-        commit_id: receipt.commit_id,
-    }))
-}
-
 async fn undo<S>(lease: SessionLease<S>) -> Result<Json<UndoResponse>, ApiError>
 where
     S: Storage + Clone + Send + Sync + 'static,
@@ -4799,12 +4781,6 @@ struct CreateBranchResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct CreateCheckpointResponse {
-    commit_id: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 struct UndoResponse {
     branch_id: String,
     target_commit_id: String,
@@ -5314,7 +5290,6 @@ mod tests {
                 ("POST", "/lix/v1/{lix_id}/file/upsert") => "upsertFile",
                 ("POST", "/lix/v1/{lix_id}/file/upsert-batch") => "upsertFileBatch",
                 ("POST", "/lix/v1/{lix_id}/branch/create") => "createBranch",
-                ("POST", "/lix/v1/{lix_id}/checkpoint/create") => "createCheckpoint",
                 ("POST", "/lix/v1/{lix_id}/undo") => "undo",
                 ("POST", "/lix/v1/{lix_id}/redo") => "redo",
                 ("POST", "/lix/v1/{lix_id}/branch/switch") => "switchBranch",
@@ -10009,13 +9984,15 @@ mod tests {
         let created = request(
             &app.router,
             "POST",
-            "/lix/v1/checkpoint/create",
+            "/lix/v1/execute",
             Some(&session_id),
-            None,
+            Some(json!({
+                "sql": "SELECT commit_id FROM lix_create_checkpoint()"
+            })),
         )
         .await;
         assert_eq!(created.status(), StatusCode::OK);
-        let checkpoint_id = response_json(created).await["commitId"]
+        let checkpoint_id = response_json(created).await["rows"][0][0]["value"]
             .as_str()
             .expect("checkpoint commit id")
             .to_string();
@@ -11931,13 +11908,15 @@ mod tests {
         let response = request(
             &app.router,
             "POST",
-            "/lix/v1/checkpoint/create",
+            "/lix/v1/execute",
             Some(&session_id),
-            None,
+            Some(json!({
+                "sql": "SELECT commit_id FROM lix_create_checkpoint()"
+            })),
         )
         .await;
         assert_eq!(response.status(), StatusCode::OK);
-        let commit_id = response_json(response).await["commitId"]
+        let commit_id = response_json(response).await["rows"][0][0]["value"]
             .as_str()
             .expect("commitId")
             .to_string();

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -2,9 +2,6 @@ use crate::LixError;
 use crate::gc::CheckpointGcState;
 use crate::gc::load_checkpoint_gc_state;
 use crate::storage_adapter::{SharedStorageAdapterRead, Storage, StorageReadOptions};
-use crate::telemetry::{
-    ActiveTelemetrySpan, CHECKPOINT_CREATE, Status, TelemetryAttribute,
-};
 #[cfg(test)]
 use crate::tracked_state::{TrackedStateDiffKind, TrackedStateDiffRow};
 #[cfg(test)]
@@ -46,66 +43,33 @@ where
     /// copies interval members. Scale-dependent physical reclamation is
     /// maintenance work and cannot extend foreground checkpoint latency.
     pub(crate) async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
-        let span = self.telemetry.as_ref().and_then(|sink| {
-            ActiveTelemetrySpan::start_if_enabled(sink, &CHECKPOINT_CREATE, Vec::new())
-        });
-        let operation = async {
-            let checkpoint = self
-                .execute(
-                    "SELECT commit_id FROM lix_create_checkpoint()",
-                    &[],
-                )
-                .await?;
-            let checkpoint_row = checkpoint.rows().first().ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "checkpoint SQL function returned no commit ID",
-                    )
-                })?;
-            let commit_id = checkpoint_row.get::<String>("commit_id")?;
-            let marker = self
-                .execute(
-                    "SELECT lixcol_change_id FROM lix_checkpoint WHERE commit_id = $1",
-                    &[crate::Value::Text(commit_id.clone())],
-                )
-                .await?;
-            let marker_row = marker.rows().first().ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_INTERNAL_ERROR,
-                        "checkpoint SQL function published no checkpoint marker",
-                    )
-                })?;
-            let change_id = marker_row.get::<String>("lixcol_change_id")?;
-            Ok::<_, LixError>(CreateCheckpointReceipt {
-                commit_id,
-                change_id,
-            })
-        };
-        let result = match span.as_ref() {
-            Some(span) => span.instrument(operation).await,
-            None => operation.await,
-        };
-        let receipt = match result {
-            Ok(receipt) => receipt,
-            Err(error) => {
-                if let Some(span) = span {
-                    span.finish(
-                        Status::error(error.code.clone()),
-                        vec![TelemetryAttribute::string("error.type", error.code.clone())],
-                    );
-                }
-                return Err(error);
-            }
-        };
-        if let Some(span) = span {
-            span.finish(
-                Status::Unset,
-                vec![
-                    TelemetryAttribute::string("lix.commit_id", receipt.commit_id.clone()),
-                ],
-            );
-        }
-        Ok(receipt)
+        let checkpoint = self
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await?;
+        let checkpoint_row = checkpoint.rows().first().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "checkpoint SQL function returned no commit ID",
+            )
+        })?;
+        let commit_id = checkpoint_row.get::<String>("commit_id")?;
+        let marker = self
+            .execute(
+                "SELECT lixcol_change_id FROM lix_checkpoint WHERE commit_id = $1",
+                &[crate::Value::Text(commit_id.clone())],
+            )
+            .await?;
+        let marker_row = marker.rows().first().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "checkpoint SQL function published no checkpoint marker",
+            )
+        })?;
+        let change_id = marker_row.get::<String>("lixcol_change_id")?;
+        Ok(CreateCheckpointReceipt {
+            commit_id,
+            change_id,
+        })
     }
 
     /// Consumes the post-commit checkpoint effect published by the transaction
@@ -275,7 +239,7 @@ mod tests {
     use crate::transaction::StagedCommitChangeBatchBuilder;
 
     #[tokio::test]
-    async fn repository_global_branch_cannot_be_checkpointed() {
+    async fn repository_global_branch_cannot_be_checkpointed_through_sql() {
         let storage = Memory::new();
         let _receipt = crate::engine::Engine::initialize(storage.clone())
             .await
@@ -289,7 +253,7 @@ mod tests {
             .expect("global session opens");
 
         let error = session
-            .create_checkpoint()
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
             .await
             .expect_err("global branch checkpoint must be rejected");
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -115,6 +115,9 @@ where
         &self,
         checkpoint_sequence: u64,
     ) {
+        #[cfg(test)]
+        self.commit_coordinator
+            .record_checkpoint_gc_post_commit_hook();
         let result = async {
         let read = SharedStorageAdapterRead::new(
             self.storage.begin_read(StorageReadOptions::default()).await?,
@@ -291,6 +294,67 @@ mod tests {
             .expect_err("global branch checkpoint must be rejected");
         assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
         assert!(error.to_string().contains("global branch"));
+    }
+
+    #[tokio::test]
+    async fn sql_checkpoint_schedules_gc_only_after_outer_commit() {
+        let storage = Memory::new();
+        crate::engine::Engine::initialize(storage.clone())
+            .await
+            .expect("repository initializes");
+        let engine = crate::engine::Engine::new(storage)
+            .await
+            .expect("repository opens");
+        let session = engine
+            .open_session()
+            .await
+            .expect("session opens");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('gc-hook', 'working')",
+                &[],
+            )
+            .await
+            .expect("working row commits");
+        assert_eq!(
+            session.commit_coordinator.checkpoint_gc_post_commit_hooks(),
+            0
+        );
+
+        let mut rolled_back = session
+            .begin_transaction()
+            .await
+            .expect("transaction begins");
+        rolled_back
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("checkpoint stages");
+        assert_eq!(
+            session.commit_coordinator.checkpoint_gc_post_commit_hooks(),
+            0,
+            "staging a checkpoint must not schedule maintenance"
+        );
+        rolled_back.rollback().await.expect("rollback succeeds");
+        assert_eq!(
+            session.commit_coordinator.checkpoint_gc_post_commit_hooks(),
+            0,
+            "rolling back a checkpoint must not schedule maintenance"
+        );
+
+        let mut committed = session
+            .begin_transaction()
+            .await
+            .expect("transaction begins");
+        committed
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("checkpoint stages");
+        committed.commit().await.expect("checkpoint commits");
+        assert_eq!(
+            session.commit_coordinator.checkpoint_gc_post_commit_hooks(),
+            1,
+            "a durable SQL checkpoint schedules maintenance exactly once"
+        );
     }
 
     #[test]

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -1,8 +1,7 @@
 use crate::LixError;
-use crate::branch::{BranchLifecycle, BranchOperation, BranchReferenceRole};
-use crate::checkpoint::checkpoint_stage_row;
 use crate::gc::CheckpointGcState;
-use crate::storage_adapter::Storage;
+use crate::gc::load_checkpoint_gc_state;
+use crate::storage_adapter::{SharedStorageAdapterRead, Storage, StorageReadOptions};
 use crate::telemetry::{
     ActiveTelemetrySpan, CHECKPOINT_CREATE, Status, TelemetryAttribute,
 };
@@ -10,13 +9,12 @@ use crate::telemetry::{
 use crate::tracked_state::{TrackedStateDiffKind, TrackedStateDiffRow};
 #[cfg(test)]
 use crate::transaction::StagedCommitChangeBatchBuilder;
-use crate::transaction_types::{RawWriteBatch, TransactionWrite, TransactionWriteMode};
 
 use super::context::SessionContext;
 
 /// Receipt returned after compacting the active working interval.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CreateCheckpointReceipt {
+pub(crate) struct CreateCheckpointReceipt {
     /// Commit containing the branch state captured by this checkpoint.
     pub commit_id: String,
     /// Logical change that published the repository-global checkpoint row.
@@ -37,13 +35,6 @@ const RECLAIM_FAILURE_BACKOFF_CAP: u32 = 10;
 /// full-sweep positions sublinear.
 const RECLAIM_MAX_STALENESS: u64 = 64;
 
-struct CreateCheckpointOutcome {
-    receipt: CreateCheckpointReceipt,
-    parent_commit_id: String,
-    gc_due: bool,
-    checkpoint_sequence: u64,
-}
-
 impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -54,87 +45,48 @@ where
     /// state while parenting the prior checkpoint. Publication never reads or
     /// copies interval members. Scale-dependent physical reclamation is
     /// maintenance work and cannot extend foreground checkpoint latency.
-    pub async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
+    pub(crate) async fn create_checkpoint(&self) -> Result<CreateCheckpointReceipt, LixError> {
         let span = self.telemetry.as_ref().and_then(|sink| {
             ActiveTelemetrySpan::start_if_enabled(sink, &CHECKPOINT_CREATE, Vec::new())
         });
-        let operation = self.with_write_transaction_lending(async move |transaction| {
-            let branch_id = transaction.active_branch_id().to_string();
-            if branch_id == crate::GLOBAL_BRANCH_ID {
-                return Err(LixError::new(
-                    LixError::CODE_INVALID_PARAM,
-                    "the repository-global branch cannot be checkpointed",
-                ));
-            }
-            let (previous_recovery, mut gc_state) =
-                transaction.checkpoint_publication_state(&branch_id).await?;
-            let head_commit_id = {
-                let reader = transaction.branch_ref_reader().await?;
-                BranchLifecycle::new(&reader)
-                    .require_existing_commit_id(
-                        &branch_id,
-                        BranchOperation::CreateCheckpoint,
-                        BranchReferenceRole::Target,
-                    )
-                    .await?
-            };
-            let previous_checkpoint_commit_id = transaction
-                .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
+        let operation = async {
+            let checkpoint = self
+                .execute(
+                    "SELECT commit_id FROM lix_create_checkpoint()",
+                    &[],
+                )
                 .await?;
-            let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
-            // The checkpoint commit severs the ordinary first-parent interval.
-            // Commit materialization publishes a complete-state fence that
-            // structurally shares the captured head root, so publication does
-            // not enumerate or copy interval members.
-            gc_state.checkpoint_sequence =
-                gc_state.checkpoint_sequence.checked_add(1).ok_or_else(|| {
+            let checkpoint_row = checkpoint.rows().first().ok_or_else(|| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
-                        "checkpoint sequence overflow",
+                        "checkpoint SQL function returned no commit ID",
                     )
                 })?;
-            if let Some(previous_recovery) = previous_recovery {
-                gc_state.add_collectible_interval(previous_recovery.interval_has_commits);
-            }
-            let gc_due = checkpoint_gc_due(gc_state)?;
-
-            let commit_id = transaction.stage_checkpoint_boundary_commit(
-                branch_id,
-                previous_checkpoint_commit_id,
-                head_commit_id,
-                interval_has_commits,
-                gc_state,
-            )?;
-            let checkpoint_commit_id =
-                crate::changelog::CommitId::parse_lix(&commit_id, "checkpoint commit id")?;
-            let change_id = transaction.functions().call_uuid_v7().to_string();
-            let mut checkpoint_rows = RawWriteBatch::with_capacity(1);
-            checkpoint_rows.push(checkpoint_stage_row(
-                &checkpoint_commit_id,
-                change_id.clone(),
-            ));
-            transaction
-                .stage_write(TransactionWrite::Rows {
-                    mode: TransactionWriteMode::Replace,
-                    rows: checkpoint_rows,
-                })
+            let commit_id = checkpoint_row.get::<String>("commit_id")?;
+            let marker = self
+                .execute(
+                    "SELECT lixcol_change_id FROM lix_checkpoint WHERE commit_id = $1",
+                    &[crate::Value::Text(commit_id.clone())],
+                )
                 .await?;
-            Ok(CreateCheckpointOutcome {
-                receipt: CreateCheckpointReceipt {
-                    commit_id,
-                    change_id,
-                },
-                parent_commit_id: previous_checkpoint_commit_id.to_string(),
-                gc_due,
-                checkpoint_sequence: gc_state.checkpoint_sequence,
+            let marker_row = marker.rows().first().ok_or_else(|| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "checkpoint SQL function published no checkpoint marker",
+                    )
+                })?;
+            let change_id = marker_row.get::<String>("lixcol_change_id")?;
+            Ok::<_, LixError>(CreateCheckpointReceipt {
+                commit_id,
+                change_id,
             })
-        });
+        };
         let result = match span.as_ref() {
             Some(span) => span.instrument(operation).await,
             None => operation.await,
         };
-        let outcome = match result {
-            Ok(outcome) => outcome,
+        let receipt = match result {
+            Ok(receipt) => receipt,
             Err(error) => {
                 if let Some(span) = span {
                     span.finish(
@@ -149,18 +101,34 @@ where
             span.finish(
                 Status::Unset,
                 vec![
-                    TelemetryAttribute::string("lix.commit_id", outcome.receipt.commit_id.clone()),
-                    TelemetryAttribute::string(
-                        "lix.parent_commit_id",
-                        outcome.parent_commit_id.clone(),
-                    ),
+                    TelemetryAttribute::string("lix.commit_id", receipt.commit_id.clone()),
                 ],
             );
         }
-        if outcome.gc_due
+        Ok(receipt)
+    }
+
+    /// Consumes the post-commit checkpoint effect published by the transaction
+    /// planner. Every checkpoint entry point, including explicit transactions
+    /// and remote SQL, reaches this hook after durability.
+    pub(super) async fn schedule_checkpoint_gc_after_commit(
+        &self,
+        checkpoint_sequence: u64,
+    ) -> Result<(), LixError> {
+        let read = SharedStorageAdapterRead::new(
+            self.storage.begin_read(StorageReadOptions::default()).await?,
+        );
+        let gc_state = load_checkpoint_gc_state(&read).await?;
+        if gc_state.checkpoint_sequence < checkpoint_sequence {
+            return Err(LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "committed checkpoint GC sequence is not visible after commit",
+            ));
+        }
+        if checkpoint_gc_due(gc_state)?
             && self
                 .commit_coordinator
-                .try_begin_checkpoint_gc(outcome.checkpoint_sequence)
+                .try_begin_checkpoint_gc(gc_state.checkpoint_sequence)
         {
             // GC debt is durable in the checkpoint transaction. The sweep is
             // therefore safely retryable and does not need to delay the user
@@ -181,7 +149,7 @@ where
                 return Err(error);
             }
         }
-        Ok(outcome.receipt)
+        Ok(())
     }
 }
 

--- a/packages/lix/src/session/checkpoint.rs
+++ b/packages/lix/src/session/checkpoint.rs
@@ -114,7 +114,8 @@ where
     pub(super) async fn schedule_checkpoint_gc_after_commit(
         &self,
         checkpoint_sequence: u64,
-    ) -> Result<(), LixError> {
+    ) {
+        let result = async {
         let read = SharedStorageAdapterRead::new(
             self.storage.begin_read(StorageReadOptions::default()).await?,
         );
@@ -149,7 +150,15 @@ where
                 return Err(error);
             }
         }
-        Ok(())
+        Ok::<_, LixError>(())
+        }
+        .await;
+        if let Err(error) = result {
+            // The checkpoint is already durable. GC debt is stored with that
+            // commit and a later checkpoint can retry it, so never turn a
+            // maintenance failure into a false mutation failure.
+            tracing::warn!(error = %error, checkpoint_sequence, "post-commit checkpoint GC scheduling failed");
+        }
     }
 }
 

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -546,6 +546,10 @@ where
                     &outcome.storage_stats,
                     outcome.commit_cohort_id.as_deref(),
                 );
+                if let Some(checkpoint_sequence) = outcome.checkpoint_gc_sequence {
+                    self.schedule_checkpoint_gc_after_commit(checkpoint_sequence)
+                        .await?;
+                }
                 if self.branch.get()?.as_str() != GLOBAL_BRANCH_ID {
                     self.base_refresh_generation.store(
                         self.observe_invalidation.generation(),

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -548,7 +548,7 @@ where
                 );
                 if let Some(checkpoint_sequence) = outcome.checkpoint_gc_sequence {
                     self.schedule_checkpoint_gc_after_commit(checkpoint_sequence)
-                        .await?;
+                        .await;
                 }
                 if self.branch.get()?.as_str() != GLOBAL_BRANCH_ID {
                     self.base_refresh_generation.store(

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -639,7 +639,7 @@ impl TryFromValue for RowRef {
     fn try_from_value(value: &Value) -> Result<Self, LixError> {
         match value {
             Value::RowRef(value) => Ok(value.clone()),
-            other => Err(value_type_error("lix_row_ref", other)),
+            other => Err(value_type_error("row_ref", other)),
         }
     }
 }
@@ -8521,7 +8521,7 @@ mod tests {
         transaction
             .execute(
                 "UPDATE lix_registered_schema SET value = $1 \
-                 WHERE lixcol_row_pk = CAST('[\"amended_parameter_insert_probe\"]' AS JSONB)",
+                 WHERE schema_key = 'amended_parameter_insert_probe'",
                 &[Value::Jsonb(amended_schema.into())],
             )
             .await
@@ -8682,7 +8682,7 @@ mod tests {
         transaction
             .execute(
                 "UPDATE lix_registered_schema SET value = $1 \
-                 WHERE lixcol_row_pk = CAST('[\"amended_parameter_update_probe\"]' AS JSONB)",
+                 WHERE schema_key = 'amended_parameter_update_probe'",
                 &[Value::Jsonb(amended_schema.into())],
             )
             .await

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -388,9 +388,9 @@ impl ExecuteResult {
     }
 
     /// Iterates rows with borrowed access to the shared column metadata.
-    pub fn iter(&self) -> impl Iterator<Item = RowRef<'_>> {
+    pub fn iter(&self) -> impl Iterator<Item = ResultRowRef<'_>> {
         let columns = self.columns();
-        self.rows().iter().map(move |row| RowRef {
+        self.rows().iter().map(move |row| ResultRowRef {
             columns,
             values: row.values(),
         })
@@ -707,12 +707,12 @@ fn value_type_error(expected: &str, actual: &Value) -> LixError {
 /// This is the ergonomic path for callers that want `row.get("column")`
 /// without storing column metadata on every owned row.
 #[derive(Debug, Clone, Copy)]
-pub struct RowRef<'a> {
+pub struct ResultRowRef<'a> {
     columns: &'a [String],
     values: &'a [Value],
 }
 
-impl RowRef<'_> {
+impl ResultRowRef<'_> {
     /// Returns the result-set column names in row value order.
     pub fn columns(&self) -> &[String] {
         self.columns

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -4162,6 +4162,12 @@ async fn execute_prepared_transaction_write<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    if let sql2::SqlLogicalPlan::Checkpoint(checkpoint) = plan {
+        let outcome = transaction
+            .execute_checkpoint_function(checkpoint, params.to_vec())
+            .await?;
+        return sql2::SqlWriteResult::checkpoint_function(outcome);
+    }
     if let Some(returning) = sql2::full_checkpoint_command(&plan) {
         let outcome = transaction.execute_full_checkpoint_command().await?;
         return sql2::SqlWriteResult::diff_command(outcome, returning.as_ref());

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -18,7 +18,7 @@ use crate::storage_adapter::{
     StorageReadDurability, StorageReadOptions, StorageWriteOptions, StorageWriteSet,
 };
 use crate::transaction::{begin_commit_boundary, commit_at_boundary};
-use crate::{Blob, LixError, LixNotice, ResultColumnType, SqlQueryResult, Value};
+use crate::{Blob, LixError, LixNotice, ResultColumnType, RowRef, SqlQueryResult, Value};
 use datafusion::arrow::array::{ArrayRef, LargeStringBuilder, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -631,6 +631,15 @@ impl TryFromValue for String {
         match value {
             Value::Text(value) => Ok(value.clone()),
             other => Err(value_type_error("text", other)),
+        }
+    }
+}
+
+impl TryFromValue for RowRef {
+    fn try_from_value(value: &Value) -> Result<Self, LixError> {
+        match value {
+            Value::RowRef(value) => Ok(value.clone()),
+            other => Err(value_type_error("lix_row_ref", other)),
         }
     }
 }
@@ -4167,10 +4176,6 @@ where
             .execute_checkpoint_function(checkpoint, params.to_vec())
             .await?;
         return sql2::SqlWriteResult::checkpoint_function(outcome);
-    }
-    if let Some(returning) = sql2::full_checkpoint_command(&plan) {
-        let outcome = transaction.execute_full_checkpoint_command().await?;
-        return sql2::SqlWriteResult::diff_command(outcome, returning.as_ref());
     }
     if let Some((command, query_sql, returning)) = sql2::diff_command_query(&plan) {
         let outcome = transaction

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -3628,6 +3628,9 @@ fn profile_result_checksum(checksum: u64, values: &[Value]) -> Result<u64, LixEr
                 let checksum = profile_checksum_bytes(checksum, &[7]);
                 profile_checksum_bytes(checksum, &value.to_le_bytes())
             }
+            Value::RowRef(value) => {
+                profile_checksum_sized_bytes(checksum, 8, value.as_str().as_bytes())
+            }
         };
     }
     Ok(checksum)

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -10,6 +10,9 @@ use crate::branch::BranchRefReader;
 use crate::common::{ExecuteStatementMetadata, ExpiredReadRetryState};
 use crate::functions::{FunctionContext, FunctionProviderHandle};
 use crate::sql_telemetry::{SqlStatementTelemetry, finish_operation, start_batch};
+use crate::telemetry::{
+    ActiveTelemetrySpan, CHECKPOINT_CREATE, Status, TelemetryAttribute,
+};
 use crate::sql2;
 use crate::sql2::SqlWriteExecutionContext;
 use crate::storage_adapter::Storage;
@@ -88,6 +91,7 @@ pub struct ExecuteResult {
     /// empty case inline avoids one Arc clone/drop pair for every scalar write.
     backing: Option<Arc<ExecuteResultBacking>>,
     rows_affected: u64,
+    checkpoint_telemetry: Option<(String, String)>,
     #[cfg(feature = "storage-benches")]
     profile_provider_rows_examined: u64,
 }
@@ -220,8 +224,9 @@ impl ExecuteResult {
         let sql2::SqlWriteResult {
             rows_affected,
             returning,
+            checkpoint_telemetry,
         } = result;
-        match returning {
+        let mut result = match returning {
             Some(result) => {
                 Self::from_query_parts(
                     result.columns,
@@ -232,7 +237,9 @@ impl ExecuteResult {
                 )
             }
             None => Self::from_rows_affected(rows_affected),
-        }
+        };
+        result.checkpoint_telemetry = checkpoint_telemetry;
+        result
     }
 
     pub fn from_rows_affected(rows_affected: u64) -> Self {
@@ -241,6 +248,7 @@ impl ExecuteResult {
             statement_label: None,
             backing: None,
             rows_affected,
+            checkpoint_telemetry: None,
             #[cfg(feature = "storage-benches")]
             profile_provider_rows_examined: 0,
         }
@@ -302,6 +310,7 @@ impl ExecuteResult {
                 file_view_mutations: Vec::new(),
             })),
             rows_affected,
+            checkpoint_telemetry: None,
             #[cfg(feature = "storage-benches")]
             profile_provider_rows_examined: 0,
         }
@@ -335,6 +344,7 @@ impl ExecuteResult {
                 file_view_mutations: Vec::new(),
             })),
             rows_affected: 0,
+            checkpoint_telemetry: None,
             #[cfg(feature = "storage-benches")]
             profile_provider_rows_examined: 0,
         }
@@ -1432,18 +1442,89 @@ where
     ) -> Result<ExecuteResult, LixError> {
         let telemetry =
             SqlStatementTelemetry::start(self.telemetry.as_ref(), sql, execution_kind, None);
-        let operation = self.execute_with_options_inner(
-            sql,
-            params,
-            options,
-            metadata,
-            execution_kind == "observe",
-            idempotency,
-            require_idempotency_for_writes,
-        );
-        let result = match telemetry.as_ref() {
-            Some(telemetry) => telemetry.instrument(operation).await,
-            None => operation.await,
+        let checkpoint_statement = self
+            .sql_planning_cache
+            .parse_statement(sql)
+            .ok()
+            .and_then(|statement| sql2::checkpoint_function_plan(&statement).ok().flatten())
+            .is_some();
+        let result = if checkpoint_statement {
+            // The checkpoint-only wrapper must begin while the SQL span is
+            // current so transaction/storage spans become its children. Box
+            // this exceptional path: nesting the engine's large execution
+            // future inline here materially increases every SQL caller's
+            // stack frame, including non-checkpoint sync traffic.
+            let operation = Box::pin(async {
+                let checkpoint_span =
+                    ActiveTelemetrySpan::start_current(&CHECKPOINT_CREATE, Vec::new());
+                let execution = self.execute_with_options_inner(
+                    sql,
+                    params,
+                    options,
+                    metadata,
+                    execution_kind == "observe",
+                    idempotency,
+                    require_idempotency_for_writes,
+                );
+                let result = match checkpoint_span.as_ref() {
+                    Some(span) => span.instrument(execution).await,
+                    None => execution.await,
+                };
+                match result {
+                    Ok(result) => {
+                        if let Some(span) = checkpoint_span {
+                            let attributes = result
+                                .checkpoint_telemetry
+                                .as_ref()
+                                .map(|(commit_id, parent_commit_id)| {
+                                    vec![
+                                        TelemetryAttribute::string(
+                                            "lix.commit_id",
+                                            commit_id.clone(),
+                                        ),
+                                        TelemetryAttribute::string(
+                                            "lix.parent_commit_id",
+                                            parent_commit_id.clone(),
+                                        ),
+                                    ]
+                                })
+                                .unwrap_or_default();
+                            span.finish(Status::Unset, attributes);
+                        }
+                        Ok(result)
+                    }
+                    Err(error) => {
+                        if let Some(span) = checkpoint_span {
+                            span.finish(
+                                Status::error(error.code.clone()),
+                                vec![TelemetryAttribute::string(
+                                    "error.type",
+                                    error.code.clone(),
+                                )],
+                            );
+                        }
+                        Err(error)
+                    }
+                }
+            });
+            match telemetry.as_ref() {
+                Some(telemetry) => telemetry.instrument(operation).await,
+                None => operation.await,
+            }
+        } else {
+            let operation = self.execute_with_options_inner(
+                sql,
+                params,
+                options,
+                metadata,
+                execution_kind == "observe",
+                idempotency,
+                require_idempotency_for_writes,
+            );
+            match telemetry.as_ref() {
+                Some(telemetry) => telemetry.instrument(operation).await,
+                None => operation.await,
+            }
         };
         if let Some(telemetry) = telemetry {
             telemetry.finish(&result);
@@ -5823,12 +5904,12 @@ mod tests {
         storage.expire_after_each_transaction_open(3);
         let reverted = session
             .execute(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff(\
                    'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
                  ) \
-                 WHERE lixcol_row_pk = CAST('[\"retry-revert\"]' AS JSONB)",
+                 WHERE key = 'retry-revert'",
                 &[],
             )
             .await
@@ -5887,12 +5968,12 @@ mod tests {
             [7; 32],
         )
         .with_branch(branch_id);
-        let sql = "INSERT INTO lix_revert (relation, row_pk) \
-                   SELECT 'lix_key_value', lixcol_row_pk \
+        let sql = "INSERT INTO lix_revert (row_ref) \
+                   SELECT row_ref \
                    FROM lix_diff(\
                      'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
                    ) \
-                   WHERE lixcol_row_pk = CAST('[\"idempotent-revert\"]' AS JSONB)";
+                   WHERE key = 'idempotent-revert'";
 
         // The first read checks for a pre-existing receipt, then every attempt
         // opens its coherent transaction read before the tracked-state reader.
@@ -6001,7 +6082,7 @@ mod tests {
         );
         let working_diff = session
             .execute(
-                "SELECT lixcol_row_pk FROM lix_diff(\
+                "SELECT row_ref FROM lix_diff(\
                  'lix_key_value', $1, lix_active_branch_commit_id())",
                 &[Value::Text(restore_target.clone())],
             )
@@ -9606,7 +9687,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn insert_compares_explicit_uuid_keys_by_external_value() {
+    async fn insert_accepts_explicit_uuid_keys_by_external_value() {
         const UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
         let session = open_session().await;
@@ -9629,12 +9710,8 @@ mod tests {
 
         session
             .execute(
-                "INSERT INTO explicit_uuid_key_probe (id, value, lixcol_row_pk) \
-                 VALUES ($1, 'value', CAST($2 AS JSONB))",
-                &[
-                    Value::Text(UUID.to_string()),
-                    Value::Text(format!("[\"{UUID}\"]")),
-                ],
+                "INSERT INTO explicit_uuid_key_probe (id, value) VALUES ($1, 'value')",
+                &[Value::Text(UUID.to_string())],
             )
             .await
             .expect("matching typed and external UUID keys should commit");
@@ -11554,9 +11631,9 @@ mod tests {
                  FROM files AS file_a \
                  JOIN files AS file_b ON file_a.id = file_b.id \
                  LEFT JOIN (\
-                     SELECT row_pk FROM lix_change \
+                     SELECT row_ref FROM lix_change \
                      UNION ALL \
-                     SELECT row_pk FROM lix_change\
+                     SELECT row_ref FROM lix_change\
                  ) AS changes ON false",
                 &[],
             )

--- a/packages/lix/src/session/idempotency.rs
+++ b/packages/lix/src/session/idempotency.rs
@@ -124,6 +124,7 @@ enum StoredValue {
     Real(f64),
     Text(String),
     Jsonb(crate::Json),
+    RowRef(String),
     Timestamptz(i64),
     Blob(String),
 }
@@ -145,6 +146,7 @@ impl StoredValue {
             }
             Value::Text(value) => Self::Text(value.clone()),
             Value::Jsonb(value) => Self::Jsonb(value.clone()),
+            Value::RowRef(value) => Self::RowRef(value.as_str().to_owned()),
             Value::Timestamptz(value) => Self::Timestamptz(*value),
             Value::Blob(value) => Self::Blob(BASE64.encode(value.as_ref())),
         })
@@ -158,6 +160,10 @@ impl StoredValue {
             Self::Real(value) => Value::Real(value),
             Self::Text(value) => Value::Text(value),
             Self::Jsonb(value) => Value::Jsonb(value),
+            Self::RowRef(value) => {
+                crate::row_ref::decode_str(&value)?;
+                Value::RowRef(crate::RowRef(value))
+            }
             Self::Timestamptz(value) => Value::Timestamptz(value),
             Self::Blob(value) => Value::Blob(
                 BASE64

--- a/packages/lix/src/session/merge/branch.rs
+++ b/packages/lix/src/session/merge/branch.rs
@@ -92,8 +92,7 @@ pub struct MergeBranchPreview {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MergeConflict {
     pub kind: MergeConflictKind,
-    pub schema_key: String,
-    pub row_pk: JsonValue,
+    pub row_ref: crate::RowRef,
     pub file_id: Option<String>,
     pub target: MergeConflictSide,
     pub source: MergeConflictSide,
@@ -2014,8 +2013,14 @@ fn merge_conflict_from_analysis(
         kind: match conflict.kind() {
             AnalysisMergeConflictKind::SameRowChanged => MergeConflictKind::SameRowChanged,
         },
-        schema_key: conflict.schema_key().to_owned(),
-        row_pk: conflict.row_pk().as_json_array_value()?,
+        row_ref: crate::row_ref::encode(
+            match conflict.schema_key() {
+                FILE_DESCRIPTOR_SCHEMA_KEY => "lix_file",
+                DIRECTORY_DESCRIPTOR_SCHEMA_KEY => "lix_directory",
+                relation => relation,
+            },
+            conflict.row_pk(),
+        )?,
         file_id: conflict.file_id().map(str::to_owned),
         target: merge_conflict_side_from_analysis(conflict.target()),
         source: merge_conflict_side_from_analysis(conflict.source()),

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -42,7 +42,7 @@ pub use context::SessionContext;
 pub(crate) use context::{SessionBranch, load_default_branch_id_from_index};
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};
 pub use execute::{
-    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, Row, RowRef,
+    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ResultRowRef, Row,
     TryFromValue,
 };
 pub(crate) use execute::{ExecutionDisposition, FileRead};

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use media_upload::{UPLOAD_MANIFEST_LEAF_SPACE, UPLOAD_STATE_SPACE};
 pub(crate) use crate::common::ExecuteStatementMetadata;
 #[cfg(feature = "server-protocol")]
 pub(crate) use crate::common::VerifiedRequestBlob;
-pub use checkpoint::CreateCheckpointReceipt;
+pub(crate) use checkpoint::CreateCheckpointReceipt;
 pub use context::SessionContext;
 pub(crate) use context::{SessionBranch, load_default_branch_id_from_index};
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};

--- a/packages/lix/src/session/transaction.rs
+++ b/packages/lix/src/session/transaction.rs
@@ -219,7 +219,7 @@ where
         if let Some(checkpoint_sequence) = outcome.checkpoint_gc_sequence {
             self.session
                 .schedule_checkpoint_gc_after_commit(checkpoint_sequence)
-                .await?;
+                .await;
         }
         Ok(())
     }

--- a/packages/lix/src/session/transaction.rs
+++ b/packages/lix/src/session/transaction.rs
@@ -216,6 +216,11 @@ where
                 notify.finish(Status::Unset, Vec::new());
             }
         }
+        if let Some(checkpoint_sequence) = outcome.checkpoint_gc_sequence {
+            self.session
+                .schedule_checkpoint_gc_after_commit(checkpoint_sequence)
+                .await?;
+        }
         Ok(())
     }
 

--- a/packages/lix/src/sql2/bind/public_udf.rs
+++ b/packages/lix/src/sql2/bind/public_udf.rs
@@ -56,6 +56,10 @@ fn validate_public_function_call(function: &Function) -> Result<(), LixError> {
 
     match name {
         "current_timestamp" => expect_exact_arity(name, arity, 0),
+        "lix_row_ref" if arity >= 2 => Ok(()),
+        "lix_row_ref" => Err(invalid_param(
+            "lix_row_ref requires a relation and at least one primary-key value",
+        )),
         name if PUBLIC_SCALAR_FUNCTION_NAMES.contains(&name) => expect_exact_arity(name, arity, 0),
         _ => Ok(()),
     }

--- a/packages/lix/src/sql2/bind/read.rs
+++ b/packages/lix/src/sql2/bind/read.rs
@@ -17,6 +17,9 @@ pub(crate) enum BoundStatementRoute {
 pub(crate) fn bind_statement_route(
     statement: &DataFusionStatement,
 ) -> Result<BoundStatementRoute, LixError> {
+    if super::super::checkpoint_function_plan(statement)?.is_some() {
+        return Ok(BoundStatementRoute::Write);
+    }
     match super::classify::classify_datafusion_statement(statement) {
         super::classify::SqlStatementKind::Read => Ok(BoundStatementRoute::Read),
         super::classify::SqlStatementKind::Write => Ok(BoundStatementRoute::Write),

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1581,7 +1581,7 @@ mod tests {
     #[test]
     fn bind_statement_rejects_row_insert_select() {
         let statement = parse_statement(
-            "INSERT INTO test_state_schema (lixcol_row_pk, value) SELECT '[\"a\"]'::jsonb, 'A'",
+            "INSERT INTO test_state_schema (value) SELECT 'A'",
         );
         let error = bind_statement(
             &statement,
@@ -1972,8 +1972,8 @@ mod tests {
     fn bind_statement_allows_only_commit_id_for_diff_command_insert_returning() {
         let bound = bind_statement(
             &parse_statement(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', CAST('[\"test\"]' AS JSONB) \
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT lix_row_ref('lix_key_value', 'test') \
                  RETURNING commit_id AS created_commit_id",
             ),
             &[],
@@ -1993,8 +1993,8 @@ mod tests {
         ));
 
         for sql in [
-            "INSERT INTO lix_revert (relation, row_pk) SELECT 'lix_key_value', CAST('[\"test\"]' AS JSONB) RETURNING row_pk",
-            "INSERT INTO lix_revert (relation, row_pk) SELECT 'lix_key_value', CAST('[\"test\"]' AS JSONB) RETURNING *",
+            "INSERT INTO lix_revert (row_ref) SELECT lix_row_ref('lix_key_value', 'test') RETURNING row_ref",
+            "INSERT INTO lix_revert (row_ref) SELECT lix_row_ref('lix_key_value', 'test') RETURNING *",
         ] {
             let error = bind_statement(&parse_statement(sql), &[], "branch1")
                 .expect_err("unsupported INSERT RETURNING shape should fail");

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -97,7 +97,7 @@ pub(super) fn bind_insert_bound(
     // implicit public column list is deliberately unsupported.
     let default_values = matches!(
         table.surface.kind,
-        PublicSurfaceKind::SchemaBase { .. } | PublicSurfaceKind::CreateCheckpoint
+        PublicSurfaceKind::SchemaBase { .. }
     )
         && insert.columns.is_empty()
         && insert.source.is_none();
@@ -313,7 +313,6 @@ fn bind_insert_returning(
         table.surface.kind,
         PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
-            | PublicSurfaceKind::CreateCheckpoint
             | PublicSurfaceKind::Restore
     ) {
         return bind_returning(table, Some(returning), params, "INSERT");
@@ -604,7 +603,7 @@ fn bind_insert_input(
     }
     if matches!(
         surface_kind,
-        PublicSurfaceKind::Revert | PublicSurfaceKind::Apply | PublicSurfaceKind::CreateCheckpoint
+        PublicSurfaceKind::Revert | PublicSurfaceKind::Apply
     ) && matches!(source.body.as_ref(), SetExpr::Values(_))
     {
         return Err(super::error::unsupported(
@@ -1354,12 +1353,10 @@ fn bound_write_target(kind: &PublicSurfaceKind) -> BoundWriteTarget {
             BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::Revert)
         }
         PublicSurfaceKind::Apply => BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::Apply),
-        PublicSurfaceKind::CreateCheckpoint => {
-            BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::CreateCheckpoint)
-        }
         PublicSurfaceKind::Change
         | PublicSurfaceKind::HistoryFunction
         | PublicSurfaceKind::DiffFunction
+        | PublicSurfaceKind::CheckpointFunction
         | PublicSurfaceKind::StateAtFunction
         | PublicSurfaceKind::Restore
         | PublicSurfaceKind::CommitAncestryFunction => {

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -227,7 +227,6 @@ mod tests {
             "lix_checkpoint",
             "lix_commit",
             "lix_commit_ancestry",
-            "lix_create_checkpoint",
             "lix_diff",
             "lix_directory",
             "lix_file",

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -227,6 +227,7 @@ mod tests {
             "lix_checkpoint",
             "lix_commit",
             "lix_commit_ancestry",
+            "lix_create_checkpoint",
             "lix_diff",
             "lix_directory",
             "lix_file",
@@ -334,7 +335,7 @@ mod tests {
             history
                 .columns
                 .iter()
-                .any(|column| { column.name == "lixcol_row_pk" && column.is_public() })
+                .any(|column| { column.name == "lixcol_row_ref" && column.is_public() })
         );
         assert!(
             !history

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -23,7 +23,7 @@ use crate::sql2::history_route::{
     HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_ORIGIN_KEY,
     HISTORY_COL_ROW_PK, HISTORY_COL_SCHEMA_KEY, HISTORY_COL_SOURCE_CHANGES,
 };
-use crate::sql2::result_metadata::json_field;
+use crate::sql2::result_metadata::{json_field, row_ref_field};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PublicCatalog {
@@ -160,8 +160,7 @@ impl PublicCatalog {
             PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
             | PublicSurfaceKind::CreateCheckpoint => Arc::new(Schema::new(vec![
-                Field::new("relation", DataType::Utf8, false),
-                json_field("row_pk", false),
+                row_ref_field("row_ref", false),
             ])),
             PublicSurfaceKind::Restore => Arc::new(Schema::new(vec![Field::new(
                 "commit_id",
@@ -312,8 +311,7 @@ impl PublicCatalog {
                 PublicSurfaceClass::CommandSink,
                 kind,
                 vec![
-                    PublicColumn::public_insert_only("relation", false),
-                    PublicColumn::public_insert_only("row_pk", false),
+                    PublicColumn::public_insert_only("row_ref", false),
                     PublicColumn::public_read_only("commit_id", false),
                 ],
                 SurfaceCapabilities {

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -170,7 +170,7 @@ impl PublicCatalog {
             PublicSurfaceKind::Change => Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),
                 Field::new("account_id", DataType::Utf8, false),
-                json_field("row_pk", false),
+                row_ref_field("row_ref", true),
                 Field::new("schema_key", DataType::Utf8, false),
                 Field::new("file_id", DataType::Utf8, true),
                 json_field("metadata", true),
@@ -263,7 +263,7 @@ impl PublicCatalog {
             public_columns([
                 ("id", false),
                 ("account_id", false),
-                ("row_pk", false),
+                ("row_ref", true),
                 ("schema_key", false),
                 ("file_id", true),
                 ("metadata", true),
@@ -476,7 +476,7 @@ fn history_filesystem_schema(include_data: bool) -> SchemaRef {
         ]
     };
     fields.extend([
-        json_field(HISTORY_COL_ROW_PK, false),
+        row_ref_field(HISTORY_COL_ROW_PK, false),
         json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),
@@ -588,14 +588,9 @@ fn filesystem_system_columns() -> Vec<PublicColumn> {
     ]
 }
 
-fn row_system_columns(spec: &SchemaSurfaceSpec, variant: SchemaSurfaceShape) -> Vec<PublicColumn> {
+fn row_system_columns(_spec: &SchemaSurfaceSpec, variant: SchemaSurfaceShape) -> Vec<PublicColumn> {
     debug_assert_ne!(variant, SchemaSurfaceShape::History);
-    let row_pk = PublicColumn::public_insert_only("lixcol_row_pk", false);
-    let row_pk = if spec.primary_key_paths.is_empty() {
-        row_pk
-    } else {
-        row_pk.conditional_on_insert()
-    };
+    let row_pk = PublicColumn::hidden("lixcol_row_pk", false);
     vec![
         row_pk,
         PublicColumn::public_read_only("lixcol_schema_key", false),

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -304,7 +304,6 @@ impl PublicCatalog {
         for (name, kind) in [
             ("lix_revert", PublicSurfaceKind::Revert),
             ("lix_apply", PublicSurfaceKind::Apply),
-            ("lix_create_checkpoint", PublicSurfaceKind::CreateCheckpoint),
         ] {
             self.insert(surface(
                 name,

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -153,13 +153,12 @@ impl PublicCatalog {
             ])),
             PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::CheckpointFunction
             | PublicSurfaceKind::StateAtFunction
             | PublicSurfaceKind::CommitAncestryFunction => {
                 return None;
             }
-            PublicSurfaceKind::Revert
-            | PublicSurfaceKind::Apply
-            | PublicSurfaceKind::CreateCheckpoint => Arc::new(Schema::new(vec![
+            PublicSurfaceKind::Revert | PublicSurfaceKind::Apply => Arc::new(Schema::new(vec![
                 row_ref_field("row_ref", false),
             ])),
             PublicSurfaceKind::Restore => Arc::new(Schema::new(vec![Field::new(
@@ -285,6 +284,13 @@ impl PublicCatalog {
             PublicSurfaceClass::TableFunction,
             PublicSurfaceKind::DiffFunction,
             Vec::new(),
+            SurfaceCapabilities::read_only(),
+        ))?;
+        self.insert(surface(
+            "lix_create_checkpoint",
+            PublicSurfaceClass::TableFunction,
+            PublicSurfaceKind::CheckpointFunction,
+            vec![PublicColumn::public_read_only("commit_id", false)],
             SurfaceCapabilities::read_only(),
         ))?;
         self.insert(surface(

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -12,7 +12,7 @@ use crate::sql2::history_route::{
     HISTORY_COL_METADATA, HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_ORIGIN_KEY,
     HISTORY_COL_ROW_PK, HISTORY_COL_SCHEMA_KEY,
 };
-use crate::sql2::result_metadata::{json_field, mark_json_field};
+use crate::sql2::result_metadata::{json_field, mark_json_field, row_ref_field};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SchemaSurfaceShape {
@@ -425,7 +425,7 @@ pub(crate) fn row_visible_fields(spec: &SchemaSurfaceSpec) -> Vec<Field> {
 pub(crate) fn row_system_fields(shape: SchemaSurfaceShape) -> Vec<Field> {
     if shape == SchemaSurfaceShape::History {
         return vec![
-            json_field(HISTORY_COL_ROW_PK, false),
+            row_ref_field(HISTORY_COL_ROW_PK, false),
             Field::new(HISTORY_COL_SCHEMA_KEY, DataType::Utf8, false),
             Field::new(HISTORY_COL_FILE_ID, DataType::Utf8, true),
             json_field(HISTORY_COL_METADATA, true),

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -167,6 +167,27 @@ pub(crate) fn derive_schema_surface_spec_from_schema(
             ),
         ));
     }
+    for primary_key in &parsed.primary_key {
+        let collides_with_envelope = matches!(
+            primary_key.as_str(),
+            "row_ref" | "diff_type" | "row_count"
+        );
+        let collides_with_side_column = ["from_", "to_"].iter().any(|prefix| {
+            primary_key.strip_prefix(prefix).is_some_and(|unprefixed| {
+                parsed.columns.iter().any(|column| {
+                    column.name == unprefixed && !parsed.primary_key.contains(&column.name)
+                })
+            })
+        });
+        if collides_with_envelope || collides_with_side_column {
+            return Err(LixError::new(
+                LixError::CODE_SCHEMA_DEFINITION,
+                format!(
+                    "schema '{schema_key}' primary-key column '{primary_key}' collides with the lix_diff result envelope"
+                ),
+            ));
+        }
+    }
     let schema_fingerprint = *parsed
         .wire_fingerprint()
         .map_err(|error| {
@@ -521,6 +542,34 @@ mod tests {
         let error = derive_schema_surface_spec_from_schema(&prefixed_reserved)
             .expect_err("embedded reserved segment must be rejected");
         assert!(error.message.contains("reserved lixcol_ segment"));
+    }
+
+    #[test]
+    fn rejects_primary_keys_that_collide_with_diff_columns() {
+        for primary_key in ["row_ref", "diff_type", "row_count"] {
+            let schema = json!({
+                "$schema": "https://lix.dev/schema-v1.json",
+                "key": format!("reserved_{primary_key}"),
+                "columns": [{ "name": primary_key, "type": "text", "nullable": false }],
+                "primary_key": [primary_key]
+            });
+            let error = derive_schema_surface_spec_from_schema(&schema)
+                .expect_err("diff envelope collision must be rejected");
+            assert!(error.message.contains("lix_diff result envelope"));
+        }
+
+        let side_collision = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "reserved_side_column",
+            "columns": [
+                { "name": "from_value", "type": "text", "nullable": false },
+                { "name": "value", "type": "text", "nullable": false }
+            ],
+            "primary_key": ["from_value"]
+        });
+        let error = derive_schema_surface_spec_from_schema(&side_collision)
+            .expect_err("generated side-column collision must be rejected");
+        assert!(error.message.contains("lix_diff result envelope"));
     }
 
     #[test]

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -40,12 +40,13 @@ pub(crate) struct PublicScalarFunctionContract {
     pub(crate) class: PublicSurfaceClass,
 }
 
-pub(crate) const PUBLIC_SCALAR_FUNCTION_NAMES: [&str; 6] = [
+pub(crate) const PUBLIC_SCALAR_FUNCTION_NAMES: [&str; 7] = [
     "lix_active_account_id",
     "lix_active_branch_commit_id",
     "lix_active_branch_id",
     "lix_latest_checkpoint_commit_id",
     "lix_root_commit_id",
+    "lix_row_ref",
     "uuidv7",
 ];
 

--- a/packages/lix/src/sql2/catalog/surface.rs
+++ b/packages/lix/src/sql2/catalog/surface.rs
@@ -86,11 +86,11 @@ pub(crate) enum PublicSurfaceKind {
     Branch,
     HistoryFunction,
     DiffFunction,
+    CheckpointFunction,
     StateAtFunction,
     CommitAncestryFunction,
     Revert,
     Apply,
-    CreateCheckpoint,
     Restore,
     Change,
 }
@@ -105,9 +105,10 @@ impl PublicSurfaceKind {
             | Self::Change => matches!(class, PublicSurfaceClass::Relation(_)),
             Self::HistoryFunction
             | Self::DiffFunction
+            | Self::CheckpointFunction
             | Self::StateAtFunction
             | Self::CommitAncestryFunction => class == PublicSurfaceClass::TableFunction,
-            Self::Revert | Self::Apply | Self::CreateCheckpoint | Self::Restore => {
+            Self::Revert | Self::Apply | Self::Restore => {
                 class == PublicSurfaceClass::CommandSink
             }
         }

--- a/packages/lix/src/sql2/change_materialization.rs
+++ b/packages/lix/src/sql2/change_materialization.rs
@@ -26,6 +26,33 @@ pub(crate) struct MaterializedChange {
     pub(crate) origin_key: Option<String>,
 }
 
+/// Returns the stable public identity for a materialized change.
+///
+/// A change's physical schema and ownership scope are storage details. Public
+/// semantic relations retain their own primary key; filesystem implementation
+/// rows collapse to the logical file or directory identity.
+pub(crate) fn public_change_row_ref(
+    change: &MaterializedChange,
+) -> Result<Option<crate::RowRef>, LixError> {
+    let (relation, row_pk) =
+        if crate::sql2::catalog::schema_exposed_as_schema_surface(&change.schema_key) {
+            (change.schema_key.as_str(), change.row_pk.clone())
+        } else if change.schema_key == "lix_directory_descriptor" {
+            ("lix_directory", change.row_pk.clone())
+        } else if let Some(file_id) = change.file_id.as_deref() {
+            let row_pk = RowPk::uuid_from_canonical(file_id).map_err(|error| {
+                LixError::new(
+                    LixError::CODE_TYPE_MISMATCH,
+                    format!("lix_change file identity is invalid: {error}"),
+                )
+            })?;
+            ("lix_file", row_pk)
+        } else {
+            return Ok(None);
+        };
+    crate::row_ref::encode(relation, &row_pk).map(Some)
+}
+
 /// Payloads that a change scan must project for its output or filters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ChangePayloadProjection {

--- a/packages/lix/src/sql2/checkpoint_function.rs
+++ b/packages/lix/src/sql2/checkpoint_function.rs
@@ -1,0 +1,151 @@
+use datafusion::sql::parser::Statement as DataFusionStatement;
+use datafusion::sql::sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, FunctionArguments, SelectItem, SetExpr,
+    Statement as SqlStatement, TableFactor,
+};
+
+use crate::LixError;
+
+/// A deliberately narrow mutating table-function statement.
+///
+/// It is recognized before ordinary read planning. Treating checkpointing as
+/// a DataFusion UDF would let an optimizer evaluate it more than once and
+/// would give a read provider write authority. This plan is instead executed
+/// exactly once by Lix's transaction coordinator.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CheckpointFunctionPlan {
+    Full,
+    Empty,
+    SelectionQuery(String),
+}
+
+pub(crate) fn checkpoint_function_plan(
+    statement: &DataFusionStatement,
+) -> Result<Option<CheckpointFunctionPlan>, LixError> {
+    let DataFusionStatement::Statement(statement) = statement else {
+        return Ok(None);
+    };
+    let SqlStatement::Query(query) = statement.as_ref() else {
+        return Ok(None);
+    };
+    let SetExpr::Select(select) = query.body.as_ref() else {
+        return Ok(None);
+    };
+    let [from] = select.from.as_slice() else {
+        return Ok(None);
+    };
+    let TableFactor::Table {
+        name,
+        args: Some(arguments),
+        ..
+    } = &from.relation
+    else {
+        return Ok(None);
+    };
+    if !crate::sql2::parse::object_name_is_public_function(name, "lix_create_checkpoint") {
+        return Ok(None);
+    }
+
+    // Once the target is recognized, reject every compositional surface. A
+    // checkpoint is one mutation yielding one receipt row, not a relation an
+    // optimizer may join, filter, aggregate, or invoke repeatedly.
+    let projection_is_commit_id = matches!(
+        select.projection.as_slice(),
+        [SelectItem::UnnamedExpr(Expr::Identifier(identifier))]
+            if identifier.quote_style.as_ref().map_or_else(
+                || identifier.value.eq_ignore_ascii_case("commit_id"),
+                |_| identifier.value == "commit_id",
+            )
+    );
+    if query.with.is_some()
+        || query.order_by.is_some()
+        || query.limit_clause.is_some()
+        || query.fetch.is_some()
+        || !query.locks.is_empty()
+        || query.for_clause.is_some()
+        || !query.pipe_operators.is_empty()
+        || !from.joins.is_empty()
+        || !projection_is_commit_id
+        || select.distinct.is_some()
+        || select.top.is_some()
+        || select.into.is_some()
+        || select.selection.is_some()
+        || !matches!(select.group_by, datafusion::sql::sqlparser::ast::GroupByExpr::Expressions(ref expressions, ref modifiers) if expressions.is_empty() && modifiers.is_empty())
+        || select.having.is_some()
+        || select.qualify.is_some()
+        || arguments.settings.is_some()
+    {
+        return Err(invalid_checkpoint_function_call());
+    }
+
+    match arguments.args.as_slice() {
+        [] => Ok(Some(CheckpointFunctionPlan::Full)),
+        [FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Array(array)))] if array.named => {
+            if array.elem.is_empty() {
+                return Ok(Some(CheckpointFunctionPlan::Empty));
+            }
+            let selection_query = array
+                .elem
+                .iter()
+                .map(|expression| format!("SELECT {expression} AS row_ref"))
+                .collect::<Vec<_>>()
+                .join(" UNION ALL ");
+            Ok(Some(CheckpointFunctionPlan::SelectionQuery(selection_query)))
+        }
+        [FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Function(function)))]
+            if crate::sql2::parse::object_name_is_public_function(&function.name, "array")
+                && matches!(function.parameters, FunctionArguments::None)
+                && function.filter.is_none()
+                && function.null_treatment.is_none()
+                && function.over.is_none()
+                && function.within_group.is_empty() =>
+        {
+            let FunctionArguments::Subquery(selection) = &function.args else {
+                return Err(invalid_checkpoint_function_call());
+            };
+            Ok(Some(CheckpointFunctionPlan::SelectionQuery(
+                selection.to_string(),
+            )))
+        }
+        _ => Err(invalid_checkpoint_function_call()),
+    }
+}
+
+fn invalid_checkpoint_function_call() -> LixError {
+    LixError::new(
+        LixError::CODE_UNSUPPORTED_SQL,
+        "lix_create_checkpoint must be called exactly as SELECT commit_id FROM lix_create_checkpoint() or with one ARRAY of row references",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckpointFunctionPlan, checkpoint_function_plan};
+
+    fn plan(sql: &str) -> Result<Option<CheckpointFunctionPlan>, crate::LixError> {
+        checkpoint_function_plan(&crate::sql2::parse_statement(sql)?)
+    }
+
+    #[test]
+    fn recognizes_only_single_invocation_checkpoint_statements() {
+        assert_eq!(
+            plan("SELECT commit_id FROM lix_create_checkpoint()").unwrap(),
+            Some(CheckpointFunctionPlan::Full)
+        );
+        assert_eq!(
+            plan("SELECT commit_id FROM lix_create_checkpoint(ARRAY[])").unwrap(),
+            Some(CheckpointFunctionPlan::Empty)
+        );
+        assert!(matches!(
+            plan("SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('lix_file', $1)])").unwrap(),
+            Some(CheckpointFunctionPlan::SelectionQuery(_))
+        ));
+        assert!(matches!(
+            plan("SELECT commit_id FROM lix_create_checkpoint(ARRAY(SELECT row_ref FROM lix_diff('lix_file')))").unwrap(),
+            Some(CheckpointFunctionPlan::SelectionQuery(_))
+        ));
+        assert!(plan("SELECT * FROM lix_create_checkpoint()").is_err());
+        assert!(plan("SELECT commit_id FROM lix_create_checkpoint() WHERE true").is_err());
+        assert!(plan("SELECT * FROM lix_file").unwrap().is_none());
+    }
+}

--- a/packages/lix/src/sql2/context.rs
+++ b/packages/lix/src/sql2/context.rs
@@ -49,6 +49,7 @@ pub(crate) struct DiffCommandSelection {
 pub(crate) struct DiffCommandOutcome {
     pub(crate) rows_affected: u64,
     pub(crate) commit_id: Option<String>,
+    pub(crate) parent_commit_id: Option<String>,
 }
 
 pub(crate) type SqlChangelogQuerySource<S> = ChangelogQuerySource<S>;

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -3534,6 +3534,7 @@ fn returning_column_types(
                         Value::Real(_) => crate::ResultColumnType::Real,
                         Value::Text(_) => crate::ResultColumnType::Text,
                         Value::Jsonb(_) => crate::ResultColumnType::Jsonb,
+                        Value::RowRef(_) => crate::ResultColumnType::RowRef,
                         Value::Timestamptz(_) => crate::ResultColumnType::Timestamptz,
                         Value::Blob(_) => crate::ResultColumnType::Blob,
                     })
@@ -3617,6 +3618,7 @@ fn returning_expr_column_type(
                 Value::Real(_) => crate::ResultColumnType::Real,
                 Value::Text(_) => crate::ResultColumnType::Text,
                 Value::Jsonb(_) => crate::ResultColumnType::Jsonb,
+                Value::RowRef(_) => crate::ResultColumnType::RowRef,
                 Value::Timestamptz(_) => crate::ResultColumnType::Timestamptz,
                 Value::Blob(_) => crate::ResultColumnType::Blob,
             }),
@@ -7485,6 +7487,7 @@ fn value_json(value: &Value) -> JsonValue {
             .unwrap_or(JsonValue::Null),
         Value::Text(value) => JsonValue::String(value.clone()),
         Value::Jsonb(value) => value.to_value(),
+        Value::RowRef(value) => JsonValue::String(value.as_str().to_owned()),
         Value::Timestamptz(value) => JsonValue::from(*value),
         Value::Blob(value) => {
             JsonValue::Array(value.iter().copied().map(JsonValue::from).collect())

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -470,8 +470,8 @@ async fn try_execute_row_insert_batch(
                 LixError::new(
                     LixError::CODE_UNIQUE,
                     format!(
-                        "cannot insert {requested} row for schema '{}' row_pk {:?}: a canonical {existing} row already exists; delete it first",
-                        row.schema_key, row_pk,
+                        "cannot insert {requested} row for schema '{}': a canonical {existing} row with the same primary key already exists; delete it first",
+                        row.schema_key,
                     ),
                 )
             } else {
@@ -5482,7 +5482,7 @@ fn certified_row_insert_rows<'a>(
                 return Err(LixError::new(
                     LixError::CODE_SCHEMA_VALIDATION,
                     format!(
-                        "INSERT into {} has lixcol_row_pk that does not match its public primary-key columns",
+                        "INSERT into {} has an internal identity that does not match its public primary-key columns",
                         layout.schema_key
                     ),
                 ));
@@ -5766,7 +5766,7 @@ fn append_row_insert_row(
             return Err(LixError::new(
                 LixError::CODE_SCHEMA_VALIDATION,
                 format!(
-                    "INSERT into {} has lixcol_row_pk that does not match its public primary-key columns",
+                    "INSERT into {} has an internal identity that does not match its public primary-key columns",
                     layout.schema_key
                 ),
             ));
@@ -5819,7 +5819,7 @@ fn append_row_insert_row(
             return Err(LixError::new(
                 LixError::CODE_SCHEMA_VALIDATION,
                 format!(
-                    "INSERT into {} has lixcol_row_pk that does not match its public primary-key columns",
+                    "INSERT into {} has an internal identity that does not match its public primary-key columns",
                     layout.schema_key
                 ),
             ));

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2660,9 +2660,12 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
         BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::Apply) => {
             Ok("lix_apply".to_string())
         }
-        BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::CreateCheckpoint) => {
-            Ok("lix_create_checkpoint".to_string())
-        }
+        BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::CreateCheckpoint) => Err(
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "checkpoint function reached the writable-table executor",
+            ),
+        ),
         BoundWriteTarget::Restore { .. } => Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
             "lix_restore reached the DataFusion write executor",
@@ -4447,7 +4450,6 @@ mod tests {
             vec![
                 "lix_apply",
                 "lix_branch",
-                "lix_create_checkpoint",
                 "lix_directory",
                 "lix_file",
                 "lix_revert",

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -1782,6 +1782,7 @@ pub(crate) async fn execute_datafusion_write_logical_plan(
             } else {
                 ctx.staged_commit_id(ctx.active_branch_id())?
             },
+            parent_commit_id: None,
         };
         return SqlWriteResult::diff_command(outcome, plan.bound.returning.as_ref());
     }
@@ -4244,6 +4245,7 @@ mod tests {
             Ok(crate::sql2::DiffCommandOutcome {
                 rows_affected: selections.len() as u64,
                 commit_id: (!selections.is_empty()).then(|| "commit-diff-command".to_string()),
+                parent_commit_id: None,
             })
         }
 
@@ -4515,9 +4517,8 @@ mod tests {
         };
         let plan = create_write_logical_plan(
             &mut ctx,
-            "INSERT INTO lix_revert (relation, row_pk) \
-             SELECT relation, CAST(row_pk AS JSONB) \
-             FROM (VALUES ('lix_key_value', '[\"test\"]')) AS selected(relation, row_pk) \
+            "INSERT INTO lix_revert (row_ref) \
+             SELECT lix_row_ref('lix_file', '01920000-0000-7000-8000-0000000000d2') \
              RETURNING commit_id",
         )
         .await
@@ -5484,8 +5485,8 @@ mod tests {
         session
             .execute(
                 "INSERT INTO test_state_schema \
-             (lixcol_row_pk, id, value, count, lixcol_metadata, lixcol_untracked) \
-             VALUES (CAST('[\"row-history\"]' AS JSONB), 'row-history', 'A', 7, '{\"source\":\"history\"}', false)",
+             (id, value, count, lixcol_metadata, lixcol_untracked) \
+             VALUES ('row-history', 'A', 7, '{\"source\":\"history\"}', false)",
                 &[],
             )
             .await?;
@@ -6073,9 +6074,9 @@ mod tests {
         let result = session
             .execute(
                 &format!(
-                    "SELECT value, count, lixcol_row_pk, lixcol_depth \
+                    "SELECT value, count, lixcol_row_ref, lixcol_depth \
 	             FROM lix_history('test_state_schema', '{head_commit_id}') \
-	             WHERE lixcol_row_pk = CAST('[\"row-history\"]' AS JSONB)"
+	             WHERE lixcol_row_ref = lix_row_ref('test_state_schema', 'row-history')"
                 ),
                 &[],
             )
@@ -6085,12 +6086,12 @@ mod tests {
 
         assert_eq!(
             columns,
-            vec!["value", "count", "lixcol_row_pk", "lixcol_depth",]
+            vec!["value", "count", "lixcol_row_ref", "lixcol_depth",]
         );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0][0], Value::Text("A".to_string()));
         assert_eq!(rows[0][1], Value::Integer(7));
-        assert_eq!(rows[0][2], Value::Jsonb(json!(["row-history"]).into()));
+        assert!(matches!(rows[0][2], Value::RowRef(_)));
         assert!(matches!(rows[0][3], Value::Integer(_)));
     }
 
@@ -6987,8 +6988,7 @@ mod tests {
 
         let result = execute_write_sql(
             &mut ctx,
-            "INSERT INTO test_state_schema (lixcol_row_pk, id, value) \
-	     VALUES (CAST('[\"row-c\"]' AS JSONB), 'row-c', 'C')",
+            "INSERT INTO test_state_schema (id, value) VALUES ('row-c', 'C')",
             &[],
         )
         .await
@@ -7094,8 +7094,7 @@ mod tests {
 
         let result = execute_write_sql(
             &mut ctx,
-            "INSERT INTO test_state_schema (lixcol_row_pk, id, value) \
-             VALUES (CAST('[\"row-c\"]' AS JSONB), 'row-c', 'C')",
+            "INSERT INTO test_state_schema (id, value) VALUES ('row-c', 'C')",
             &[],
         )
         .await
@@ -9310,17 +9309,17 @@ mod tests {
 
         let result = execute_sql(
             &ctx,
-            "SELECT value, lixcol_row_pk \
+            "SELECT value, id \
                      FROM test_state_schema",
             &[],
         )
         .await
         .expect("sql2 execute should read row view");
 
-        assert_eq!(result.columns, vec!["value", "lixcol_row_pk"]);
+        assert_eq!(result.columns, vec!["value", "id"]);
         assert_eq!(result.rows.len(), 1);
         assert_eq!(result.rows[0][0], Value::Text("A".to_string()));
-        assert_eq!(result.rows[0][1], Value::Jsonb(json!(["row-a"]).into()));
+        assert_eq!(result.rows[0][1], Value::Text("row-a".to_string()));
     }
 
     #[tokio::test]

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -57,7 +57,8 @@ use crate::sql2::predicate_typecheck::{
 };
 use crate::sql2::providers::ProviderSelection;
 use crate::sql2::result_metadata::{
-    LIX_VALUE_TYPE_JSONB, LIX_VALUE_TYPE_METADATA_KEY, field_is_json,
+    LIX_VALUE_TYPE_JSONB, LIX_VALUE_TYPE_METADATA_KEY, LIX_VALUE_TYPE_ROW_REF, field_is_json,
+    field_is_row_ref,
 };
 use crate::sql2::session::{
     SqlWriteSessionOptions, build_read_session, build_read_session_at_head,
@@ -3055,6 +3056,10 @@ fn scalar_value_from_lix_value(value: &Value) -> ScalarAndMetadata {
             ScalarValue::Utf8(Some(value.to_string())),
             Some(json_field_metadata()),
         ),
+        Value::RowRef(value) => ScalarAndMetadata::new(
+            ScalarValue::Utf8(Some(value.as_str().to_owned())),
+            Some(row_ref_field_metadata()),
+        ),
         Value::Timestamptz(value) => {
             ScalarValue::TimestampMicrosecond(Some(*value), Some("UTC".into())).into()
         }
@@ -3066,6 +3071,13 @@ fn json_field_metadata() -> FieldMetadata {
     FieldMetadata::new(BTreeMap::from([(
         LIX_VALUE_TYPE_METADATA_KEY.to_string(),
         LIX_VALUE_TYPE_JSONB.to_string(),
+    )]))
+}
+
+fn row_ref_field_metadata() -> FieldMetadata {
+    FieldMetadata::new(BTreeMap::from([(
+        LIX_VALUE_TYPE_METADATA_KEY.to_string(),
+        LIX_VALUE_TYPE_ROW_REF.to_string(),
     )]))
 }
 
@@ -3242,13 +3254,16 @@ enum ColumnCursor<'a> {
 enum TextKind {
     Text,
     Jsonb,
+    RowRef,
 }
 
 fn column_cursor<'a>(
     field: Option<&Field>,
     array: &'a dyn Array,
 ) -> Result<ColumnCursor<'a>, LixError> {
-    let text_kind = if field.is_some_and(field_is_json) {
+    let text_kind = if field.is_some_and(field_is_row_ref) {
+        TextKind::RowRef
+    } else if field.is_some_and(field_is_json) {
         TextKind::Jsonb
     } else {
         TextKind::Text
@@ -3547,6 +3562,7 @@ fn text_value(value: &str, kind: TextKind) -> Value {
         // verbatim. Re-parsing here only rebuilt a DOM that was immediately
         // re-serialized, so the bytes are retained directly instead.
         TextKind::Jsonb => Value::Jsonb(crate::Json::from_canonical_text(value)),
+        TextKind::RowRef => Value::RowRef(crate::RowRef(value.to_owned())),
         TextKind::Text => Value::Text(value.to_owned()),
     }
 }

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -11,6 +11,7 @@ use crate::SqlQueryResult;
 pub(crate) struct SqlWriteResult {
     pub(crate) rows_affected: u64,
     pub(crate) returning: Option<SqlQueryResult>,
+    pub(crate) checkpoint_telemetry: Option<(String, String)>,
 }
 
 impl SqlWriteResult {
@@ -18,6 +19,7 @@ impl SqlWriteResult {
         Self {
             rows_affected,
             returning: None,
+            checkpoint_telemetry: None,
         }
     }
 
@@ -25,12 +27,20 @@ impl SqlWriteResult {
         Self {
             rows_affected,
             returning: Some(returning),
+            checkpoint_telemetry: None,
         }
     }
 
     pub(crate) fn checkpoint_function(
         outcome: crate::sql2::DiffCommandOutcome,
     ) -> Result<Self, crate::LixError> {
+        let checkpoint_telemetry = outcome
+            .commit_id
+            .as_ref()
+            .zip(outcome.parent_commit_id.as_ref())
+            .map(|(commit_id, parent_commit_id)| {
+                (commit_id.clone(), parent_commit_id.clone())
+            });
         let rows = match outcome.commit_id {
             Some(commit_id) => vec![vec![crate::Value::Text(commit_id)]],
             None if outcome.rows_affected == 0 => Vec::new(),
@@ -41,7 +51,7 @@ impl SqlWriteResult {
                 ));
             }
         };
-        Ok(Self::returning(
+        let mut result = Self::returning(
             outcome.rows_affected,
             SqlQueryResult {
                 columns: vec!["commit_id".to_string()],
@@ -49,7 +59,9 @@ impl SqlWriteResult {
                 rows,
                 notices: Vec::new(),
             },
-        ))
+        );
+        result.checkpoint_telemetry = checkpoint_telemetry;
+        Ok(result)
     }
 
     pub(crate) fn diff_command(

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -28,6 +28,30 @@ impl SqlWriteResult {
         }
     }
 
+    pub(crate) fn checkpoint_function(
+        outcome: crate::sql2::DiffCommandOutcome,
+    ) -> Result<Self, crate::LixError> {
+        let rows = match outcome.commit_id {
+            Some(commit_id) => vec![vec![crate::Value::Text(commit_id)]],
+            None if outcome.rows_affected == 0 => Vec::new(),
+            None => {
+                return Err(crate::LixError::new(
+                    crate::LixError::CODE_INTERNAL_ERROR,
+                    "checkpoint function staged rows without a commit ID",
+                ));
+            }
+        };
+        Ok(Self::returning(
+            outcome.rows_affected,
+            SqlQueryResult {
+                columns: vec!["commit_id".to_string()],
+                column_types: vec![crate::ResultColumnType::Text],
+                rows,
+                notices: Vec::new(),
+            },
+        ))
+    }
+
     pub(crate) fn diff_command(
         outcome: crate::sql2::DiffCommandOutcome,
         returning: Option<&crate::sql2::bind::write::BoundReturning>,
@@ -94,6 +118,7 @@ pub(crate) use write::{
 };
 
 pub(crate) enum SqlLogicalPlan {
+    Checkpoint(crate::sql2::CheckpointFunctionPlan),
     DataFusion(SqlDataFusionLogicalPlan),
     Write(SqlWriteLogicalPlan),
 }

--- a/packages/lix/src/sql2/exec/mod.rs
+++ b/packages/lix/src/sql2/exec/mod.rs
@@ -111,7 +111,7 @@ pub(crate) use write::{
 };
 pub(crate) use write::{
     WriteLogicalPlan as SqlWriteLogicalPlan, create_write_logical_plan_from_template,
-    create_write_plan_template_from_parsed, diff_command_query, full_checkpoint_command,
+    create_write_plan_template_from_parsed, diff_command_query,
     execute_write_logical_plan_parameter_batch, execute_write_logical_plan_prepared_dml_batch,
     execute_write_logical_plan_result_with_metadata, execute_write_logical_plan_value_batch,
     parameter_record_batch, parameter_row, write_plan_requires_post_stage_returning_checkpoint,

--- a/packages/lix/src/sql2/exec/write.rs
+++ b/packages/lix/src/sql2/exec/write.rs
@@ -272,6 +272,7 @@ enum ParameterKind {
     Real,
     Text,
     Jsonb,
+    RowRef,
     Timestamptz,
     Blob,
 }
@@ -285,6 +286,7 @@ impl ParameterKind {
             Value::Real(_) => Some(Self::Real),
             Value::Text(_) => Some(Self::Text),
             Value::Jsonb(_) => Some(Self::Jsonb),
+            Value::RowRef(_) => Some(Self::RowRef),
             Value::Timestamptz(_) => Some(Self::Timestamptz),
             Value::Blob(_) => Some(Self::Blob),
         }
@@ -295,7 +297,7 @@ impl ParameterKind {
             Self::Boolean => DataType::Boolean,
             Self::Integer => DataType::Int64,
             Self::Real => DataType::Float64,
-            Self::Text | Self::Jsonb => DataType::Utf8,
+            Self::Text | Self::Jsonb | Self::RowRef => DataType::Utf8,
             Self::Timestamptz => DataType::Timestamp(
                 datafusion::arrow::datatypes::TimeUnit::Microsecond,
                 Some("UTC".into()),
@@ -311,6 +313,9 @@ impl ParameterKind {
             (Self::Real, Value::Real(value)) => Ok(ScalarValue::Float64(Some(*value))),
             (Self::Text, Value::Text(value)) => Ok(ScalarValue::Utf8(Some(value.clone()))),
             (Self::Jsonb, Value::Jsonb(value)) => Ok(ScalarValue::Utf8(Some(value.to_string()))),
+            (Self::RowRef, Value::RowRef(value)) => {
+                Ok(ScalarValue::Utf8(Some(value.as_str().to_owned())))
+            }
             (Self::Timestamptz, Value::Timestamptz(value)) => Ok(
                 ScalarValue::TimestampMicrosecond(Some(*value), Some("UTC".into())),
             ),
@@ -318,7 +323,7 @@ impl ParameterKind {
             (Self::Boolean, Value::Null) => Ok(ScalarValue::Boolean(None)),
             (Self::Integer, Value::Null) => Ok(ScalarValue::Int64(None)),
             (Self::Real, Value::Null) => Ok(ScalarValue::Float64(None)),
-            (Self::Text | Self::Jsonb, Value::Null) => Ok(ScalarValue::Utf8(None)),
+            (Self::Text | Self::Jsonb | Self::RowRef, Value::Null) => Ok(ScalarValue::Utf8(None)),
             (Self::Timestamptz, Value::Null) => Ok(ScalarValue::TimestampMicrosecond(
                 None,
                 Some("UTC".into()),

--- a/packages/lix/src/sql2/exec/write.rs
+++ b/packages/lix/src/sql2/exec/write.rs
@@ -59,27 +59,6 @@ pub(crate) fn diff_command_query(
     ))
 }
 
-pub(crate) fn full_checkpoint_command(
-    plan: &SqlLogicalPlan,
-) -> Option<Option<crate::sql2::bind::write::BoundReturning>> {
-    let SqlLogicalPlan::Write(write) = plan else {
-        return None;
-    };
-    if !matches!(
-        write.plan.bound.target,
-        BoundWriteTarget::DiffCommand(crate::sql2::DiffCommand::CreateCheckpoint)
-    ) {
-        return None;
-    }
-    let crate::sql2::bind::write::BoundWriteInput::Values(values) = &write.plan.bound.input else {
-        return None;
-    };
-    if !values.columns.is_empty() || values.rows.len() != 1 || !values.rows[0].is_empty() {
-        return None;
-    }
-    Some(write.plan.bound.returning.clone())
-}
-
 /// Returns whether an explicit transaction needs a statement checkpoint
 /// before executing this `RETURNING` write. Generic providers construct their
 /// result from a staged postimage. Direct row writes are the one fast path

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -213,6 +213,7 @@ pub(crate) fn serialize_history_source_changes(
             Ok(serde_json::json!({
                 "id": change.id,
                 "row_ref": row_ref,
+                "schema_key": change.schema_key,
                 "file_id": change.file_id,
                 "snapshot_content": snapshot_content,
                 "metadata": metadata,
@@ -861,6 +862,7 @@ mod tests {
             .expect("public change should have a row reference");
         let decoded = crate::row_ref::decode_str(encoded).expect("row reference should decode");
 
+        assert_eq!(value[0]["schema_key"], "lix_file_descriptor");
         assert_eq!(decoded.relation, "lix_file");
         assert_eq!(decoded.row_pk, row_pk);
     }

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -27,9 +27,9 @@ pub(crate) struct HistoryRoute {
     pub(crate) row_pks: Vec<String>,
     /// Schema-resolved physical identities for traversal.
     ///
-    /// `row_pks` remains the canonical JSON surface representation used to
-    /// match projected rows. Keeping the typed form alongside it avoids
-    /// re-inferring component types from values after routing.
+    /// `row_pks` is the provider's legacy physical-filter scratch space;
+    /// public history identities resolve from opaque row references into the
+    /// typed form below before traversal.
     pub(crate) resolved_row_pks: Vec<RowPk>,
     pub(crate) schema_keys: Vec<String>,
     pub(crate) file_ids: Vec<String>,

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -13,7 +13,9 @@ use crate::commit_graph::{CommitGraphChangeHistoryRequest, CommitGraphReader};
 use crate::row_pk::RowPk;
 
 use super::SqlHistoryQuerySource;
-use crate::sql2::change_materialization::{MaterializedChange, materialize_located_history_change};
+use crate::sql2::change_materialization::{
+    MaterializedChange, materialize_located_history_change, public_change_row_ref,
+};
 use crate::storage_adapter::StorageAdapterRead;
 
 /// Shared routing state for commit-shaped history SQL surfaces.
@@ -188,9 +190,9 @@ pub(crate) const HISTORY_COL_IS_DELETED: &str = "lixcol_is_deleted";
 
 /// Serializes the deterministic provenance set for one composed history row.
 ///
-/// Each object mirrors the public `lix_change` fields. Composed history uses
-/// an array because one logical revision can be caused by multiple source
-/// changes in the same commit.
+/// Each object carries the stable public provenance subset of `lix_change`.
+/// Composed history uses an array because one logical revision can be caused
+/// by multiple source changes in the same commit.
 pub(crate) fn serialize_history_source_changes(
     changes: &[MaterializedChange],
     surface_name: &str,
@@ -200,7 +202,7 @@ pub(crate) fn serialize_history_source_changes(
     let source_changes = ordered_changes
         .into_iter()
         .map(|change| {
-            let row_ref = crate::row_ref::encode(&change.schema_key, &change.row_pk)?.to_string();
+            let row_ref = public_change_row_ref(change)?.map(|value| value.to_string());
             let snapshot_content = parse_optional_source_json(
                 change.snapshot_content.as_deref(),
                 surface_name,
@@ -524,12 +526,18 @@ fn parse_history_disjunction(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum HistoryFilterTerm {
     AsOfCommitIds(Vec<String>),
-    RowPks(Vec<String>),
+    RowRefs(Vec<RoutedRowRef>),
     SchemaKeys(Vec<String>),
     FileIds(Vec<String>),
     MinDepth(i64),
     MaxDepth(i64),
     ExactDepth(i64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RoutedRowRef {
+    row_pk_json: String,
+    row_pk: RowPk,
 }
 
 fn merge_history_disjunction_terms(
@@ -541,9 +549,9 @@ fn merge_history_disjunction_terms(
             extend_unique(&mut left, right);
             Some(HistoryFilterTerm::AsOfCommitIds(left))
         }
-        (HistoryFilterTerm::RowPks(mut left), HistoryFilterTerm::RowPks(right)) => {
+        (HistoryFilterTerm::RowRefs(mut left), HistoryFilterTerm::RowRefs(right)) => {
             extend_unique(&mut left, right);
-            Some(HistoryFilterTerm::RowPks(left))
+            Some(HistoryFilterTerm::RowRefs(left))
         }
         (HistoryFilterTerm::FileIds(mut left), HistoryFilterTerm::FileIds(right)) => {
             extend_unique(&mut left, right);
@@ -578,7 +586,7 @@ fn parse_history_binary_filter(
             _ => unreachable!(),
         }),
         ("row_ref", Operator::Eq, Expr::Literal(ScalarValue::Utf8(Some(value)), _)) => {
-            canonical_row_ref_pk_value(value).map(|value| HistoryFilterTerm::RowPks(vec![value]))
+            routed_row_ref(value).map(|value| HistoryFilterTerm::RowRefs(vec![value]))
         }
         ("depth", Operator::Eq, depth_expr) => {
             scalar_i64_literal(depth_expr).map(HistoryFilterTerm::ExactDepth)
@@ -651,7 +659,7 @@ fn parse_history_in_list_filter(in_list: &InList) -> Option<HistoryFilterTerm> {
 
     match column_name {
         "as_of_commit_id" => Some(HistoryFilterTerm::AsOfCommitIds(values)),
-        "row_ref" => canonical_row_ref_pk_values(values).map(HistoryFilterTerm::RowPks),
+        "row_ref" => routed_row_refs(values).map(HistoryFilterTerm::RowRefs),
         "schema_key" => Some(HistoryFilterTerm::SchemaKeys(values)),
         "file_id" => Some(HistoryFilterTerm::FileIds(values)),
         _ => None,
@@ -665,8 +673,25 @@ fn apply_history_filter(expr: &Expr, route: &mut HistoryRoute) {
                 route.contradictory |=
                     apply_conjunctive_values_filter(&mut route.as_of_commit_ids, values);
             }
-            HistoryFilterTerm::RowPks(values) => {
-                route.contradictory |= apply_conjunctive_values_filter(&mut route.row_pks, values);
+            HistoryFilterTerm::RowRefs(values) => {
+                let row_pk_json = values
+                    .iter()
+                    .map(|value| value.row_pk_json.clone())
+                    .collect();
+                route.contradictory |=
+                    apply_conjunctive_values_filter(&mut route.row_pks, row_pk_json);
+                let typed_row_pks = values
+                    .into_iter()
+                    .filter(|value| route.row_pks.contains(&value.row_pk_json))
+                    .map(|value| value.row_pk)
+                    .collect::<Vec<_>>();
+                if route.resolved_row_pks.is_empty() {
+                    route.resolved_row_pks = typed_row_pks;
+                } else {
+                    route
+                        .resolved_row_pks
+                        .retain(|row_pk| typed_row_pks.contains(row_pk));
+                }
             }
             HistoryFilterTerm::SchemaKeys(values) => {
                 route.contradictory |=
@@ -704,19 +729,19 @@ fn apply_conjunctive_values_filter(bucket: &mut Vec<String>, incoming_values: Ve
     bucket.is_empty()
 }
 
-fn canonical_row_ref_pk_values(values: Vec<String>) -> Option<Vec<String>> {
+fn routed_row_refs(values: Vec<String>) -> Option<Vec<RoutedRowRef>> {
     values
         .into_iter()
-        .map(|value| canonical_row_ref_pk_value(&value))
+        .map(|value| routed_row_ref(&value))
         .collect()
 }
 
-fn canonical_row_ref_pk_value(value: &str) -> Option<String> {
-    crate::row_ref::decode_str(value)
-        .ok()?
-        .row_pk
-        .as_json_array_text()
-        .ok()
+fn routed_row_ref(value: &str) -> Option<RoutedRowRef> {
+    let row_pk = crate::row_ref::decode_str(value).ok()?.row_pk;
+    Some(RoutedRowRef {
+        row_pk_json: row_pk.as_json_array_text().ok()?,
+        row_pk,
+    })
 }
 
 fn canonical_history_column_name(name: &str) -> Option<&str> {
@@ -734,7 +759,7 @@ fn nonnegative_u32(value: i64) -> Option<u32> {
     u32::try_from(value).ok()
 }
 
-fn extend_unique(bucket: &mut Vec<String>, values: Vec<String>) {
+fn extend_unique<T: PartialEq>(bucket: &mut Vec<T>, values: Vec<T>) {
     for value in values {
         if !bucket.contains(&value) {
             bucket.push(value);
@@ -780,6 +805,7 @@ mod tests {
         CommitGraphNode, CommitGraphReader, ReachableCommitGraphNode,
     };
     use crate::row_pk::RowPk;
+    use crate::sql2::change_materialization::MaterializedChange;
     use crate::sql2::HistoryQuerySource;
     use crate::storage_adapter::{
         Memory, MemoryRead, SharedStorageAdapterRead, StorageAdapter, StorageReadOptions,
@@ -787,9 +813,57 @@ mod tests {
 
     use super::{
         HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_COMMIT_CREATED_AT, HISTORY_COL_DEPTH,
-        HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
-        parse_history_filter,
+        HISTORY_COL_ROW_PK, HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor,
+        commit_graph_history_request, load_history_entries, parse_history_filter,
+        serialize_history_source_changes,
     };
+
+    #[test]
+    fn row_ref_route_preserves_uuid_primary_key_type() {
+        let row_pk = RowPk::uuid_from_canonical("018f6f7e-7cb2-7d45-8e1f-0a2b3c4d5e6f")
+            .expect("test UUID should be canonical");
+        let row_ref = crate::row_ref::encode("lix_file", &row_pk)
+            .expect("row reference should encode");
+        let route = HistoryRoute::from_filters(&[eq(
+            col(HISTORY_COL_ROW_PK),
+            str_lit(row_ref.as_str()),
+        )]);
+
+        assert_eq!(route.resolved_row_pks, vec![row_pk.clone()]);
+        let request = commit_graph_history_request(&route, vec![], None)
+            .expect("history request should route");
+        assert_eq!(request.row_pks, vec![row_pk]);
+    }
+
+    #[test]
+    fn source_change_row_ref_uses_public_filesystem_relation() {
+        let file_id = "018f6f7e-7cb2-7d45-8e1f-0a2b3c4d5e6f";
+        let row_pk = RowPk::uuid_from_canonical(file_id).expect("test UUID should be canonical");
+        let change = MaterializedChange {
+            id: "change-1".to_owned(),
+            account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+            row_pk: row_pk.clone(),
+            schema_key: "lix_file_descriptor".to_owned(),
+            file_id: Some(file_id.to_owned()),
+            snapshot_content: None,
+            metadata: None,
+            decoded_snapshot: None,
+            created_at: "2026-08-27T00:00:00Z".to_owned(),
+            origin_key: None,
+        };
+
+        let json = serialize_history_source_changes(&[change], "test history")
+            .expect("source changes should serialize");
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("source changes should be JSON");
+        let encoded = value[0]["row_ref"]
+            .as_str()
+            .expect("public change should have a row reference");
+        let decoded = crate::row_ref::decode_str(encoded).expect("row reference should decode");
+
+        assert_eq!(decoded.relation, "lix_file");
+        assert_eq!(decoded.row_pk, row_pk);
+    }
 
     #[test]
     fn route_extraction_keeps_supported_terms_from_mixed_and_filter() {

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -172,7 +172,7 @@ pub(crate) struct HistoryEntry {
     pub(crate) depth: u32,
 }
 
-pub(crate) const HISTORY_COL_ROW_PK: &str = "lixcol_row_pk";
+pub(crate) const HISTORY_COL_ROW_PK: &str = "lixcol_row_ref";
 pub(crate) const HISTORY_COL_SCHEMA_KEY: &str = "lixcol_schema_key";
 pub(crate) const HISTORY_COL_FILE_ID: &str = "lixcol_file_id";
 pub(crate) const HISTORY_COL_METADATA: &str = "lixcol_metadata";
@@ -200,14 +200,7 @@ pub(crate) fn serialize_history_source_changes(
     let source_changes = ordered_changes
         .into_iter()
         .map(|change| {
-            let row_pk =
-                serde_json::from_str::<serde_json::Value>(&change.row_pk.as_json_array_text()?)
-                    .map_err(|error| {
-                        LixError::new(
-                            LixError::CODE_INTERNAL_ERROR,
-                            format!("{surface_name} source row_pk is invalid JSON: {error}"),
-                        )
-                    })?;
+            let row_ref = crate::row_ref::encode(&change.schema_key, &change.row_pk)?.to_string();
             let snapshot_content = parse_optional_source_json(
                 change.snapshot_content.as_deref(),
                 surface_name,
@@ -217,8 +210,7 @@ pub(crate) fn serialize_history_source_changes(
                 parse_optional_source_json(change.metadata.as_deref(), surface_name, "metadata")?;
             Ok(serde_json::json!({
                 "id": change.id,
-                "row_pk": row_pk,
-                "schema_key": change.schema_key,
+                "row_ref": row_ref,
                 "file_id": change.file_id,
                 "snapshot_content": snapshot_content,
                 "metadata": metadata,
@@ -285,6 +277,10 @@ impl HistoryMetadataProjection {
 
 pub(crate) fn parse_history_filter(expr: &Expr) -> Option<()> {
     parse_history_filter_terms(expr).map(|_| ())
+}
+
+pub(crate) fn history_filter_references_row_ref(expr: &Expr) -> bool {
+    expr.column_refs().iter().any(|column| column.name == HISTORY_COL_ROW_PK)
 }
 
 /// Rejects an anchor predicate unless every occurrence can be routed exactly.
@@ -581,8 +577,8 @@ fn parse_history_binary_filter(
             "file_id" => HistoryFilterTerm::FileIds(vec![value.clone()]),
             _ => unreachable!(),
         }),
-        ("row_pk", Operator::Eq, Expr::Literal(ScalarValue::Utf8(Some(value)), _)) => {
-            canonical_row_pk_value(value).map(|value| HistoryFilterTerm::RowPks(vec![value]))
+        ("row_ref", Operator::Eq, Expr::Literal(ScalarValue::Utf8(Some(value)), _)) => {
+            canonical_row_ref_pk_value(value).map(|value| HistoryFilterTerm::RowPks(vec![value]))
         }
         ("depth", Operator::Eq, depth_expr) => {
             scalar_i64_literal(depth_expr).map(HistoryFilterTerm::ExactDepth)
@@ -655,7 +651,7 @@ fn parse_history_in_list_filter(in_list: &InList) -> Option<HistoryFilterTerm> {
 
     match column_name {
         "as_of_commit_id" => Some(HistoryFilterTerm::AsOfCommitIds(values)),
-        "row_pk" => canonical_row_pk_values(values).map(HistoryFilterTerm::RowPks),
+        "row_ref" => canonical_row_ref_pk_values(values).map(HistoryFilterTerm::RowPks),
         "schema_key" => Some(HistoryFilterTerm::SchemaKeys(values)),
         "file_id" => Some(HistoryFilterTerm::FileIds(values)),
         _ => None,
@@ -708,16 +704,17 @@ fn apply_conjunctive_values_filter(bucket: &mut Vec<String>, incoming_values: Ve
     bucket.is_empty()
 }
 
-fn canonical_row_pk_values(values: Vec<String>) -> Option<Vec<String>> {
+fn canonical_row_ref_pk_values(values: Vec<String>) -> Option<Vec<String>> {
     values
         .into_iter()
-        .map(|value| canonical_row_pk_value(&value))
+        .map(|value| canonical_row_ref_pk_value(&value))
         .collect()
 }
 
-fn canonical_row_pk_value(value: &str) -> Option<String> {
-    RowPk::from_json_array_text(value)
+fn canonical_row_ref_pk_value(value: &str) -> Option<String> {
+    crate::row_ref::decode_str(value)
         .ok()?
+        .row_pk
         .as_json_array_text()
         .ok()
 }
@@ -725,9 +722,9 @@ fn canonical_row_pk_value(value: &str) -> Option<String> {
 fn canonical_history_column_name(name: &str) -> Option<&str> {
     match name {
         HISTORY_COL_AS_OF_COMMIT_ID => Some("as_of_commit_id"),
-        HISTORY_COL_ROW_PK => Some("row_pk"),
         HISTORY_COL_SCHEMA_KEY => Some("schema_key"),
         HISTORY_COL_FILE_ID => Some("file_id"),
+        HISTORY_COL_ROW_PK => Some("row_ref"),
         HISTORY_COL_DEPTH => Some("depth"),
         _ => None,
     }

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -19,9 +19,18 @@ use super::catalog::{
     PublicCatalog, PublicColumnInsertPolicy, PublicRelationKind, PublicSurfaceClass,
     PublicSurfaceKind,
 };
-use super::result_metadata::field_is_json;
+use super::result_metadata::{field_is_json, field_is_row_ref};
 
 const LIX_VALUE_KIND_JSONB: &str = "JSONB";
+const LIX_VALUE_KIND_ROW_REF: &str = "ROW_REF";
+
+fn field_value_kind(field: &Field) -> Option<String> {
+    if field_is_row_ref(field) {
+        Some(LIX_VALUE_KIND_ROW_REF.to_owned())
+    } else {
+        field_is_json(field).then(|| LIX_VALUE_KIND_JSONB.to_owned())
+    }
+}
 const TABLE_FUNCTIONS: &str = "table_functions";
 const LIX_SURFACES: &str = "lix_surfaces";
 
@@ -205,7 +214,7 @@ impl LixInformationSchemaProvider {
                 ordinal_position.push((position + 1) as u64);
                 is_nullable.push(if column.read_nullable { "YES" } else { "NO" }.to_string());
                 data_type.push(public_sql_type(field.data_type()));
-                lix_value_kind.push(field_is_json(field).then(|| LIX_VALUE_KIND_JSONB.to_string()));
+                lix_value_kind.push(field_value_kind(field));
             }
         }
 
@@ -255,7 +264,7 @@ impl LixInformationSchemaProvider {
                             .push(if field.is_nullable() { "YES" } else { "NO" }.to_string());
                         data_type.push(public_sql_type(field.data_type()));
                         lix_value_kind.push(
-                            field_is_json(field).then(|| LIX_VALUE_KIND_JSONB.to_string()),
+                            field_value_kind(field),
                         );
                     }
                 }
@@ -286,7 +295,7 @@ impl LixInformationSchemaProvider {
                 ordinal_position.push((position + 1) as u64);
                 is_nullable.push(if field.is_nullable() { "YES" } else { "NO" }.to_string());
                 data_type.push(public_sql_type(field.data_type()));
-                lix_value_kind.push(field_is_json(field).then(|| LIX_VALUE_KIND_JSONB.to_string()));
+                lix_value_kind.push(field_value_kind(field));
             }
         }
 
@@ -546,7 +555,7 @@ impl ColumnsRows {
             self.datetime_precision.push(None);
             self.interval_type.push(None);
             self.lix_value_kind
-                .push(field_is_json(field).then(|| LIX_VALUE_KIND_JSONB.to_string()));
+                .push(field_value_kind(field));
             self.lix_insert_policy
                 .push(insert_policy.as_str().to_string());
         }

--- a/packages/lix/src/sql2/information_schema.rs
+++ b/packages/lix/src/sql2/information_schema.rs
@@ -254,7 +254,7 @@ impl LixInformationSchemaProvider {
                         function_name.push(surface.name.clone());
                         source_relation.push(Some(relation.name.clone()));
                         argument_signature.push(if surface.kind == PublicSurfaceKind::DiffFunction {
-                            "(relation TEXT, from_commit_id TEXT, to_commit_id TEXT)".to_string()
+                            "(relation TEXT) | (relation TEXT, from_commit_id TEXT, to_commit_id TEXT)".to_string()
                         } else {
                             "(relation TEXT, commit_id TEXT)".to_string()
                         });
@@ -275,6 +275,14 @@ impl LixInformationSchemaProvider {
                 PublicSurfaceKind::CommitAncestryFunction => (
                     "() | (commit_id TEXT)",
                     super::providers::commit_ancestry_schema(),
+                ),
+                PublicSurfaceKind::CheckpointFunction => (
+                    "() | (row_refs ROW_REF[])",
+                    Arc::new(Schema::new(vec![Field::new(
+                        "commit_id",
+                        DataType::Utf8,
+                        false,
+                    )])),
                 ),
                 PublicSurfaceKind::DiffFunction => unreachable!("relation-specific diffs handled above"),
                 PublicSurfaceKind::StateAtFunction => unreachable!("relation-specific state handled above"),
@@ -348,7 +356,10 @@ impl LixInformationSchemaProvider {
             can_insert.push(surface.capabilities.insert);
             can_update.push(surface.capabilities.update);
             can_delete.push(surface.capabilities.delete);
-            is_side_effecting.push(matches!(surface.class, PublicSurfaceClass::CommandSink));
+            is_side_effecting.push(
+                matches!(surface.class, PublicSurfaceClass::CommandSink)
+                    || surface.kind == PublicSurfaceKind::CheckpointFunction,
+            );
         }
         for function in self.public_catalog.scalar_functions() {
             surface_catalog.push(self.public_catalog_name.clone());

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -77,7 +77,7 @@ pub(crate) use exec::{
     execute_write_logical_plan_prepared_dml_batch, execute_write_logical_plan_result_with_metadata,
     execute_write_logical_plan_value_batch, parameter_record_batch, parameter_row,
     prepare_path_value_replacement_program, prepare_path_value_replacement_row,
-    full_checkpoint_command, prepare_read_session, prepare_read_session_at_head, query_result_from_batches,
+    prepare_read_session, prepare_read_session_at_head, query_result_from_batches,
     query_values_from_batches, write_plan_requires_post_stage_returning_checkpoint,
 };
 #[cfg(test)]

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -94,7 +94,7 @@ pub(crate) use exec::{
 pub(crate) use file_view::{
     SessionFileViewKey, SessionFileViewMutation, SessionFileViews, SessionPluginFileView,
 };
-pub(crate) use parse::parse_statement;
+pub(crate) use parse::{object_name_is_public_function, parse_statement};
 pub(crate) use plan::plan_write;
 pub(crate) use planning_cache::{
     CachedPhysicalRead, CachedReadPlan, CachedScanRequest, CachedUpdateLiteralShape,

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -2,6 +2,7 @@ mod bind;
 mod branch_ref;
 mod branch_scope;
 mod catalog;
+mod checkpoint_function;
 mod change_materialization;
 mod context;
 mod dialect;
@@ -51,6 +52,7 @@ pub(crate) use catalog::{
     PublicCatalog, PublicSurfaceKind, SchemaColumnType, SchemaIndexedColumn, SchemaSurfaceSpec,
     derive_schema_surface_spec_from_schema, row_visible_fields,
 };
+pub(crate) use checkpoint_function::{CheckpointFunctionPlan, checkpoint_function_plan};
 pub(crate) use context::WriteContextLiveness;
 pub(crate) use context::{
     ChangelogQuerySource, DiffCommand, DiffCommandOutcome, DiffCommandSelection, HistoryQuerySource,

--- a/packages/lix/src/sql2/planning_cache.rs
+++ b/packages/lix/src/sql2/planning_cache.rs
@@ -67,6 +67,7 @@ enum ParameterType {
     Real,
     Text,
     Jsonb,
+    RowRef,
     Timestamptz,
     Blob,
 }
@@ -662,6 +663,7 @@ impl<CatalogKey> PhysicalReadPlanCacheKey<CatalogKey> {
                 }
                 Value::Blob(value) => (7, value.to_vec()),
                 Value::Timestamptz(value) => (8, value.to_le_bytes().to_vec()),
+                Value::RowRef(value) => (9, value.as_str().as_bytes().to_vec()),
             };
             parameters.push(tag);
             parameters.extend_from_slice(&bytes.len().to_le_bytes());
@@ -685,6 +687,7 @@ impl From<&Value> for ParameterType {
             Value::Real(_) => Self::Real,
             Value::Text(_) => Self::Text,
             Value::Jsonb(_) => Self::Jsonb,
+            Value::RowRef(_) => Self::RowRef,
             Value::Blob(_) => Self::Blob,
             Value::Timestamptz(_) => Self::Timestamptz,
         }

--- a/packages/lix/src/sql2/providers/change.rs
+++ b/packages/lix/src/sql2/providers/change.rs
@@ -338,7 +338,15 @@ static LIX_CHANGE_COLS: ColumnTable<MaterializedChange> = ColumnTable {
 };
 
 fn change_public_row_ref(row: &MaterializedChange) -> Result<Option<String>, LixError> {
-    let (relation, row_pk) = if let Some(file_id) = row.file_id.as_deref() {
+    let (relation, row_pk) = if crate::sql2::catalog::schema_exposed_as_schema_surface(&row.schema_key)
+    {
+        // File ownership is scope, not identity. Public semantic relations
+        // keep their own typed (including composite) primary key even when
+        // their physical change is attached to a file.
+        (row.schema_key.as_str(), row.row_pk.clone())
+    } else if row.schema_key == "lix_directory_descriptor" {
+        ("lix_directory", row.row_pk.clone())
+    } else if let Some(file_id) = row.file_id.as_deref() {
         let row_pk = crate::row_pk::RowPk::uuid_from_canonical(file_id).map_err(|error| {
             LixError::new(
                 LixError::CODE_TYPE_MISMATCH,
@@ -346,10 +354,6 @@ fn change_public_row_ref(row: &MaterializedChange) -> Result<Option<String>, Lix
             )
         })?;
         ("lix_file", row_pk)
-    } else if row.schema_key == "lix_directory_descriptor" {
-        ("lix_directory", row.row_pk.clone())
-    } else if crate::sql2::catalog::schema_exposed_as_schema_surface(&row.schema_key) {
-        (row.schema_key.as_str(), row.row_pk.clone())
     } else {
         return Ok(None);
     };

--- a/packages/lix/src/sql2/providers/change.rs
+++ b/packages/lix/src/sql2/providers/change.rs
@@ -17,7 +17,7 @@ use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::WriteAccess;
 use crate::sql2::change_materialization::{
     ChangePayloadProjection, MaterializedChange, materialize_changelog_change_record,
-    materialize_commit_graph_change,
+    materialize_commit_graph_change, public_change_row_ref,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::{json_field, row_ref_field};
@@ -338,26 +338,7 @@ static LIX_CHANGE_COLS: ColumnTable<MaterializedChange> = ColumnTable {
 };
 
 fn change_public_row_ref(row: &MaterializedChange) -> Result<Option<String>, LixError> {
-    let (relation, row_pk) = if crate::sql2::catalog::schema_exposed_as_schema_surface(&row.schema_key)
-    {
-        // File ownership is scope, not identity. Public semantic relations
-        // keep their own typed (including composite) primary key even when
-        // their physical change is attached to a file.
-        (row.schema_key.as_str(), row.row_pk.clone())
-    } else if row.schema_key == "lix_directory_descriptor" {
-        ("lix_directory", row.row_pk.clone())
-    } else if let Some(file_id) = row.file_id.as_deref() {
-        let row_pk = crate::row_pk::RowPk::uuid_from_canonical(file_id).map_err(|error| {
-            LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                format!("lix_change file identity is invalid: {error}"),
-            )
-        })?;
-        ("lix_file", row_pk)
-    } else {
-        return Ok(None);
-    };
-    crate::row_ref::encode(relation, &row_pk).map(|value| Some(value.to_string()))
+    public_change_row_ref(row).map(|row_ref| row_ref.map(|value| value.to_string()))
 }
 
 fn change_batch_error(error: ColumnTableError) -> DataFusionError {

--- a/packages/lix/src/sql2/providers/change.rs
+++ b/packages/lix/src/sql2/providers/change.rs
@@ -20,7 +20,7 @@ use crate::sql2::change_materialization::{
     materialize_commit_graph_change,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
-use crate::sql2::result_metadata::json_field;
+use crate::sql2::result_metadata::{json_field, row_ref_field};
 use crate::storage_adapter::StorageAdapterRead;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
@@ -304,7 +304,7 @@ pub(super) fn lix_change_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("id", DataType::Utf8, false),
         Field::new("account_id", DataType::Utf8, false),
-        json_field("row_pk", false),
+        row_ref_field("row_ref", true),
         Field::new("schema_key", DataType::Utf8, false),
         Field::new("file_id", DataType::Utf8, true),
         json_field("metadata", true),
@@ -319,14 +319,8 @@ static LIX_CHANGE_COLS: ColumnTable<MaterializedChange> = ColumnTable {
         ("id", Col::Utf8(|row| Some(row.id.as_str()))),
         ("account_id", Col::Utf8(|row| Some(row.account_id.as_str()))),
         (
-            "row_pk",
-            Col::Utf8Owned(|row| {
-                Some(
-                    row.row_pk
-                        .as_json_array_text()
-                        .expect("canonical change row primary key should project"),
-                )
-            }),
+            "row_ref",
+            Col::Utf8Fallible(change_public_row_ref),
         ),
         ("schema_key", Col::Utf8(|row| Some(row.schema_key.as_str()))),
         ("file_id", Col::Utf8(|row| row.file_id.as_deref())),
@@ -342,6 +336,25 @@ static LIX_CHANGE_COLS: ColumnTable<MaterializedChange> = ColumnTable {
         ),
     ],
 };
+
+fn change_public_row_ref(row: &MaterializedChange) -> Result<Option<String>, LixError> {
+    let (relation, row_pk) = if let Some(file_id) = row.file_id.as_deref() {
+        let row_pk = crate::row_pk::RowPk::uuid_from_canonical(file_id).map_err(|error| {
+            LixError::new(
+                LixError::CODE_TYPE_MISMATCH,
+                format!("lix_change file identity is invalid: {error}"),
+            )
+        })?;
+        ("lix_file", row_pk)
+    } else if row.schema_key == "lix_directory_descriptor" {
+        ("lix_directory", row.row_pk.clone())
+    } else if crate::sql2::catalog::schema_exposed_as_schema_surface(&row.schema_key) {
+        (row.schema_key.as_str(), row.row_pk.clone())
+    } else {
+        return Ok(None);
+    };
+    crate::row_ref::encode(relation, &row_pk).map(|value| Some(value.to_string()))
+}
 
 fn change_batch_error(error: ColumnTableError) -> DataFusionError {
     match error {

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -28,6 +28,8 @@ use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind};
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::{field_is_json, row_ref_field};
+#[cfg(test)]
+use crate::sql2::result_metadata::field_is_row_ref;
 use crate::sql2::udfs::{ExecutionSlots, execution_slots};
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{
@@ -1637,16 +1639,15 @@ mod tests {
             .map(|field| field.name().as_str())
             .collect::<Vec<_>>();
         assert_eq!(
-            &names[..6],
-            &[
-                "lixcol_row_pk",
-                "diff_type",
-                "from_key",
-                "to_key",
-                "from_value",
-                "to_value"
-            ]
+            &names[..5],
+            &["row_ref", "key", "diff_type", "from_value", "to_value"]
         );
+        assert!(field_is_row_ref(
+            relation.schema.field_with_name("row_ref").unwrap()
+        ));
+        assert!(!names.contains(&"lixcol_row_pk"));
+        assert!(!names.contains(&"from_key"));
+        assert!(!names.contains(&"to_key"));
         assert_eq!(names.last(), Some(&"row_count"));
         assert!(!names.contains(&"lixcol_diff_type"));
         assert!(!names.contains(&"lixcol_row_count"));

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -27,7 +27,7 @@ use crate::row_pk::{RowPk, RowPkComponentType};
 use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind};
 use crate::sql2::error::lix_error_to_datafusion_error;
-use crate::sql2::result_metadata::{field_is_json, json_field};
+use crate::sql2::result_metadata::{field_is_json, row_ref_field};
 use crate::sql2::udfs::{ExecutionSlots, execution_slots};
 use crate::storage_adapter::StorageAdapterRead;
 use crate::tracked_state::{
@@ -79,14 +79,26 @@ where
     S: StorageAdapterRead + Clone + Send + Sync + 'static,
 {
     fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
-        let [relation, from_commit_id, to_commit_id] = args else {
-            return Err(DataFusionError::Plan(
-                "lix_diff requires a relation and exactly two commit ID arguments".to_string(),
-            ));
+        let (relation, from_commit_id, to_commit_id) = match args {
+            [relation] => (
+                relation,
+                self.slots.latest_checkpoint_commit_id().ok_or_else(|| {
+                    DataFusionError::Plan("lix_diff default range requires an active checkpoint".to_string())
+                })?,
+                self.slots.active_branch_commit_id().ok_or_else(|| {
+                    DataFusionError::Plan("lix_diff default range requires an active branch head".to_string())
+                })?,
+            ),
+            [relation, from_commit_id, to_commit_id] => (
+                relation,
+                text_argument(from_commit_id, 2, "commit ID", Some(&self.slots))?,
+                text_argument(to_commit_id, 3, "commit ID", Some(&self.slots))?,
+            ),
+            _ => return Err(DataFusionError::Plan(
+                "lix_diff requires a relation and either zero or two commit ID arguments".to_string(),
+            )),
         };
         let relation_name = text_argument(relation, 1, "relation name", None)?;
-        let from_commit_id = text_argument(from_commit_id, 2, "commit ID", Some(&self.slots))?;
-        let to_commit_id = text_argument(to_commit_id, 3, "commit ID", Some(&self.slots))?;
         let relation = DiffRelation::from_catalog(&self.catalog, &relation_name)?;
         Ok(Arc::new(SpecTableProvider::new(Arc::new(DiffSpec {
             store: self.store.clone(),
@@ -135,9 +147,10 @@ fn text_argument(
 
 #[derive(Clone)]
 struct DiffRelation {
+    name: String,
     kind: DiffRelationKind,
     schema: SchemaRef,
-    primary_key_component_types: Vec<RowPkComponentType>,
+    primary_key_columns: Vec<String>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -164,23 +177,43 @@ impl DiffRelation {
                 )));
             }
         };
-        let primary_key_component_types = match &kind {
-            DiffRelationKind::Schema { schema_key } => catalog
-                .schema_spec(schema_key)
-                .map(|spec| spec.primary_key_component_types.clone())
-                .unwrap_or_default(),
-            DiffRelationKind::File | DiffRelationKind::Directory => {
-                vec![RowPkComponentType::Uuid]
-            }
-        };
         let source_schema = catalog.surface_schema(name).ok_or_else(|| {
             DataFusionError::Plan(format!("lix_diff does not support relation '{name}'"))
         })?;
-        let mut fields = vec![
-            json_field("lixcol_row_pk", false),
-            Field::new("diff_type", DataType::Utf8, false),
-        ];
-        for column in surface.columns.iter().filter(|column| column.is_public()) {
+        let primary_key_columns = match &kind {
+            DiffRelationKind::File | DiffRelationKind::Directory => vec!["id".to_owned()],
+            DiffRelationKind::Schema { schema_key } => catalog
+                .schema_spec(schema_key)
+                .map(|spec| {
+                    spec.primary_key_paths
+                        .iter()
+                        .map(|path| match path.as_slice() {
+                            [column] => Ok(column.clone()),
+                            _ => Err(DataFusionError::Plan(format!(
+                                "lix_diff relation '{name}' has a non-column primary-key path"
+                            ))),
+                        })
+                        .collect::<Result<Vec<_>>>()
+                })
+                .transpose()?
+                .unwrap_or_default(),
+        };
+        let mut fields = vec![row_ref_field("row_ref", false)];
+        for column in &primary_key_columns {
+            let field = source_schema.field_with_name(column).map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "lix_diff relation '{name}' is missing primary-key column '{column}': {error}"
+                ))
+            })?;
+            fields.push(Field::new(column, field.data_type().clone(), false)
+                .with_metadata(field.metadata().clone()));
+        }
+        fields.push(Field::new("diff_type", DataType::Utf8, false));
+        for column in surface.columns.iter().filter(|column| {
+            column.is_public()
+                && column.name != "lixcol_row_pk"
+                && !primary_key_columns.contains(&column.name)
+        }) {
             let field = source_schema
                 .field_with_name(&column.name)
                 .map_err(|error| {
@@ -202,9 +235,10 @@ impl DiffRelation {
         }
         fields.push(Field::new("row_count", DataType::Int64, false));
         Ok(Self {
+            name: name.to_owned(),
             kind,
             schema: Arc::new(Schema::new(fields)),
-            primary_key_component_types,
+            primary_key_columns,
         })
     }
 }
@@ -236,7 +270,8 @@ where
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         if filter.column_refs().iter().any(|column| {
-            matches!(column.name.as_str(), "lixcol_row_pk" | "from_id" | "to_id")
+            column.name == "row_ref"
+                || self.relation.primary_key_columns.contains(&column.name)
                 || matches!(
                     column.name.as_str(),
                     "from_lixcol_file_id" | "to_lixcol_file_id"
@@ -292,7 +327,7 @@ where
                     active_branch_id,
                 )| async move {
                     if limit == Some(0) || route.contradictory || from_commit_id == to_commit_id {
-                        return diff_record_batch(schema, &[]);
+                        return diff_record_batch(schema, &[], &relation);
                     }
                     let mut tracked = TrackedStateContext::new().reader(store.clone());
                     let from_descriptor =
@@ -360,7 +395,7 @@ where
                     } else {
                         (HashSet::new(), HashSet::new())
                     };
-                    let mut rows = match relation.kind {
+                    let mut rows = match &relation.kind {
                         DiffRelationKind::Schema { .. } => {
                             schema_diff_rows(
                                 diff,
@@ -399,7 +434,7 @@ where
                     if let Some(limit) = limit {
                         rows.truncate(limit);
                     }
-                    diff_record_batch(schema, &rows)
+                    diff_record_batch(schema, &rows, &relation)
                 },
             ),
         })
@@ -433,22 +468,17 @@ struct DiffRoute {
 impl DiffRoute {
     fn from_filters(filters: &[Expr], relation: &DiffRelation, projection: &Schema) -> Self {
         let conjuncts = filter_conjuncts(filters);
-        let row_pk_values = optional_values(&conjuncts, "lixcol_row_pk");
-        let extracted_row_pk_values = extracted_first_row_pk_values(&conjuncts);
-        let id_values =
-            optional_values(&conjuncts, "from_id").or_else(|| optional_values(&conjuncts, "to_id"));
-        let explicit_row_filter = row_pk_values.is_some();
-        let mut contradictory = row_pk_values.as_ref().is_some_and(Vec::is_empty)
-            || id_values.as_ref().is_some_and(Vec::is_empty)
-            || extracted_row_pk_values.as_ref().is_some_and(Vec::is_empty);
-        let mut row_pks = row_pk_values
+        let row_ref_values = optional_values(&conjuncts, "row_ref");
+        let id_values = optional_values(&conjuncts, "id");
+        let explicit_row_filter = row_ref_values.is_some();
+        let mut contradictory = row_ref_values.as_ref().is_some_and(Vec::is_empty)
+            || id_values.as_ref().is_some_and(Vec::is_empty);
+        let mut row_pks = row_ref_values
             .unwrap_or_default()
             .into_iter()
             .filter_map(|value| {
-                let JsonValue::Array(values) = serde_json::from_str(&value).ok()? else {
-                    return None;
-                };
-                RowPk::from_json_values(&values, &relation.primary_key_component_types).ok()
+                let resolved = crate::row_ref::decode_str(&value).ok()?;
+                (resolved.relation == relation.name).then_some(resolved.row_pk)
             })
             .collect::<Vec<_>>();
         contradictory |= explicit_row_filter && row_pks.is_empty();
@@ -457,26 +487,6 @@ impl DiffRoute {
         match &relation.kind {
             DiffRelationKind::Schema { schema_key } => {
                 schema_keys.push(schema_key.clone());
-                if relation.primary_key_component_types.len() == 1
-                    && let Some(values) = extracted_row_pk_values.as_ref()
-                {
-                    let extracted_keys = values
-                        .iter()
-                        .filter_map(|value| {
-                            RowPk::from_json_values(
-                                &[JsonValue::String(value.clone())],
-                                &relation.primary_key_component_types,
-                            )
-                            .ok()
-                        })
-                        .collect::<Vec<_>>();
-                    if row_pks.is_empty() {
-                        row_pks = extracted_keys;
-                    } else {
-                        row_pks.retain(|row_pk| extracted_keys.contains(row_pk));
-                    }
-                    contradictory |= row_pks.is_empty();
-                }
                 if let Some(ids) = optional_values(&conjuncts, "from_lixcol_file_id")
                     .or_else(|| optional_values(&conjuncts, "to_lixcol_file_id"))
                 {
@@ -485,16 +495,10 @@ impl DiffRoute {
             }
             DiffRelationKind::File => {
                 let mut ids = id_values.unwrap_or_default();
-                if let Some(values) = extracted_row_pk_values {
-                    ids.extend(values);
-                }
                 for row_pk in row_pks.drain(..) {
-                    if let Ok(JsonValue::Array(values)) = row_pk.as_json_array_value()
-                        && let [JsonValue::String(id)] = values.as_slice()
-                    {
-                        ids.push(id.clone());
-                    } else {
-                        contradictory = true;
+                    match row_pk.as_single_string_owned() {
+                        Ok(id) => ids.push(id),
+                        Err(_) => contradictory = true,
                     }
                 }
                 file_ids.extend(ids.into_iter().map(NullableKeyFilter::Value));
@@ -541,61 +545,6 @@ impl DiffRoute {
             contradictory,
         }
     }
-}
-
-fn extracted_first_row_pk_values(conjuncts: &[Expr]) -> Option<Vec<String>> {
-    let mut values: Option<Vec<String>> = None;
-    for conjunct in conjuncts {
-        let Expr::BinaryExpr(binary) = conjunct else {
-            continue;
-        };
-        if binary.op != Operator::Eq {
-            continue;
-        }
-        let extracted = [
-            (binary.left.as_ref(), binary.right.as_ref()),
-            (binary.right.as_ref(), binary.left.as_ref()),
-        ]
-        .into_iter()
-        .find_map(|(expression, expected)| {
-            let Expr::ScalarFunction(function) = strip_cast(expression) else {
-                return None;
-            };
-            if function.func.name() != "__lix_json_get_text" || function.args.len() != 2 {
-                return None;
-            }
-            let Expr::Column(column) = strip_cast(&function.args[0]) else {
-                return None;
-            };
-            if column.name != "lixcol_row_pk" {
-                return None;
-            }
-            let Expr::Literal(index, _) = strip_cast(&function.args[1]) else {
-                return None;
-            };
-            if index.to_string() != "0" {
-                return None;
-            }
-            let Expr::Literal(value, _) = strip_cast(expected) else {
-                return None;
-            };
-            value.try_as_str().flatten().map(str::to_string)
-        });
-        if let Some(value) = extracted {
-            match values.as_mut() {
-                None => values = Some(vec![value]),
-                Some(existing) => existing.retain(|existing| existing == &value),
-            }
-        }
-    }
-    values
-}
-
-fn strip_cast(mut expression: &Expr) -> &Expr {
-    while let Expr::Cast(cast) = expression {
-        expression = cast.expr.as_ref();
-    }
-    expression
 }
 
 fn optional_values(conjuncts: &[Expr], column: &'static str) -> Option<Vec<String>> {
@@ -1492,7 +1441,11 @@ fn side_column(name: &str) -> Option<(bool, &str)> {
         .or_else(|| name.strip_prefix("to_").map(|column| (true, column)))
 }
 
-fn diff_record_batch(schema: SchemaRef, rows: &[DiffSqlRow]) -> Result<RecordBatch> {
+fn diff_record_batch(
+    schema: SchemaRef,
+    rows: &[DiffSqlRow],
+    relation: &DiffRelation,
+) -> Result<RecordBatch> {
     if schema.fields().is_empty() {
         return RecordBatch::try_new_with_options(
             schema,
@@ -1504,20 +1457,18 @@ fn diff_record_batch(schema: SchemaRef, rows: &[DiffSqlRow]) -> Result<RecordBat
     let arrays = schema
         .fields()
         .iter()
-        .map(|field| diff_column_array(field, rows))
+        .map(|field| diff_column_array(field, rows, relation))
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(schema, arrays).map_err(DataFusionError::from)
 }
 
-fn diff_column_array(field: &Field, rows: &[DiffSqlRow]) -> Result<ArrayRef> {
+fn diff_column_array(field: &Field, rows: &[DiffSqlRow], relation: &DiffRelation) -> Result<ArrayRef> {
     match field.name().as_str() {
-        "lixcol_row_pk" => Ok(Arc::new(StringArray::from(
+        "row_ref" => Ok(Arc::new(StringArray::from(
             rows.iter()
-                .map(|row| {
-                    row.row_pk
-                        .as_json_array_text()
-                        .map_err(lix_error_to_datafusion_error)
-                })
+                .map(|row| crate::row_ref::encode(&relation.name, &row.row_pk)
+                    .map(|value| value.as_str().to_owned())
+                    .map_err(lix_error_to_datafusion_error))
                 .collect::<Result<Vec<_>>>()?,
         ))),
         "diff_type" => Ok(Arc::new(StringArray::from_iter_values(
@@ -1526,6 +1477,13 @@ fn diff_column_array(field: &Field, rows: &[DiffSqlRow]) -> Result<ArrayRef> {
         "row_count" => Ok(Arc::new(Int64Array::from_iter_values(
             rows.iter().map(|row| row.row_count),
         ))),
+        name if relation.primary_key_columns.iter().any(|column| column == name) => {
+            let values = rows
+                .iter()
+                .map(|row| side_value(row.to.as_ref().or(row.from.as_ref()), name))
+                .collect::<Result<Vec<_>>>()?;
+            values_array(field, &values)
+        }
         name => {
             let (after, column) = side_column(name).ok_or_else(|| {
                 DataFusionError::Execution(format!("unsupported diff column '{name}'"))

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -23,7 +23,7 @@ use crate::branch::BranchHeadControlContext;
 use crate::changelog::{ChangeRecordProjection, CommitId};
 use crate::hot_state::TrackedHeadContext;
 use crate::plugin::runtime::WasmTypedRow;
-use crate::row_pk::{RowPk, RowPkComponentType};
+use crate::row_pk::{RowPk, RowPkComponent, RowPkComponentType};
 use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind};
 use crate::sql2::error::lix_error_to_datafusion_error;
@@ -1480,11 +1480,12 @@ fn diff_column_array(field: &Field, rows: &[DiffSqlRow], relation: &DiffRelation
             rows.iter().map(|row| row.row_count),
         ))),
         name if relation.primary_key_columns.iter().any(|column| column == name) => {
-            let values = rows
+            let component_index = relation
+                .primary_key_columns
                 .iter()
-                .map(|row| side_value(row.to.as_ref().or(row.from.as_ref()), name))
-                .collect::<Result<Vec<_>>>()?;
-            values_array(field, &values)
+                .position(|column| column == name)
+                .expect("the primary-key column guard found this column");
+            primary_key_array(field, rows, component_index)
         }
         name => {
             let (after, column) = side_column(name).ok_or_else(|| {
@@ -1504,6 +1505,64 @@ fn diff_column_array(field: &Field, rows: &[DiffSqlRow], relation: &DiffRelation
             values_array(field, &values)
         }
     }
+}
+
+/// Materializes a typed primary-key column from the stable diff identity.
+///
+/// A key is neither a before-side nor an after-side payload property: it is
+/// the identity joining those sides. Reading it from a snapshot made projected
+/// key-only diffs NULL for additions/removals because no side payload needed
+/// to be hydrated. The canonical RowPk is always present for every diff kind.
+fn primary_key_array(
+    field: &Field,
+    rows: &[DiffSqlRow],
+    component_index: usize,
+) -> Result<ArrayRef> {
+    match field.data_type() {
+        DataType::Utf8 => Ok(Arc::new(StringArray::from_iter_values(
+            rows.iter()
+                .map(|row| match row.row_pk.components.as_slice().get(component_index) {
+                    Some(RowPkComponent::Uuid(value)) => {
+                        Ok(uuid::Uuid::from_bytes(*value).to_string())
+                    }
+                    Some(RowPkComponent::String(value)) => Ok(value.to_string()),
+                    component => Err(primary_key_component_error(field, component)),
+                })
+                .collect::<Result<Vec<_>>>()?,
+        ))),
+        DataType::Int64 => Ok(Arc::new(Int64Array::from_iter_values(
+            rows.iter()
+                .map(|row| match row.row_pk.components.as_slice().get(component_index) {
+                    Some(RowPkComponent::Integer(value)) => Ok(*value),
+                    component => Err(primary_key_component_error(field, component)),
+                })
+                .collect::<Result<Vec<_>>>()?,
+        ))),
+        DataType::LargeBinary => {
+            let values = rows
+                .iter()
+                .map(|row| match row.row_pk.components.as_slice().get(component_index) {
+                    Some(RowPkComponent::Bytes(value)) => Ok(value.as_ref()),
+                    component => Err(primary_key_component_error(field, component)),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Arc::new(LargeBinaryArray::from_iter_values(values)))
+        }
+        data_type => Err(DataFusionError::Execution(format!(
+            "lix_diff primary-key column '{}' has unsupported type {data_type}",
+            field.name()
+        ))),
+    }
+}
+
+fn primary_key_component_error(
+    field: &Field,
+    component: Option<&RowPkComponent>,
+) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "lix_diff primary-key column '{}' does not match canonical identity component {component:?}",
+        field.name()
+    ))
 }
 
 fn side_value(side: Option<&DiffSide>, column: &str) -> Result<Option<lix_schema::Value>> {

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -26,6 +26,7 @@ use crate::plugin::runtime::WasmTypedRow;
 use crate::row_pk::{RowPk, RowPkComponent, RowPkComponentType};
 use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::catalog::{PublicCatalog, PublicSurfaceKind};
+use crate::sql2::catalog::schema_surface::SchemaSurfaceSpec;
 use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::result_metadata::{field_is_json, row_ref_field};
 #[cfg(test)]
@@ -153,6 +154,7 @@ struct DiffRelation {
     kind: DiffRelationKind,
     schema: SchemaRef,
     primary_key_columns: Vec<String>,
+    schema_spec: Option<SchemaSurfaceSpec>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -182,6 +184,10 @@ impl DiffRelation {
         let source_schema = catalog.surface_schema(name).ok_or_else(|| {
             DataFusionError::Plan(format!("lix_diff does not support relation '{name}'"))
         })?;
+        let schema_spec = match &kind {
+            DiffRelationKind::Schema { schema_key } => catalog.schema_spec(schema_key).cloned(),
+            DiffRelationKind::File | DiffRelationKind::Directory => None,
+        };
         let primary_key_columns = match &kind {
             DiffRelationKind::File | DiffRelationKind::Directory => vec!["id".to_owned()],
             DiffRelationKind::Schema { schema_key } => catalog
@@ -241,6 +247,7 @@ impl DiffRelation {
             kind,
             schema: Arc::new(Schema::new(fields)),
             primary_key_columns,
+            schema_spec,
         })
     }
 }
@@ -472,10 +479,16 @@ impl DiffRoute {
         let conjuncts = filter_conjuncts(filters);
         let row_ref_values = optional_values(&conjuncts, "row_ref");
         let id_values = optional_values(&conjuncts, "id");
-        let explicit_row_filter = row_ref_values.is_some();
+        let typed_row_pks = relation.schema_spec.as_ref().and_then(|spec| {
+            super::schema::row_pks_from_primary_key_filters(spec, filters)
+                .ok()
+                .flatten()
+        });
+        let explicit_row_filter = row_ref_values.is_some() || typed_row_pks.is_some();
         let mut contradictory = row_ref_values.as_ref().is_some_and(Vec::is_empty)
-            || id_values.as_ref().is_some_and(Vec::is_empty);
-        let mut row_pks = row_ref_values
+            || id_values.as_ref().is_some_and(Vec::is_empty)
+            || typed_row_pks.as_ref().is_some_and(Vec::is_empty);
+        let row_ref_pks = row_ref_values
             .unwrap_or_default()
             .into_iter()
             .filter_map(|value| {
@@ -483,6 +496,14 @@ impl DiffRoute {
                 (resolved.relation == relation.name).then_some(resolved.row_pk)
             })
             .collect::<Vec<_>>();
+        let mut row_pks = match typed_row_pks {
+            Some(typed) if !row_ref_pks.is_empty() => typed
+                .into_iter()
+                .filter(|row_pk| row_ref_pks.contains(row_pk))
+                .collect(),
+            Some(typed) => typed,
+            None => row_ref_pks,
+        };
         contradictory |= explicit_row_filter && row_pks.is_empty();
         let mut schema_keys = Vec::new();
         let mut file_ids = Vec::new();
@@ -1762,12 +1783,12 @@ mod tests {
     }
 
     #[test]
-    fn relation_diff_pushes_file_id_without_filtering_content_row_primary_keys() {
+    fn relation_diff_pushes_typed_file_id_without_filtering_content_row_primary_keys() {
         let relation = DiffRelation::from_catalog(PublicCatalog::fixed_system(), "lix_file")
             .expect("file relation is registered");
         let projection = Schema::empty();
         let route = DiffRoute::from_filters(
-            &[col("to_id").eq(lit("0193182b-2a72-7ed5-9015-76bf271af333"))],
+            &[col("id").eq(lit("0193182b-2a72-7ed5-9015-76bf271af333"))],
             &relation,
             &projection,
         );

--- a/packages/lix/src/sql2/providers/diff_command.rs
+++ b/packages/lix/src/sql2/providers/diff_command.rs
@@ -11,9 +11,8 @@ use datafusion::logical_expr::Expr;
 use datafusion::physical_plan::ExecutionPlan;
 
 use crate::LixError;
-use crate::row_pk::RowPk;
 use crate::sql2::error::lix_error_to_datafusion_error;
-use crate::sql2::result_metadata::json_field;
+use crate::sql2::result_metadata::row_ref_field;
 use crate::sql2::{DiffCommand, DiffCommandSelection, SqlWriteContext, WriteAccess};
 
 use super::spec::{InsertApply, PlannedScan, TableSpec, register_spec_table, scan_row_source};
@@ -101,8 +100,7 @@ impl TableSpec for DiffCommandSpec {
 
 fn command_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
-        Field::new("relation", DataType::Utf8, false),
-        json_field("row_pk", false),
+        row_ref_field("row_ref", false),
         Field::new("commit_id", DataType::Utf8, false),
     ]))
 }
@@ -110,32 +108,23 @@ fn command_schema() -> SchemaRef {
 fn selections_from_batches(batches: &[RecordBatch]) -> Result<Vec<DiffCommandSelection>> {
     let mut selections = Vec::new();
     for batch in batches {
-        let relations = batch
-            .column_by_name("relation")
-            .ok_or_else(|| DataFusionError::Execution("relation column is required".to_string()))?
+        let row_refs = batch
+            .column_by_name("row_ref")
+            .ok_or_else(|| DataFusionError::Execution("row_ref column is required".to_string()))?
             .as_any()
             .downcast_ref::<StringArray>()
-            .ok_or_else(|| DataFusionError::Execution("relation must be text".to_string()))?;
-        let row_pks = batch
-            .column_by_name("row_pk")
-            .ok_or_else(|| DataFusionError::Execution("row_pk column is required".to_string()))?
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .ok_or_else(|| DataFusionError::Execution("row_pk must be JSONB".to_string()))?;
-        for index in 0..relations.len() {
-            if relations.is_null(index) || row_pks.is_null(index) {
+            .ok_or_else(|| DataFusionError::Execution("row_ref must be lix_row_ref".to_string()))?;
+        for index in 0..row_refs.len() {
+            if row_refs.is_null(index) {
                 return Err(DataFusionError::Execution(
-                    "relation and row_pk cannot be NULL".to_string(),
+                    "row_ref cannot be NULL".to_string(),
                 ));
             }
-            let row_pk = RowPk::from_json_array_text(row_pks.value(index)).map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "row_pk must be a JSON primary-key array: {error}"
-                ))
-            })?;
+            let resolved = crate::row_ref::decode_str(row_refs.value(index))
+                .map_err(lix_error_to_datafusion_error)?;
             selections.push(DiffCommandSelection {
-                relation: relations.value(index).to_string(),
-                row_pk,
+                relation: resolved.relation,
+                row_pk: resolved.row_pk,
                 source_commits: None,
             });
         }
@@ -148,7 +137,7 @@ fn selections_from_batches(batches: &[RecordBatch]) -> Result<Vec<DiffCommandSel
         .any(|pair| pair[0].relation == pair[1].relation && pair[0].row_pk == pair[1].row_pk)
     {
         return Err(DataFusionError::Execution(
-            "diff command selection contains duplicate (relation, row_pk) rows".to_string(),
+            "diff command selection contains duplicate row_ref values".to_string(),
         ));
     }
     Ok(selections)

--- a/packages/lix/src/sql2/providers/directory_history.rs
+++ b/packages/lix/src/sql2/providers/directory_history.rs
@@ -26,7 +26,8 @@ use crate::sql2::history_route::{
     HISTORY_COL_IS_DELETED, HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_ROW_PK,
     HISTORY_COL_SOURCE_CHANGES, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
     HistoryViewDescriptor, load_history_entries, parse_history_filter,
-    serialize_history_source_changes, validate_history_anchor_filter,
+    history_filter_references_row_ref, serialize_history_source_changes,
+    validate_history_anchor_filter,
 };
 use crate::sql2::providers::filesystem_history_path::{
     DirectoryPathRecord, HistoryDirectoryTree, load_history_commit_parents,
@@ -86,7 +87,9 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter).is_some() {
+        if history_filter_references_row_ref(filter) && parse_history_filter(filter).is_some() {
+            TableProviderFilterPushDown::Inexact
+        } else if parse_history_filter(filter).is_some() {
             TableProviderFilterPushDown::Exact
         } else {
             TableProviderFilterPushDown::Unsupported
@@ -584,7 +587,12 @@ static LIX_DIRECTORY_HISTORY_COLS: ColumnTable<DirectoryHistoryOutputRow> = Colu
         ("name", Col::Utf8(|row| row.descriptor().name.as_deref())),
         (
             HISTORY_COL_ROW_PK,
-            Col::Utf8Fallible(|row| row_pk_json_array(&row.descriptor().id).map(Some)),
+            Col::Utf8Fallible(|row| {
+                let row_pk = crate::row_pk::RowPk::uuid_from_canonical(&row.descriptor().id)
+                    .map_err(|error| LixError::new(LixError::CODE_TYPE_MISMATCH, error.to_string()))?;
+                crate::row_ref::encode("lix_directory", &row_pk)
+                    .map(|value| Some(value.to_string()))
+            }),
         ),
         (
             HISTORY_COL_SOURCE_CHANGES,
@@ -641,7 +649,7 @@ pub(super) fn lix_directory_history_schema() -> SchemaRef {
         Field::new("path", DataType::Utf8, true),
         Field::new("parent_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, true),
-        json_field(HISTORY_COL_ROW_PK, false),
+        crate::sql2::result_metadata::row_ref_field(HISTORY_COL_ROW_PK, false),
         json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),

--- a/packages/lix/src/sql2/providers/file_history.rs
+++ b/packages/lix/src/sql2/providers/file_history.rs
@@ -41,7 +41,8 @@ use crate::sql2::history_route::{
     HISTORY_COL_IS_DELETED, HISTORY_COL_OBSERVED_COMMIT_ID, HISTORY_COL_ROW_PK,
     HISTORY_COL_SOURCE_CHANGES, HistoryEntry, HistoryMetadataProjection, HistoryRoute,
     HistoryViewDescriptor, load_history_entries, parse_history_filter,
-    serialize_history_source_changes, validate_history_anchor_filter,
+    history_filter_references_row_ref, serialize_history_source_changes,
+    validate_history_anchor_filter,
 };
 use crate::sql2::providers::filesystem_history_path::{
     DirectoryPathRecord, HistoryDirectoryTree, load_history_commit_parents,
@@ -107,7 +108,9 @@ where
     }
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
-        if parse_history_filter(filter).is_some()
+        if history_filter_references_row_ref(filter) && parse_history_filter(filter).is_some() {
+            TableProviderFilterPushDown::Inexact
+        } else if parse_history_filter(filter).is_some()
             || FileHistoryPublicPredicate::parse_exact(filter).is_some()
         {
             TableProviderFilterPushDown::Exact
@@ -2753,7 +2756,11 @@ static LIX_FILE_HISTORY_COLS: ColumnTable<FileHistoryOutputRow> = ColumnTable {
         ("content", Col::Binary(|row| row.data.clone())),
         (
             HISTORY_COL_ROW_PK,
-            Col::Utf8Fallible(|row| row_pk_json_array(&row.descriptor().id).map(Some)),
+            Col::Utf8Fallible(|row| {
+                let row_pk = RowPk::uuid_from_canonical(&row.descriptor().id)
+                    .map_err(|error| LixError::new(LixError::CODE_TYPE_MISMATCH, error.to_string()))?;
+                crate::row_ref::encode("lix_file", &row_pk).map(|value| Some(value.to_string()))
+            }),
         ),
         (
             HISTORY_COL_SOURCE_CHANGES,
@@ -2811,7 +2818,7 @@ pub(super) fn lix_file_history_schema() -> SchemaRef {
         Field::new("directory_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, true),
         Field::new("content", DataType::LargeBinary, true),
-        json_field(HISTORY_COL_ROW_PK, false),
+        crate::sql2::result_metadata::row_ref_field(HISTORY_COL_ROW_PK, false),
         json_field(HISTORY_COL_SOURCE_CHANGES, false),
         Field::new(HISTORY_COL_OBSERVED_COMMIT_ID, DataType::Utf8, false),
         Field::new(HISTORY_COL_COMMIT_CREATED_AT, DataType::Utf8, false),

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -603,10 +603,10 @@ where
             PublicSurfaceKind::SchemaBase { .. }
             | PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::CheckpointFunction
             | PublicSurfaceKind::StateAtFunction
             | PublicSurfaceKind::Revert
             | PublicSurfaceKind::Apply
-            | PublicSurfaceKind::CreateCheckpoint
             | PublicSurfaceKind::Restore => {}
         }
     }
@@ -813,18 +813,10 @@ async fn register_write_from_catalog(
                 )
                 .await?;
             }
-            PublicSurfaceKind::CreateCheckpoint => {
-                diff_command::register_diff_command_provider(
-                    session,
-                    &surface.name,
-                    crate::sql2::DiffCommand::CreateCheckpoint,
-                    write_ctx.clone(),
-                )
-                .await?;
-            }
             PublicSurfaceKind::Change
             | PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
+            | PublicSurfaceKind::CheckpointFunction
             | PublicSurfaceKind::StateAtFunction
             | PublicSurfaceKind::CommitAncestryFunction
             | PublicSurfaceKind::Restore => {}

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -874,11 +874,11 @@ mod tests {
              SELECT left_side.id \
              FROM shadowed AS left_side \
              JOIN (\
-                 SELECT row_pk FROM lix_change \
+                 SELECT row_ref FROM lix_change \
                  UNION ALL \
-                 SELECT row_pk FROM lix_change\
-             ) AS right_side \
-               ON left_side.id = right_side.row_pk \
+                 SELECT row_ref FROM lix_change\
+               ) AS right_side \
+               ON false \
              JOIN public.\"lix_directory\" AS directory_a ON true \
              JOIN public.\"lix_directory\" AS directory_b ON true"]);
 
@@ -1075,6 +1075,7 @@ mod tests {
             vec![
                 "lix_change",
                 "lix_commit_ancestry",
+                "lix_create_checkpoint",
                 "lix_diff",
                 "lix_history",
                 "lix_state_at",
@@ -1094,7 +1095,7 @@ mod tests {
         );
         assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
         assert_eq!(all_read + writable.len(), 20, "construction count");
-        assert_eq!(read_only.len() + writable.len(), 12, "surface count");
+        assert_eq!(read_only.len() + writable.len(), 13, "surface count");
     }
 
     #[test]
@@ -1111,7 +1112,7 @@ mod tests {
             .map(|surface| surface.name.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(all_writable, 7, "standalone write count");
+        assert_eq!(all_writable, 6, "standalone write count");
         assert_eq!(selected_writable, vec!["lix_file"]);
     }
 

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -1093,7 +1093,6 @@ mod tests {
             vec![
                 "lix_apply",
                 "lix_branch",
-                "lix_create_checkpoint",
                 "lix_directory",
                 "lix_file",
                 "lix_restore",
@@ -1102,8 +1101,8 @@ mod tests {
             ]
         );
         assert_eq!(read_only.len() + writable.len(), catalog.surfaces().count());
-        assert_eq!(all_read + writable.len(), 21, "construction count");
-        assert_eq!(read_only.len() + writable.len(), 13, "surface count");
+        assert_eq!(all_read + writable.len(), 20, "construction count");
+        assert_eq!(read_only.len() + writable.len(), 12, "surface count");
     }
 
     #[test]

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -79,14 +79,12 @@ pub(crate) async fn register_read<C>(
 where
     C: SqlExecutionContext + ?Sized,
 {
-    if selection.is_empty() {
-        return Ok(());
-    }
     let catalog = if selection.requires_visible_schemas() {
         ctx.public_catalog().await?
     } else {
         Arc::clone(PublicCatalog::fixed_system_shared())
     };
+    crate::sql2::udfs::register_row_ref_function(session, Arc::clone(&catalog));
     if catalog
         .surface("lix_diff")
         .is_some_and(|surface| selection.includes(surface))
@@ -349,6 +347,32 @@ fn collect_dynamic_relation_literals(
 
     impl Visitor for DiffRelationVisitor<'_> {
         type Break = ();
+
+        fn pre_visit_expr(&mut self, expression: &SqlExpr) -> ControlFlow<Self::Break> {
+            let SqlExpr::Function(function) = expression else {
+                return ControlFlow::Continue(());
+            };
+            if !crate::sql2::parse::object_name_is_public_function(
+                &function.name,
+                "lix_row_ref",
+            ) {
+                return ControlFlow::Continue(());
+            }
+            let datafusion::sql::sqlparser::ast::FunctionArguments::List(arguments) =
+                &function.args
+            else {
+                return ControlFlow::Continue(());
+            };
+            let Some(FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(value)))) =
+                arguments.args.first()
+            else {
+                return ControlFlow::Continue(());
+            };
+            if let SqlValue::SingleQuotedString(relation_name) = &value.value {
+                self.0.insert(relation_name.clone());
+            }
+            ControlFlow::Continue(())
+        }
 
         fn pre_visit_table_factor(
             &mut self,
@@ -662,6 +686,7 @@ pub(crate) async fn register_write(
     selection: &ProviderSelection,
 ) -> Result<(), LixError> {
     let catalog = write_ctx.public_catalog()?;
+    crate::sql2::udfs::register_row_ref_function(session, Arc::clone(&catalog));
     register_write_from_catalog(session, write_ctx, branch_ref, options, &catalog, selection)
         .await?;
     register_information_schema(session, selection, catalog)
@@ -684,6 +709,7 @@ where
     // Reuse that immutable metadata, then install read-only providers from the
     // committed read capability and writable providers from the overlay.
     let catalog = write_ctx.public_catalog()?;
+    crate::sql2::udfs::register_row_ref_function(session, Arc::clone(&catalog));
     if catalog
         .surface("lix_diff")
         .is_some_and(|surface| selection.includes(surface))

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -163,10 +163,6 @@ pub(crate) enum ProviderSelection {
 }
 
 impl ProviderSelection {
-    fn is_empty(&self) -> bool {
-        matches!(self, Self::Only { names, history_relations } if names.is_empty() && history_relations.is_empty())
-    }
-
     fn includes(&self, surface: &PublicSurfaceContract) -> bool {
         match self {
             Self::All | Self::AllWithHistory(_) => true,

--- a/packages/lix/src/sql2/providers/schema_history.rs
+++ b/packages/lix/src/sql2/providers/schema_history.rs
@@ -625,10 +625,16 @@ mod tests {
             "primary_key": ["locale", "key"],
         }))
         .expect("schema should derive");
+        let conflicting_row_ref = crate::row_ref::encode(
+            "localized_message",
+            &RowPk::from_json_array_text(r#"["fr","welcome"]"#).unwrap(),
+        )
+        .unwrap()
+        .to_string();
         let filters = vec![
             eq("key", "welcome"),
             eq("locale", "en"),
-            eq("lixcol_row_pk", r#"["fr","welcome"]"#),
+            eq("lixcol_row_ref", &conflicting_row_ref),
         ];
 
         let route =
@@ -636,12 +642,18 @@ mod tests {
 
         assert!(route.is_contradictory());
 
+        let wrong_arity_row_ref = crate::row_ref::encode(
+            "localized_message",
+            &RowPk::single("en"),
+        )
+        .unwrap()
+        .to_string();
         let wrong_arity_route = row_history_route_from_filters(
             &spec,
             &[
                 eq("key", "welcome"),
                 eq("locale", "en"),
-                eq("lixcol_row_pk", r#"["en"]"#),
+                eq("lixcol_row_ref", &wrong_arity_row_ref),
             ],
         )
         .expect("wrong-arity identity should produce a route");

--- a/packages/lix/src/sql2/providers/schema_history.rs
+++ b/packages/lix/src/sql2/providers/schema_history.rs
@@ -27,8 +27,10 @@ use crate::sql2::error::lix_error_to_datafusion_error;
 use crate::sql2::history_projection::{HistoryIdentityProjection, tombstone_identity_column_value};
 use crate::sql2::history_route::{
     HISTORY_COL_AS_OF_COMMIT_ID, HISTORY_COL_CHANGE_CREATED_AT, HISTORY_COL_IS_DELETED,
-    HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor, load_history_entries,
-    parse_history_filter, validate_history_anchor_filter,
+    HISTORY_COL_ROW_PK,
+    HistoryMetadataProjection, HistoryRoute, HistoryViewDescriptor,
+    history_filter_references_row_ref, load_history_entries, parse_history_filter,
+    validate_history_anchor_filter,
 };
 use crate::sql2::providers::schema::{
     parse_snapshot, row_f64_value, row_i64_value, row_json_text_value,
@@ -93,7 +95,9 @@ where
 
     fn filter_pushdown(&self, filter: &Expr) -> TableProviderFilterPushDown {
         let identity_analyzer = RowPrimaryKeyFilterAnalyzer::new(&self.spec);
-        if parse_history_filter(filter).is_some() || identity_analyzer.supports(filter) {
+        if history_filter_references_row_ref(filter) && parse_history_filter(filter).is_some() {
+            TableProviderFilterPushDown::Inexact
+        } else if parse_history_filter(filter).is_some() || identity_analyzer.supports(filter) {
             TableProviderFilterPushDown::Exact
         } else if identity_analyzer.contains_routable_conjunct(filter) {
             // Keep DataFusion's residual evaluation for mixed predicates while
@@ -226,13 +230,12 @@ where
 static ROW_HISTORY_SYSTEM_COLS: ColumnTable<SchemaHistoryRow> = ColumnTable {
     columns: &[
         (
-            "lixcol_row_pk",
+            HISTORY_COL_ROW_PK,
             Col::Utf8Owned(|row| {
                 Some(
-                    row.change
-                        .row_pk
-                        .as_json_array_text()
-                        .expect("canonical change row primary key should project"),
+                    crate::row_ref::encode(&row.change.schema_key, &row.change.row_pk)
+                        .expect("canonical history identity should project")
+                        .to_string(),
                 )
             }),
         ),

--- a/packages/lix/src/sql2/providers/state_at.rs
+++ b/packages/lix/src/sql2/providers/state_at.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
 
 use async_trait::async_trait;
-use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{TableFunctionImpl, TableProvider};
 use datafusion::common::{DataFusionError, Result};
@@ -159,6 +159,20 @@ where
                 "lix_state_at does not support relation '{relation_name}'"
             ))
         })?;
+        // Historical relation state has the same typed relation columns as the
+        // live surface. The durable JSON row key is an engine implementation
+        // detail, however, and must not reappear through this table function.
+        // Callers can construct a universal address from the typed key columns
+        // with `lix_row_ref(relation, ...)` when they need one.
+        let schema = Arc::new(Schema::new_with_metadata(
+            schema
+                .fields()
+                .iter()
+                .filter(|field| field.name() != "lixcol_row_pk")
+                .map(|field| field.as_ref().clone())
+                .collect::<Vec<_>>(),
+            schema.metadata().clone(),
+        ));
         let kind = match &surface.kind {
             PublicSurfaceKind::SchemaBase { schema_key } => StateRelationKind::Schema {
                 schema_key: schema_key.clone(),

--- a/packages/lix/src/sql2/read_only.rs
+++ b/packages/lix/src/sql2/read_only.rs
@@ -46,7 +46,9 @@ fn read_only_schema_message(schema_key: &str) -> Option<&'static str> {
         "lix_commit" | "lix_change" => Some(
             "Commit graph and changelog surfaces are read-only; Lix creates them when transactions commit.",
         ),
-        "lix_checkpoint" => Some("Checkpoints are created through the create_checkpoint API."),
+        "lix_checkpoint" => {
+            Some("Create checkpoints with SELECT commit_id FROM lix_create_checkpoint().")
+        }
         "lix_undo_redo_marker" => Some(
             "Undo/redo markers are internal; use the undo and redo APIs to change branch history.",
         ),

--- a/packages/lix/src/sql2/result_metadata.rs
+++ b/packages/lix/src/sql2/result_metadata.rs
@@ -6,6 +6,7 @@ use crate::{LixError, ResultColumnType};
 
 pub(crate) const LIX_VALUE_TYPE_METADATA_KEY: &str = "lix.value_type";
 pub(crate) const LIX_VALUE_TYPE_JSONB: &str = "jsonb";
+pub(crate) const LIX_VALUE_TYPE_ROW_REF: &str = "row_ref";
 
 pub(crate) fn json_field(name: impl Into<String>, nullable: bool) -> Field {
     Field::new(name, DataType::Utf8, nullable)
@@ -14,6 +15,20 @@ pub(crate) fn json_field(name: impl Into<String>, nullable: bool) -> Field {
 
 pub(crate) fn mark_json_field(field: Field) -> Field {
     field.with_metadata(json_field_metadata_map())
+}
+
+pub(crate) fn row_ref_field(name: impl Into<String>, nullable: bool) -> Field {
+    Field::new(name, DataType::Utf8, nullable).with_metadata(HashMap::from([(
+        LIX_VALUE_TYPE_METADATA_KEY.to_string(),
+        LIX_VALUE_TYPE_ROW_REF.to_string(),
+    )]))
+}
+
+pub(crate) fn field_is_row_ref(field: &Field) -> bool {
+    field
+        .metadata()
+        .get(LIX_VALUE_TYPE_METADATA_KEY)
+        .is_some_and(|value| value == LIX_VALUE_TYPE_ROW_REF)
 }
 
 pub(crate) fn field_is_json(field: &Field) -> bool {
@@ -37,7 +52,9 @@ pub(crate) fn result_column_type(field: &Field) -> Result<ResultColumnType, LixE
         | DataType::UInt64 => ResultColumnType::Integer,
         DataType::Float32 | DataType::Float64 => ResultColumnType::Real,
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
-            if field_is_json(field) {
+            if field_is_row_ref(field) {
+                ResultColumnType::RowRef
+            } else if field_is_json(field) {
                 ResultColumnType::Jsonb
             } else {
                 ResultColumnType::Text

--- a/packages/lix/src/sql2/session.rs
+++ b/packages/lix/src/sql2/session.rs
@@ -274,6 +274,15 @@ fn statement_uses_execution_function(statement: &DataFusionStatement, function_n
             {
                 return ControlFlow::Break(());
             }
+            if matches!(
+                self.function_name,
+                "lix_latest_checkpoint_commit_id" | "lix_active_branch_commit_id"
+            ) && let TableFactor::Table { name, args: Some(arguments), .. } = table
+                && crate::sql2::parse::object_name_is_public_function(name, "lix_diff")
+                && arguments.args.len() == 1
+            {
+                return ControlFlow::Break(());
+            }
             ControlFlow::Continue(())
         }
     }

--- a/packages/lix/src/sql2/test_support/differential.rs
+++ b/packages/lix/src/sql2/test_support/differential.rs
@@ -408,9 +408,9 @@ mod tests {
         match probe {
             DifferentialProbe::RegisteredSchemaActive => ProbeQuery {
                 name: "lix_registered_schema".to_string(),
-                sql: "SELECT lixcol_row_pk, value, lixcol_metadata, lixcol_global, lixcol_untracked \
+                sql: "SELECT schema_key, value, lixcol_metadata, lixcol_global, lixcol_untracked \
                  FROM lix_registered_schema \
-                 ORDER BY lixcol_row_pk"
+                 ORDER BY schema_key"
                     .to_string(),
                 params: Vec::new(),
             },

--- a/packages/lix/src/sql2/udfs/lix_row_ref.rs
+++ b/packages/lix/src/sql2/udfs/lix_row_ref.rs
@@ -1,0 +1,163 @@
+use std::any::Any;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use base64::Engine as _;
+use datafusion::arrow::array::StringArray;
+use datafusion::arrow::datatypes::{DataType, FieldRef};
+use datafusion::common::{DataFusionError, Result, ScalarValue, plan_err};
+use datafusion::logical_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+
+use crate::row_pk::{RowPk, RowPkComponentType};
+use crate::sql2::catalog::PublicCatalog;
+use crate::sql2::result_metadata::row_ref_field;
+
+use super::common::scalar_inputs;
+
+#[derive(Debug)]
+pub(super) struct LixRowRef {
+    signature: Signature,
+    catalog: Arc<PublicCatalog>,
+}
+
+impl PartialEq for LixRowRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.signature == other.signature && Arc::ptr_eq(&self.catalog, &other.catalog)
+    }
+}
+
+impl Eq for LixRowRef {}
+
+impl Hash for LixRowRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.signature.hash(state);
+        Arc::as_ptr(&self.catalog).hash(state);
+    }
+}
+
+impl LixRowRef {
+    pub(super) fn new(catalog: Arc<PublicCatalog>) -> Self {
+        Self {
+            signature: Signature::variadic_any(Volatility::Stable),
+            catalog,
+        }
+    }
+}
+
+impl ScalarUDFImpl for LixRowRef {
+    fn as_any(&self) -> &dyn Any { self }
+    fn name(&self) -> &'static str { "lix_row_ref" }
+    fn signature(&self) -> &Signature { &self.signature }
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> { Ok(DataType::Utf8) }
+    fn return_field_from_args(&self, _args: ReturnFieldArgs) -> Result<FieldRef> {
+        Ok(Arc::new(row_ref_field(self.name(), false)))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        if args.args.len() < 2 {
+            return plan_err!("lix_row_ref requires a relation and at least one primary-key value");
+        }
+        let scalar = scalar_inputs(&args.args);
+        let arrays = ColumnarValue::values_to_arrays(&args.args)?;
+        let len = arrays[0].len();
+        let mut output = Vec::with_capacity(len);
+        for row in 0..len {
+            let relation_value = ScalarValue::try_from_array(arrays[0].as_ref(), row)?;
+            let relation = scalar_text(&relation_value)
+                .ok_or_else(|| DataFusionError::Execution(
+                    "lix_row_ref relation must be non-null text".to_string(),
+                ))?;
+            let component_types = crate::row_ref::primary_key_component_types(
+                &self.catalog,
+                relation,
+            ).map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
+            if component_types.len() != arrays.len() - 1 {
+                return Err(DataFusionError::Execution(format!(
+                    "lix_row_ref relation '{relation}' requires {} primary-key values, got {}",
+                    component_types.len(), arrays.len() - 1,
+                )));
+            }
+            let parts = arrays[1..]
+                .iter()
+                .zip(&component_types)
+                .enumerate()
+                .map(|(index, (array, expected))| {
+                    external_component(
+                        &ScalarValue::try_from_array(array.as_ref(), row)?,
+                        *expected,
+                        index,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let row_pk = RowPk::from_external_parts(parts, &component_types).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "lix_row_ref relation '{relation}' has an invalid primary key: {error}"
+                ))
+            })?;
+            output.push(crate::row_ref::encode(relation, &row_pk)
+                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?
+                .as_str().to_owned());
+        }
+        if scalar {
+            Ok(ColumnarValue::Scalar(ScalarValue::Utf8(output.into_iter().next())))
+        } else {
+            Ok(ColumnarValue::Array(Arc::new(StringArray::from(output))))
+        }
+    }
+}
+
+fn external_component(
+    value: &ScalarValue,
+    expected: RowPkComponentType,
+    index: usize,
+) -> Result<String> {
+    let value = match expected {
+        RowPkComponentType::Uuid | RowPkComponentType::String => {
+            scalar_text(value).map(str::to_owned)
+        }
+        RowPkComponentType::Bytes => match value {
+            ScalarValue::Binary(Some(value))
+            | ScalarValue::LargeBinary(Some(value))
+            | ScalarValue::BinaryView(Some(value)) => Some(
+                base64::engine::general_purpose::STANDARD.encode(value),
+            ),
+            _ => scalar_text(value).map(str::to_owned),
+        },
+        RowPkComponentType::Integer => scalar_integer(value).map(|value| value.to_string()),
+    };
+    value.ok_or_else(|| DataFusionError::Execution(format!(
+        "lix_row_ref primary-key value {} must be a non-null {}",
+        index + 1,
+        match expected {
+            RowPkComponentType::Uuid => "UUID string",
+            RowPkComponentType::Integer => "integer",
+            RowPkComponentType::String => "text value",
+            RowPkComponentType::Bytes => "base64 string",
+        }
+    )))
+}
+
+fn scalar_text(value: &ScalarValue) -> Option<&str> {
+    match value {
+        ScalarValue::Utf8(Some(value))
+        | ScalarValue::LargeUtf8(Some(value))
+        | ScalarValue::Utf8View(Some(value)) => Some(value),
+        _ => None,
+    }
+}
+
+fn scalar_integer(value: &ScalarValue) -> Option<i64> {
+    match value {
+        ScalarValue::Int8(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::Int16(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::Int32(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::Int64(Some(value)) => Some(*value),
+        ScalarValue::UInt8(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::UInt16(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::UInt32(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::UInt64(Some(value)) => i64::try_from(*value).ok(),
+        _ => None,
+    }
+}

--- a/packages/lix/src/sql2/udfs/mod.rs
+++ b/packages/lix/src/sql2/udfs/mod.rs
@@ -11,6 +11,7 @@ mod lix_jsonb;
 mod lix_latest_checkpoint_commit_id;
 mod lix_octet_length;
 mod lix_root_commit_id;
+mod lix_row_ref;
 mod uuidv7;
 
 use std::sync::Arc;
@@ -21,6 +22,13 @@ use datafusion::logical_expr::ScalarUDF;
 use crate::functions::FunctionProviderHandle;
 
 pub(crate) use execution_slots::{ExecutionSlots, execution_slots};
+
+pub(crate) fn register_row_ref_function(
+    ctx: &SessionContext,
+    catalog: Arc<crate::sql2::catalog::PublicCatalog>,
+) {
+    ctx.register_udf(ScalarUDF::from(lix_row_ref::LixRowRef::new(catalog)));
+}
 
 #[cfg(test)]
 pub(crate) fn system_sql2_function_provider() -> FunctionProviderHandle {

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -11646,7 +11646,7 @@ mod tests {
         );
         let peer_diff = peer
             .execute(
-                "SELECT lixcol_row_pk, diff_type \
+                "SELECT id, diff_type \
                  FROM lix_diff('lix_file', $1, lix_active_branch_commit_id())",
                 &[Value::Text(pushed_checkpoint.to_owned())],
             )
@@ -11921,7 +11921,7 @@ mod tests {
         let diff = loop {
             match replica
                 .execute(
-                    "SELECT lixcol_row_pk ->> 0 AS file_id FROM lix_diff('lix_file', $1, $2)",
+                    "SELECT id AS file_id FROM lix_diff('lix_file', $1, $2)",
                     &[
                         Value::Text(previous_checkpoint.clone()),
                         Value::Text(latest_checkpoint.clone()),

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -406,7 +406,11 @@ where
                 deterministic: true,
             },
             case_id,
-            test_fn,
+            // Keep the scenario state machine off the test harness thread's
+            // fixed-size stack. Engine SQL futures intentionally carry their
+            // transaction state across awaits and should not be nested inline
+            // into this generic simulation runner.
+            move |sim| Box::pin(test_fn(sim)),
         ),
     );
 }
@@ -692,7 +696,7 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ ORDER BY lixcol_row_pk",
+                "SELECT key FROM __LIX_RELATION_DIFF__ ORDER BY key",
             )
             .await,
             &[],
@@ -702,9 +706,9 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
     assert_eq!(remaining.rows().len(), 1);
     assert_eq!(
         remaining.rows()[0]
-            .get::<serde_json::Value>("lixcol_row_pk")
+            .get::<String>("key")
             .expect("remaining row key"),
-        serde_json::json!(["remaining"]),
+        "remaining",
     );
     let final_values = hot_digest(&replica.lix)
         .await
@@ -758,7 +762,7 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ ORDER BY lixcol_row_pk",
+				"SELECT key FROM __LIX_RELATION_DIFF__ ORDER BY key",
 			)
 			.await,
 			&[],
@@ -767,10 +771,8 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 		.expect("unselected snapshot-local diff should remain readable");
 	assert_eq!(remaining.rows().len(), 49);
 	assert_eq!(
-		remaining.rows()[0]
-			.get::<serde_json::Value>("lixcol_row_pk")
-			.unwrap(),
-		serde_json::json!(["working-01"]),
+		remaining.rows()[0].get::<String>("key").unwrap(),
+		"working-01",
 	);
 }
 
@@ -1130,7 +1132,7 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk ->> 0 = 'selected-recreate'",
+                 WHERE key = 'selected-recreate'",
             )
             .await,
             &[],
@@ -1148,7 +1150,7 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk ->> 0 = 'remaining'",
+                 WHERE key = 'remaining'",
             )
             .await,
             &[],
@@ -1168,7 +1170,7 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
                 &replica.lix,
                 "lix_key_value",
                 "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk ->> 0 = 'remaining'",
+                 WHERE key = 'remaining'",
             )
             .await,
             &[],
@@ -1256,7 +1258,7 @@ async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simul
                 &working_diff_sql(
                     &replica.lix,
                     "lix_file",
-                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE lixcol_row_pk ->> 0 = $1",
+                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE id = $1",
                 )
                 .await,
                 &[Value::Text(selected_file_id.clone())],
@@ -1307,7 +1309,7 @@ async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simul
                 &working_diff_sql(
                     &replica.lix,
                     "lix_file",
-                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE lixcol_row_pk ->> 0 = $1",
+                    "SELECT count(*) AS count FROM __LIX_RELATION_DIFF__ WHERE id = $1",
                 )
                 .await,
                 &[Value::Text(selected_file_id)],
@@ -1582,7 +1584,7 @@ async fn partial_checkpoint_uncertified_index_uses_hot_primary_fallback(_sim: Si
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT lixcol_row_pk ->> 0 AS key FROM __LIX_RELATION_DIFF__",
+                "SELECT key FROM __LIX_RELATION_DIFF__",
             )
             .await,
             &[],
@@ -1641,7 +1643,7 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT diff_type, lixcol_row_pk FROM __LIX_RELATION_DIFF__",
+                "SELECT diff_type, key FROM __LIX_RELATION_DIFF__",
             )
             .await,
             &[],
@@ -1656,10 +1658,8 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
         "removed"
     );
     assert_eq!(
-        remaining.rows()[0]
-            .get::<serde_json::Value>("lixcol_row_pk")
-            .unwrap(),
-        serde_json::json!(["removed"]),
+        remaining.rows()[0].get::<String>("key").unwrap(),
+        "removed",
     );
     replica.restart().await;
     assert_eq!(

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -580,14 +580,13 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
         .await
         .expect("replica should import the sparse working interval");
 
-    let selected_row_pk = replica
+    let selected_row_ref = replica
         .lix
         .execute(
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
+                "SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'selected'",
             )
             .await,
             &[],
@@ -595,8 +594,8 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
         .await
         .expect("selected working diff should be hot")
         .rows()[0]
-        .get::<serde_json::Value>("lixcol_row_pk")
-        .expect("selected primary key should decode");
+        .get::<crate::RowRef>("row_ref")
+        .expect("selected row reference should decode");
     let head_commit_id_text = replica
         .lix
         .execute("SELECT lix_active_branch_commit_id() AS id", &[])
@@ -642,9 +641,8 @@ async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
     let checkpoint = replica
         .lix
         .execute(
-            "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-             SELECT 'lix_key_value', $1 RETURNING commit_id",
-            &[Value::Jsonb(selected_row_pk.into())],
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY[$1])",
+            &[Value::RowRef(selected_row_ref)],
         )
         .await
         .expect("partial checkpoint should use the hot working-diff authority");
@@ -745,10 +743,8 @@ async fn snapshot_partial_checkpoint_uses_local_selected_payloads(_sim: Simulati
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"INSERT INTO lix_create_checkpoint (relation, row_pk) \
-				 SELECT 'lix_key_value', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE lixcol_row_pk = CAST('[\"working-00\"]' AS JSONB) \
-				 RETURNING commit_id",
+				"SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+				 SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'working-00'))",
 			)
 			.await,
 			&[],
@@ -811,14 +807,13 @@ async fn partial_checkpoint_rebases_hot_epoch_without_cold_history(_sim: Simulat
         .expect("replica should import every sparse update");
 
     crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
-    let selected_row_pk = replica
+    let selected_row_ref = replica
         .lix
         .execute(
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk = CAST('[\"owner-00\"]' AS JSONB)",
+                "SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'owner-00'",
             )
             .await,
             &[],
@@ -826,8 +821,8 @@ async fn partial_checkpoint_rebases_hot_epoch_without_cold_history(_sim: Simulat
         .await
         .expect("working diff should already be HOT")
         .rows()[0]
-        .get::<serde_json::Value>("lixcol_row_pk")
-        .expect("selected primary key should decode");
+        .get::<crate::RowRef>("row_ref")
+        .expect("selected row reference should decode");
     assert!(
         crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
         "working-diff classification must not touch cold commit owners",
@@ -837,9 +832,8 @@ async fn partial_checkpoint_rebases_hot_epoch_without_cold_history(_sim: Simulat
     let checkpoint = replica
         .lix
         .execute(
-            "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-             SELECT 'lix_key_value', $1 RETURNING commit_id",
-            &[Value::Jsonb(selected_row_pk.into())],
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY[$1])",
+            &[Value::RowRef(selected_row_ref)],
         )
         .await
         .expect("checkpoint should use the exact selected HOT payload");
@@ -983,9 +977,8 @@ async fn partial_file_checkpoint_rebases_hot_epoch(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_file",
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_file', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk ->> 0 = $1 RETURNING commit_id",
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE id = $1))",
             )
             .await,
             &[Value::Text(selected_file_id)],
@@ -1106,9 +1099,8 @@ async fn packed_recreate_partial_checkpoint_stays_hot(_sim: Simulation) {
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk ->> 0 = 'selected-recreate' RETURNING commit_id",
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'selected-recreate'))",
             )
             .await,
             &[],
@@ -1286,9 +1278,8 @@ async fn packed_snapshot_partial_file_checkpoint_stays_payload_local(_sim: Simul
                 &working_diff_sql(
                     &replica.lix,
                     "lix_file",
-                    "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                     SELECT 'lix_file', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                     WHERE lixcol_row_pk ->> 0 = $1 RETURNING commit_id",
+                    "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                     SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE id = $1))",
                 )
                 .await,
                 &[Value::Text(selected_file_id.clone())],
@@ -1362,14 +1353,13 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 	let mut replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
 	replica.write("selected", "local-selected").await;
 	replica.write("remaining", "local-remaining").await;
-	let first_selected_row_pk = replica
+	let first_selected_row_ref = replica
 		.lix
 		.execute(
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
+				"SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'selected'",
 			)
 			.await,
 			&[],
@@ -1377,14 +1367,13 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 		.await
 		.unwrap()
 		.rows()[0]
-		.get::<serde_json::Value>("lixcol_row_pk")
+		.get::<crate::RowRef>("row_ref")
 		.unwrap();
 	replica
 		.lix
 		.execute(
-			"INSERT INTO lix_create_checkpoint (relation, row_pk) \
-			 SELECT 'lix_key_value', $1 RETURNING commit_id",
-			&[Value::Jsonb(first_selected_row_pk.into())],
+			"SELECT commit_id FROM lix_create_checkpoint(ARRAY[$1])",
+			&[Value::RowRef(first_selected_row_ref)],
 		)
 		.await
 		.unwrap();
@@ -1415,14 +1404,13 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 	// checkpoint while the sparse working-diff epoch still pointed at the old
 	// checkpoint and generation.
 	replica.write("selected", "local-selected-again").await;
-	let selected_row_pk = replica
+	let selected_row_ref = replica
 		.lix
 		.execute(
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
+				"SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'selected'",
 			)
 			.await,
 			&[],
@@ -1430,7 +1418,7 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 		.await
 		.unwrap()
 		.rows()[0]
-		.get::<serde_json::Value>("lixcol_row_pk")
+		.get::<crate::RowRef>("row_ref")
 		.unwrap();
 	let head_commit_id = replica
 		.lix
@@ -1460,9 +1448,8 @@ async fn partial_checkpoint_after_partial_checkpoint_snapshot_stays_hot(_sim: Si
 	replica
 		.lix
 		.execute(
-			"INSERT INTO lix_create_checkpoint (relation, row_pk) \
-			 SELECT 'lix_key_value', $1 RETURNING commit_id",
-			&[Value::Jsonb(selected_row_pk.into())],
+			"SELECT commit_id FROM lix_create_checkpoint(ARRAY[$1])",
+			&[Value::RowRef(selected_row_ref)],
 		)
 		.await
 		.unwrap();
@@ -1568,9 +1555,9 @@ async fn partial_checkpoint_uncertified_index_uses_hot_primary_fallback(_sim: Si
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE coalesce(lixcol_row_pk ->> 0, '') = 'selected' RETURNING commit_id",
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref FROM __LIX_RELATION_DIFF__ \
+                 WHERE coalesce(key, '') = 'selected'))",
             )
             .await,
             &[],
@@ -1618,14 +1605,13 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
         .await
         .unwrap();
     replica.pump().await.unwrap();
-    let selected_row_pk = replica
+    let selected_row_ref = replica
         .lix
         .execute(
             &working_diff_sql(
                 &replica.lix,
                 "lix_key_value",
-                "SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-                 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
+                "SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'selected'",
             )
             .await,
             &[],
@@ -1633,16 +1619,15 @@ async fn partial_checkpoint_rebases_unselected_tombstone(_sim: Simulation) {
         .await
         .unwrap()
         .rows()[0]
-        .get::<serde_json::Value>("lixcol_row_pk")
+        .get::<crate::RowRef>("row_ref")
         .unwrap();
 
     crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
     replica
         .lix
         .execute(
-            "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-             SELECT 'lix_key_value', $1 RETURNING commit_id",
-            &[Value::Jsonb(selected_row_pk.into())],
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY[$1])",
+            &[Value::RowRef(selected_row_ref)],
         )
         .await
         .unwrap();
@@ -1722,14 +1707,13 @@ async fn pre_v75_partial_checkpoint_repository_is_rejected(_sim: Simulation) {
 
 	replica.write("selected", "local-selected").await;
 	replica.write("remaining", "local-remaining").await;
-	let selected_row_pk = replica
+	let selected_row_ref = replica
 		.lix
 		.execute(
 			&working_diff_sql(
 				&replica.lix,
 				"lix_key_value",
-				"SELECT lixcol_row_pk FROM __LIX_RELATION_DIFF__ \
-				 WHERE lixcol_row_pk = CAST('[\"selected\"]' AS JSONB)",
+				"SELECT row_ref FROM __LIX_RELATION_DIFF__ WHERE key = 'selected'",
 			)
 			.await,
 			&[],
@@ -1737,14 +1721,13 @@ async fn pre_v75_partial_checkpoint_repository_is_rejected(_sim: Simulation) {
 		.await
 		.unwrap()
 		.rows()[0]
-		.get::<serde_json::Value>("lixcol_row_pk")
+		.get::<crate::RowRef>("row_ref")
 		.unwrap();
 	replica
 		.lix
 		.execute(
-			"INSERT INTO lix_create_checkpoint (relation, row_pk) \
-			 SELECT 'lix_key_value', $1 RETURNING commit_id",
-			&[Value::Jsonb(selected_row_pk.into())],
+			"SELECT commit_id FROM lix_create_checkpoint(ARRAY[$1])",
+			&[Value::RowRef(selected_row_ref)],
 		)
 		.await
 		.unwrap();

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -1841,8 +1841,7 @@ where
                     serde_json::json!({
                         "change_id": row.change_id().to_string(),
                         "commit_id": commit_id.to_string(),
-                        "schema_key": row.schema_key(),
-                        "row_pk": row.row_pk().as_typed_json_array_value().ok(),
+                        "row_ref": crate::row_ref::schema_identity_detail(row.schema_key(), row.row_pk()),
                         "file_id": row.file_id(),
                     }),
                 ));
@@ -8542,12 +8541,9 @@ mod tests {
             .expect("internal invariant should retain entity coordinates");
         assert_eq!(details["change_id"], row.change_id.to_string());
         assert_eq!(details["commit_id"], commit_id.to_string());
-        assert_eq!(details["schema_key"], row.schema_key);
         assert_eq!(
-            details["row_pk"],
-            row.row_pk
-                .as_typed_json_array_value()
-                .expect("test row PK should encode")
+            details["row_ref"],
+            crate::row_ref::schema_identity_detail(&row.schema_key, &row.row_pk)
         );
     }
 

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -4763,14 +4763,10 @@ where
             if parent_value.as_ref().is_some_and(|value| !value.deleted())
                 && absence_guards.contains(&key)
             {
-                let row_pk = key
-                    .row_pk
-                    .as_json_array_text()
-                    .unwrap_or_else(|_| "<invalid row_pk>".to_string());
                 return Err(LixError::new(
                     LixError::CODE_UNIQUE,
                     format!(
-                        "primary-key constraint violation on schema '{}': INSERT would duplicate row_pk '{row_pk}'",
+                        "primary-key constraint violation on schema '{}': INSERT would duplicate a primary key",
                         key.schema_key
                     ),
                 ));

--- a/packages/lix/src/tracked_state/row_materialization.rs
+++ b/packages/lix/src/tracked_state/row_materialization.rs
@@ -465,8 +465,7 @@ where
                     serde_json::json!({
                         "change_id": change_id.to_string(),
                         "commit_id": commit_id.to_string(),
-                        "schema_key": key.schema_key,
-                        "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                        "row_ref": crate::row_ref::schema_identity_detail(&key.schema_key, &key.row_pk),
                         "file_id": key.file_id,
                     }),
                 )
@@ -487,8 +486,7 @@ where
                     serde_json::json!({
                         "change_id": change_id.to_string(),
                         "commit_id": commit_id.to_string(),
-                        "schema_key": key.schema_key,
-                        "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                        "row_ref": crate::row_ref::schema_identity_detail(&key.schema_key, &key.row_pk),
                         "file_id": key.file_id,
                     }),
                 ));
@@ -642,8 +640,7 @@ fn shared_payload_fields(
             serde_json::json!({
                 "change_id": change_id.to_string(),
                 "commit_id": commit_id.to_string(),
-                "schema_key": key.schema_key,
-                "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                "row_ref": crate::row_ref::schema_identity_detail(key.schema_key, key.row_pk),
                 "file_id": key.file_id,
             }),
         )
@@ -660,8 +657,7 @@ fn shared_payload_fields(
             serde_json::json!({
                 "change_id": change_id.to_string(),
                 "commit_id": commit_id.to_string(),
-                "schema_key": key.schema_key,
-                "row_pk": key.row_pk.as_typed_json_array_value().ok(),
+                "row_ref": crate::row_ref::schema_identity_detail(key.schema_key, key.row_pk),
                 "file_id": key.file_id,
             }),
         ));
@@ -1278,12 +1274,9 @@ mod tests {
         let details = error.details.expect("invariant should retain entity IDs");
         assert_eq!(details["change_id"], change_id.to_string());
         assert_eq!(details["commit_id"], commit_id.to_string());
-        assert_eq!(details["schema_key"], key.schema_key);
         assert_eq!(
-            details["row_pk"],
-            key.row_pk
-                .as_typed_json_array_value()
-                .expect("test row PK should encode")
+            details["row_ref"],
+            crate::row_ref::schema_identity_detail(&key.schema_key, &key.row_pk)
         );
     }
 }

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -238,6 +238,7 @@ const COMMIT_DELTA_PAYLOAD_AUTHORED: u8 = 0;
 const COMMIT_DELTA_PAYLOAD_SELECTED_REF: u8 = 1;
 const COMMIT_DELTA_PAYLOAD_SELECTED_TOMBSTONE: u8 = 2;
 const COMMIT_DELTA_PAYLOAD_AUTHORED_SNAPSHOT: u8 = 3;
+const STALE_SELECTED_CHANGE_LOCATOR: &str = "LIX_STALE_SELECTED_CHANGE_LOCATOR";
 
 #[derive(Debug, musli::Decode)]
 #[musli(packed)]
@@ -541,6 +542,10 @@ pub(crate) struct CommitDeltaChangeLocator {
 
 pub(crate) struct AddressableCommitDeltaStage {
     pub(crate) locators: Vec<CommitDeltaChangeLocator>,
+    /// Locators whose durable payload is authored by this commit. Selected
+    /// references may need physical locators while moving sync inventories,
+    /// but must never replace the canonical locator owned by their source.
+    pub(crate) authored_locators: Vec<CommitDeltaChangeLocator>,
     /// Final ids by input delta ordinal. Non-addressable entries retain the
     /// nil sentinel and never require a second per-row index.
     pub(crate) assigned_change_ids: Vec<crate::changelog::ChangeId>,
@@ -6589,6 +6594,7 @@ fn stage_commit_deltas_inner(
     let Some(&commit_id) = deltas.first().map(|delta| &delta.delta.commit_id) else {
         return Ok(AddressableCommitDeltaStage {
             locators: Vec::new(),
+            authored_locators: Vec::new(),
             assigned_change_ids: Vec::new(),
             mutation_inventory: CommitStateMutationInventory::default(),
         });
@@ -6821,7 +6827,6 @@ fn stage_commit_deltas_inner(
             .map(|(range, _)| direct_ownership_bits(&addressable[range.clone()]))
             .collect::<Vec<_>>()
     };
-    let has_direct_address_inventory = !direct_segment_row_counts.is_empty();
     let segment_count = encoded_segments.len();
     if segment_count == 1 {
         let (_, inline_segment) = encoded_segments
@@ -6843,18 +6848,29 @@ fn stage_commit_deltas_inner(
             inline_segment: inline_segment.encoded,
             segments: Vec::new(),
         };
-        let locators = commit_delta_change_locators(commit_id, 0, &entries)?
+        let all_locators = commit_delta_change_locators(commit_id, 0, &entries)?;
+        let authored_locators = all_locators
+            .iter()
+            .copied()
+            .enumerate()
+            .filter_map(|(index, locator)| {
+                (payloads[index].authored && !addressable[index]).then_some(locator)
+            })
+            .collect();
+        let locators = all_locators
             .into_iter()
             .enumerate()
             .filter_map(|(index, locator)| (!addressable[index]).then_some(locator))
             .collect();
         return Ok(AddressableCommitDeltaStage {
             locators,
+            authored_locators,
             assigned_change_ids,
             mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
         });
     }
     writes.reserve_space(TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE, segment_count, 0);
+    let has_direct_address_inventory = !direct_segment_row_counts.is_empty();
     let mut manifest = CommitDeltaManifest {
         account_id: crate::ANONYMOUS_ACCOUNT_ID.to_string(),
         selected_source_commit_id: selected_source_commit_id
@@ -6872,9 +6888,11 @@ fn stage_commit_deltas_inner(
         segments: Vec::with_capacity(segment_count),
     };
     let mut locators = Vec::with_capacity(entries.len());
+    let mut authored_locators = Vec::with_capacity(entries.len());
     for (segment_index, (range, encoded)) in encoded_segments.into_iter().enumerate() {
         let segment_entries = &entries[range.clone()];
-        let segment_addressable = &addressable[range];
+        let segment_addressable = &addressable[range.clone()];
+        let segment_payloads = &payloads[range];
         let first_key = segment_entries
             .first()
             .expect("non-empty packed commit-delta segment")
@@ -6900,6 +6918,16 @@ fn stage_commit_deltas_inner(
         );
         let segment_locators =
             commit_delta_change_locators(commit_id, segment_index, segment_entries)?;
+        authored_locators.extend(
+            segment_locators
+                .iter()
+                .copied()
+                .zip(segment_addressable)
+                .zip(segment_payloads)
+                .filter_map(|((locator, &direct), payload)| {
+                    (payload.authored && !direct).then_some(locator)
+                }),
+        );
         if has_direct_address_inventory {
             locators.extend(
                 segment_locators
@@ -6913,6 +6941,7 @@ fn stage_commit_deltas_inner(
     }
     Ok(AddressableCommitDeltaStage {
         locators,
+        authored_locators,
         assigned_change_ids,
         mutation_inventory: commit_state_inventory_from_delta_manifest(&manifest),
     })
@@ -7104,9 +7133,21 @@ pub(crate) async fn load_change_record_by_id(
         super::mutation_directory::record_direct_route_explicit_fallback(1);
     }
     if let Some(locator) = load_change_locator_by_id(store, change_id).await? {
-        return Ok(load_explicit_change_records_at_locators(store, &[locator])
-            .await?
-            .pop());
+        return match load_explicit_change_records_at_locators(store, &[locator]).await {
+            Ok(mut records) => Ok(records.pop()),
+            // v72 partial checkpoints could overwrite a direct owner's
+            // explicit fallback locator with a selected reference. Treat that
+            // stale alias as missing local authority so sync-mode callers can
+            // demand the encoded direct owner instead of accepting the
+            // checkpoint copy as canonical.
+            Err(error)
+                if direct_change_locator(change_id).is_some()
+                    && error.code == STALE_SELECTED_CHANGE_LOCATOR =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        };
     }
     Ok(None)
 }
@@ -8333,7 +8374,7 @@ where
         ),
         CommitDeltaPayload::SelectedRef(_) | CommitDeltaPayload::SelectedTombstone(_) => {
             return Err(LixError::new(
-                LixError::CODE_INTERNAL_ERROR,
+                STALE_SELECTED_CHANGE_LOCATOR,
                 format!(
                     "tracked_state authoritative change locator for '{change_id}' points to a selected row"
                 ),

--- a/packages/lix/src/tracked_state/tree.rs
+++ b/packages/lix/src/tracked_state/tree.rs
@@ -2224,14 +2224,10 @@ where
 }
 
 fn duplicate_root_insert_error(delta: &TrackedStateDeltaRef<'_>) -> LixError {
-    let row_pk = delta
-        .row_pk
-        .as_json_array_text()
-        .unwrap_or_else(|_| "<invalid row_pk>".to_string());
     LixError::new(
         LixError::CODE_UNIQUE,
         format!(
-            "primary-key constraint violation on schema '{}': INSERT would duplicate row_pk '{row_pk}'",
+            "primary-key constraint violation on schema '{}': INSERT would duplicate a primary key",
             delta.schema_key
         ),
     )

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -5159,19 +5159,18 @@ fn selected_tracked_ref_untracked_collision_error(
     branch_id: &str,
     identity: &TrackedStateKey,
 ) -> LixError {
+    let row_ref = crate::row_ref::schema_identity_detail(&identity.schema_key, &identity.row_pk);
     LixError::new(
         LixError::CODE_MERGE_CONFLICT,
         format!(
-            "cannot publish selected tracked change on branch '{branch_id}': it conflicts with an untracked current row for schema '{}' row_pk {:?}",
-            identity.schema_key, identity.row_pk
+            "cannot publish selected tracked change on branch '{branch_id}': row_ref {row_ref} conflicts with an untracked current row"
         ),
     )
     .with_hint("Resolve the tracked and untracked identity conflict before retrying.")
     .with_details(serde_json::json!({
         "kind": "trackedUntrackedIdentityCollision",
         "branchId": branch_id,
-        "schemaKey": &identity.schema_key,
-        "rowPk": &identity.row_pk,
+        "rowRef": row_ref,
         "fileId": &identity.file_id,
     }))
 }

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -2191,15 +2191,6 @@ async fn stage_tracked_commit_delta_index(
             } else {
                 None
             };
-        let authored_change_ids = state_row_indices
-            .iter()
-            .filter_map(|&row_index| {
-                let row = state_rows.row(row_index);
-                (!row.addressable_change_id)
-                    .then_some(row.change_id)
-                    .flatten()
-            })
-            .collect::<std::collections::HashSet<_>>();
         let staged = if let Some(source_commit_id) = selected_source_alias {
             deltas.truncate(state_row_indices.len());
             addressable.truncate(state_row_indices.len());
@@ -2214,12 +2205,6 @@ async fn stage_tracked_commit_delta_index(
         };
         inventories.insert(root.commit_id, staged.mutation_inventory().clone());
         drop(deltas);
-        let assigned_change_ids = staged
-            .assigned_change_ids
-            .iter()
-            .copied()
-            .filter(|change_id| *change_id != ChangeId::default())
-            .collect::<std::collections::HashSet<_>>();
         for (source_index, &row_index) in state_row_indices.iter().enumerate() {
             if !state_rows.row(row_index).addressable_change_id {
                 continue;
@@ -2233,15 +2218,7 @@ async fn stage_tracked_commit_delta_index(
             }
             state_rows.set_change_id(row_index, Some(change_id));
         }
-        let authored_locators = staged
-            .locators
-            .into_iter()
-            .filter(|locator| {
-                authored_change_ids.contains(&locator.change_id)
-                    || assigned_change_ids.contains(&locator.change_id)
-            })
-            .collect::<Vec<_>>();
-        stage_change_locators(writes, &authored_locators);
+        stage_change_locators(writes, &staged.authored_locators);
     }
     Ok(StagedCommitDeltaIndex {
         ordered_addressable_commits,
@@ -3444,14 +3421,10 @@ fn apply_lifecycle_tracked_snapshot_row(
 }
 
 fn lifecycle_duplicate_tracked_row_error(key: &TrackedStateKey) -> LixError {
-    let row_pk = key
-        .row_pk
-        .as_json_array_text()
-        .unwrap_or_else(|_| "<invalid row_pk>".to_string());
     LixError::new(
         LixError::CODE_UNIQUE,
         format!(
-            "primary-key constraint violation on schema '{}': INSERT would duplicate row_pk '{row_pk}'",
+            "primary-key constraint violation on schema '{}': INSERT would duplicate a primary key",
             key.schema_key
         ),
     )

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -88,6 +88,7 @@ struct CommitCoordinatorStats {
     cohort_count: AtomicUsize,
     commit_count: AtomicUsize,
     max_cohort_size: AtomicUsize,
+    checkpoint_gc_post_commit_hooks: AtomicUsize,
 }
 
 impl<StorageImpl> CommitCoordinator<StorageImpl>
@@ -130,6 +131,22 @@ where
             .checkpoint_gc_running
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_checkpoint_gc_post_commit_hook(&self) {
+        self.inner
+            .stats
+            .checkpoint_gc_post_commit_hooks
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn checkpoint_gc_post_commit_hooks(&self) -> usize {
+        self.inner
+            .stats
+            .checkpoint_gc_post_commit_hooks
+            .load(Ordering::Relaxed)
     }
 
     /// Process-local fallback when even the durable failure counter loses its
@@ -342,8 +359,10 @@ where
                 .map(|request| request.tracing_dispatch.clone());
             let mut senders = Vec::with_capacity(transaction_count);
             let mut inputs = Vec::with_capacity(cohort.len());
+            let mut checkpoint_gc_sequences = Vec::with_capacity(cohort.len());
             for request in cohort {
                 senders.push((request.result, request._capacity));
+                checkpoint_gc_sequences.push(request.transaction.checkpoint_gc_sequence());
                 inputs.push((request.transaction, request.runtime_functions));
             }
             let commit_and_notify = async {
@@ -376,8 +395,15 @@ where
                 Some(context) => Box::pin(context.instrument(commit_and_notify)).await,
                 None => Box::pin(commit_and_notify).await,
             };
-            for outcome in outcomes.iter_mut().flatten() {
-                *outcome = TransactionCommitOutcome::default();
+            for (outcome, checkpoint_gc_sequence) in
+                outcomes.iter_mut().zip(checkpoint_gc_sequences)
+            {
+                if let Ok(outcome) = outcome {
+                    *outcome = TransactionCommitOutcome {
+                        checkpoint_gc_sequence,
+                        ..TransactionCommitOutcome::default()
+                    };
+                }
             }
             debug_assert_eq!(outcomes.len(), senders.len());
             for ((sender, _capacity), outcome) in senders.into_iter().zip(outcomes) {

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -27,8 +27,8 @@ use crate::branch::{
     BranchOperation, BranchRefReader, BranchReferenceRole, branch_ref_stage_row,
 };
 use crate::catalog::{
-    CatalogContext, CatalogFingerprint, CatalogRevision, CatalogSnapshot, SchemaPlanId,
-    load_catalog_revision, stage_catalog_revision,
+    CatalogContext, CatalogFingerprint, CatalogRevision, CatalogSnapshot, ForeignKeyPlan,
+    SchemaPlan, SchemaPlanId, load_catalog_revision, stage_catalog_revision,
 };
 use crate::changelog::{
     ChangeId, ChangeRecord, ChangeRecordProjection, ChangelogReader, CommitId, CommitLoadRequest,
@@ -8163,7 +8163,7 @@ where
     pub(crate) fn plugin_schema_plan(
         &self,
         schema_key: &str,
-    ) -> Option<&crate::catalog::SchemaPlan> {
+    ) -> Option<&SchemaPlan> {
         self.sql_schema_snapshot
             .plan_for_key(schema_key)
             .map(|(_, plan)| plan)
@@ -8788,7 +8788,9 @@ where
         let catalog = self.sql_public_catalog()?;
         let mut schema_selections = BTreeMap::<&str, BTreeMap<RowPk, usize>>::new();
         let mut file_selections = BTreeMap::new();
+        let mut directory_selections = BTreeMap::new();
         let mut file_descriptor_row_pks = Vec::new();
+        let mut directory_descriptor_row_pks = Vec::new();
         for (index, selection) in selections.iter().enumerate() {
             match selection.relation.as_str() {
                 "lix_file" => {
@@ -8813,10 +8815,27 @@ where
                     file_selections.insert(file_id, index);
                 }
                 "lix_directory" => {
-                    return Err(LixError::new(
-                        LixError::CODE_UNSUPPORTED_SQL,
-                        "lix_directory command selections require recursive foreign-key closure and are not supported yet",
-                    ));
+                    let directory_id = selection.row_pk.as_single_string_owned().map_err(|_| {
+                        LixError::new(
+                            LixError::CODE_TYPE_MISMATCH,
+                            "lix_directory selections require a single directory-id primary key",
+                        )
+                    })?;
+                    let JsonValue::Array(parts) = selection.row_pk.as_json_array_value()? else {
+                        unreachable!("RowPk always serializes as a JSON array")
+                    };
+                    let descriptor_row_pk =
+                        RowPk::from_json_values(&parts, &[crate::row_pk::RowPkComponentType::Uuid])
+                            .map_err(|error| {
+                                LixError::new(
+                                    LixError::CODE_TYPE_MISMATCH,
+                                    format!(
+                                        "lix_directory row reference must contain a UUID directory id: {error}"
+                                    ),
+                                )
+                            })?;
+                    directory_descriptor_row_pks.push(descriptor_row_pk);
+                    directory_selections.insert(directory_id, index);
                 }
                 relation => {
                     let spec = catalog.schema_spec(relation).ok_or_else(|| {
@@ -8843,33 +8862,19 @@ where
                 }
             }
         }
-        if !schema_selections.is_empty() && !file_selections.is_empty() {
-            return Err(LixError::new(
-                LixError::CODE_UNSUPPORTED_SQL,
-                "diff commands do not support mixing lix_file and schema relation selections",
-            ));
-        }
-
         let mut requests = Vec::new();
-        if file_selections.is_empty() {
-            let schema_keys = schema_selections
-                .keys()
-                .map(|relation| (*relation).to_string())
-                .collect();
-            let row_pks = schema_selections
-                .values()
-                .flat_map(|rows| rows.keys().cloned())
-                .collect();
+        for (relation, rows) in &schema_selections {
             requests.push(TrackedStateDiffRequest {
                 filter: TrackedStateFilter {
-                    schema_keys,
-                    row_pks,
+                    schema_keys: vec![(*relation).to_string()],
+                    row_pks: rows.keys().cloned().collect(),
                     include_tombstones: true,
                     ..TrackedStateFilter::default()
                 },
                 retain_payloads: false,
             });
-        } else {
+        }
+        if !file_selections.is_empty() {
             requests.push(TrackedStateDiffRequest {
                 filter: TrackedStateFilter {
                     file_ids: file_selections
@@ -8891,16 +8896,29 @@ where
                 },
                 retain_payloads: false,
             });
-            if command == DiffCommand::CreateCheckpoint {
-                requests.push(TrackedStateDiffRequest {
-                    filter: TrackedStateFilter {
-                        schema_keys: vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
-                        include_tombstones: true,
-                        ..TrackedStateFilter::default()
-                    },
-                    retain_payloads: false,
-                });
-            }
+        }
+        if !directory_selections.is_empty() {
+            requests.push(TrackedStateDiffRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+                    row_pks: directory_descriptor_row_pks,
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+                retain_payloads: false,
+            });
+        }
+        if command == DiffCommand::CreateCheckpoint
+            && (!file_selections.is_empty() || !directory_selections.is_empty())
+        {
+            requests.push(TrackedStateDiffRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec![DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string()],
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+                retain_payloads: false,
+            });
         }
 
         let source = selections
@@ -8969,8 +8987,14 @@ where
         }
 
         let selected_directory_ids =
-            if command == DiffCommand::CreateCheckpoint && !file_selections.is_empty() {
-                self.selected_file_directory_closure(&entries, &file_selections)
+            if command == DiffCommand::CreateCheckpoint
+                && (!file_selections.is_empty() || !directory_selections.is_empty())
+            {
+                self.selected_directory_closure(
+                    &entries,
+                    &file_selections,
+                    &directory_selections,
+                )
                     .await?
             } else {
                 BTreeSet::new()
@@ -9005,13 +9029,14 @@ where
                 selected = true;
             }
             if entry.identity.schema_key() == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
-                && entry
-                    .identity
-                    .row_pk()
-                    .as_single_string_owned()
-                    .is_ok_and(|directory_id| selected_directory_ids.contains(&directory_id))
             {
-                selected = true;
+                if let Ok(directory_id) = entry.identity.row_pk().as_single_string_owned() {
+                    if let Some(index) = directory_selections.get(directory_id.as_str()) {
+                        matched.insert(*index);
+                        selected = true;
+                    }
+                    selected |= selected_directory_ids.contains(&directory_id);
+                }
             }
             if selected {
                 resolved.push(entry.diff_id()?);
@@ -9027,10 +9052,11 @@ where
 
     /// Includes only changed, live ancestors of selected file descriptors.
     /// Unrelated dirty directories remain in the unselected working interval.
-    async fn selected_file_directory_closure(
+    async fn selected_directory_closure(
         &mut self,
         entries: &[TrackedStateDiffEntry],
         file_selections: &BTreeMap<String, usize>,
+        directory_selections: &BTreeMap<String, usize>,
     ) -> Result<BTreeSet<String>, LixError> {
         if !entries.iter().any(|entry| {
             entry.identity.schema_key() == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
@@ -9049,7 +9075,14 @@ where
                     .is_ok_and(|file_id| file_selections.contains_key(&file_id));
             let live_directory = entry.identity.schema_key() == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
                 && entry.kind != TrackedStateDiffKind::Removed;
-            if (selected_file_descriptor || live_directory)
+            let selected_directory_descriptor = entry.identity.schema_key()
+                == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                && entry
+                    .identity
+                    .row_pk()
+                    .as_single_string_owned()
+                    .is_ok_and(|directory_id| directory_selections.contains_key(&directory_id));
+            if (selected_file_descriptor || selected_directory_descriptor || live_directory)
                 && let Some(after) = entry.after.as_ref().filter(|after| !after.deleted)
             {
                 change_ids.insert(after.change_id);
@@ -9125,6 +9158,7 @@ where
             }
         }
         let mut selected = BTreeSet::new();
+        file_parents.extend(directory_selections.keys().cloned());
         for mut directory_id in file_parents {
             while selected.insert(directory_id.clone()) {
                 let Some(Some(parent_id)) = directory_parents.get(&directory_id) else {
@@ -9134,12 +9168,6 @@ where
             }
         }
         Ok(selected)
-    }
-
-    pub(crate) async fn execute_full_checkpoint_command(
-        &mut self,
-    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
-        self.execute_checkpoint_plan(None).await
     }
 
     pub(crate) async fn execute_checkpoint_function(
@@ -9256,7 +9284,16 @@ where
                         "scoped checkpoint selection cannot be empty",
                     ));
                 }
-                let closed = close_and_validate_checkpoint_selection(&diff.entries, requested)?;
+                let (before_snapshots, after_snapshots) = self
+                    .checkpoint_dependency_snapshots(&diff.entries)
+                    .await?;
+                let closed = close_and_validate_checkpoint_selection(
+                    &diff.entries,
+                    requested,
+                    self.tracked_schema_snapshot.as_ref(),
+                    &before_snapshots,
+                    &after_snapshots,
+                )?;
                 let rows_affected = u64::try_from(requested_count).map_err(|_| {
                     LixError::new(
                         LixError::CODE_INTERNAL_ERROR,
@@ -9383,6 +9420,84 @@ where
         diff_ids: Vec<String>,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
         self.execute_checkpoint_plan(Some(diff_ids)).await
+    }
+
+    async fn checkpoint_dependency_snapshots(
+        &mut self,
+        entries: &[TrackedStateDiffEntry],
+    ) -> Result<(BTreeMap<String, JsonValue>, BTreeMap<String, JsonValue>), LixError> {
+        let changes = entries
+            .iter()
+            .map(|entry| {
+                Ok((
+                    entry.diff_id()?,
+                    entry
+                        .before
+                        .as_ref()
+                        .filter(|before| !before.deleted)
+                        .map(|before| before.change_id),
+                    entry
+                        .after
+                        .as_ref()
+                        .filter(|after| !after.deleted)
+                        .map(|after| after.change_id),
+                ))
+            })
+            .collect::<Result<Vec<_>, LixError>>()?;
+        if changes.is_empty() {
+            return Ok((BTreeMap::new(), BTreeMap::new()));
+        }
+        let read = SharedStorageAdapterRead::new(
+            self.storage.begin_read(StorageReadOptions::default()).await?,
+        );
+        let change_ids = changes
+            .iter()
+            .flat_map(|(_, before, after)| [*before, *after])
+            .flatten()
+            .collect::<BTreeSet<_>>();
+        let mut records = load_change_records(&read, change_ids.into_iter()).await?;
+        let payloads = materialize_known_change_payloads(
+            records.drain().map(|(_, record)| record),
+            ChangeRecordProjection {
+                snapshot_content: true,
+                metadata: false,
+                snapshot: false,
+                raw_snapshot: false,
+            },
+        )?;
+        let snapshots_by_change_id = payloads
+            .into_iter()
+            .filter_map(|(change_id, payload)| payload.snapshot_content.map(|value| (change_id, value)))
+            .map(|(change_id, snapshot)| {
+                serde_json::from_str(snapshot.as_ref())
+                    .map(|snapshot| (change_id, snapshot))
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!("checkpoint dependency snapshot is invalid JSON: {error}"),
+                        )
+                    })
+            })
+            .collect::<Result<HashMap<_, JsonValue>, LixError>>()?;
+        let load = |change_id: ChangeId| {
+            snapshots_by_change_id.get(&change_id).cloned().ok_or_else(|| {
+                LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("checkpoint dependency row '{change_id}' has no snapshot"),
+                )
+            })
+        };
+        let mut before_snapshots = BTreeMap::new();
+        let mut after_snapshots = BTreeMap::new();
+        for (diff_id, before, after) in changes {
+            if let Some(change_id) = before {
+                before_snapshots.insert(diff_id.clone(), load(change_id)?);
+            }
+            if let Some(change_id) = after {
+                after_snapshots.insert(diff_id, load(change_id)?);
+            }
+        }
+        Ok((before_snapshots, after_snapshots))
     }
 
     pub(crate) async fn execute_diff_command_query_owned(
@@ -9901,6 +10016,9 @@ fn parse_materialized_diff_json(
 fn close_and_validate_checkpoint_selection(
     entries: &[TrackedStateDiffEntry],
     requested: BTreeSet<String>,
+    catalog: &CatalogSnapshot,
+    before_snapshots: &BTreeMap<String, JsonValue>,
+    after_snapshots: &BTreeMap<String, JsonValue>,
 ) -> Result<BTreeSet<String>, LixError> {
     let mut by_diff_id = BTreeMap::new();
     let mut registration_by_schema_key = BTreeMap::new();
@@ -9930,9 +10048,30 @@ fn close_and_validate_checkpoint_selection(
 
     let mut closed = requested;
     loop {
+        for diff_id in &closed {
+            let entry = by_diff_id
+                .get(diff_id)
+                .expect("closed checkpoint identity is indexed");
+            if entry.identity.schema_key() == REGISTERED_SCHEMA_KEY
+                && entry.after.as_ref().is_none_or(|after| after.deleted)
+            {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    "a scoped checkpoint cannot remove a schema registration; checkpoint the complete working set",
+                )
+                .with_details(serde_json::json!({
+                    "operation": "lix_create_checkpoint",
+                    "rowRef": crate::row_ref::encode(
+                        REGISTERED_SCHEMA_KEY,
+                        entry.identity.row_pk(),
+                    )?.as_str(),
+                })));
+            }
+        }
         let required_schema_keys = closed
             .iter()
             .filter_map(|diff_id| by_diff_id.get(diff_id))
+            .filter(|entry| entry.after.as_ref().is_some_and(|after| !after.deleted))
             .map(|entry| entry.identity.schema_key().to_string())
             .collect::<BTreeSet<_>>();
         let mut changed = false;
@@ -9957,12 +10096,206 @@ fn close_and_validate_checkpoint_selection(
                     ),
                 )
                 .with_details(serde_json::json!({
-                    "operation": "createCheckpoint",
+                    "operation": "lix_create_checkpoint",
+                    "rowRef": crate::row_ref::encode(schema_key.as_str(), registration.identity.row_pk())?.as_str(),
                     "schemaKey": schema_key,
-                    "dependency": REGISTERED_SCHEMA_KEY,
                 })));
             }
             changed |= closed.insert(registration_diff_id.clone());
+        }
+
+        // Follow declared foreign keys when the referenced row also changed
+        // in this working interval. An unchanged target is already present in
+        // the checkpoint baseline; a changed target must cross the boundary
+        // with the selected child.
+        let selected_now = closed.iter().cloned().collect::<Vec<_>>();
+        for selected_diff_id in selected_now {
+            let Some(snapshot) = after_snapshots.get(&selected_diff_id) else {
+                continue;
+            };
+            let entry = by_diff_id
+                .get(&selected_diff_id)
+                .expect("closed diff identity is indexed");
+            let Some((_, source_plan)) = catalog.plan_for_key(entry.identity.schema_key()) else {
+                continue;
+            };
+            for foreign_key in &source_plan.foreign_keys {
+                let Some((_, target_plan)) =
+                    catalog.plan_for_key(&foreign_key.referenced_schema.schema_key)
+                else {
+                    return Err(LixError::new(
+                        LixError::CODE_CONSTRAINT_VIOLATION,
+                        format!(
+                            "checkpoint dependency target schema '{}' is not visible",
+                            foreign_key.referenced_schema.schema_key
+                        ),
+                    ));
+                };
+                if target_plan.primary_key.as_ref() != Some(&foreign_key.referenced_properties) {
+                    // Non-primary unique references are valid Lix schemas, but
+                    // resolving them requires a value-index lookup rather than
+                    // row identity. The complete working diff still lets us
+                    // close over a changed live target by comparing its
+                    // projected unique tuple.
+                    let Some(local_values) = checkpoint_json_pointer_values(
+                        snapshot,
+                        &foreign_key.local_properties,
+                    ) else {
+                        continue;
+                    };
+                    for (target_diff_id, target_entry) in &by_diff_id {
+                        if target_entry.identity.schema_key()
+                            != foreign_key.referenced_schema.schema_key
+                        {
+                            continue;
+                        }
+                        let Some(target_snapshot) = after_snapshots.get(target_diff_id) else {
+                            continue;
+                        };
+                        if checkpoint_json_pointer_values(
+                            target_snapshot,
+                            &foreign_key.referenced_properties,
+                        ) == Some(local_values.clone())
+                        {
+                            changed |= closed.insert(target_diff_id.clone());
+                        }
+                    }
+                    continue;
+                }
+                let Some(local_values) = checkpoint_json_pointer_values(
+                    snapshot,
+                    &foreign_key.local_properties,
+                ) else {
+                    continue;
+                };
+                let Some(component_types) = target_plan.primary_key_component_types.as_ref() else {
+                    return Err(LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "foreign-key target has no primary-key component types",
+                    ));
+                };
+                let target_row_pk = RowPk::from_json_values(&local_values, component_types)
+                    .map_err(|error| {
+                        LixError::new(
+                            LixError::CODE_CONSTRAINT_VIOLATION,
+                            format!("checkpoint foreign-key value is invalid: {error}"),
+                        )
+                    })?;
+                if let Some((target_diff_id, target_entry)) = by_diff_id.iter().find(|(_, target)| {
+                    target.identity.schema_key() == foreign_key.referenced_schema.schema_key
+                        && target.identity.row_pk() == &target_row_pk
+                }) {
+                    if target_entry
+                        .after
+                        .as_ref()
+                        .is_none_or(|after| after.deleted)
+                    {
+                        return Err(LixError::new(
+                            LixError::CODE_CONSTRAINT_VIOLATION,
+                            format!(
+                                "checkpoint selection references removed row '{} {:?}'",
+                                foreign_key.referenced_schema.schema_key,
+                                target_row_pk
+                            ),
+                        ));
+                    }
+                    changed |= closed.insert(target_diff_id.clone());
+                }
+            }
+        }
+
+        // Closing only outbound references is insufficient for deletes and
+        // referenced-unique-key changes. If a selected target stops satisfying
+        // a foreign key, every changed child that used the old target must
+        // cross the checkpoint boundary as well so the baseline never retains
+        // the old child beside the new target state.
+        let selected_targets = closed.iter().cloned().collect::<Vec<_>>();
+        for target_diff_id in selected_targets {
+            let target_entry = by_diff_id
+                .get(&target_diff_id)
+                .expect("closed checkpoint identity is indexed");
+            let target_before = before_snapshots.get(&target_diff_id);
+            for (child_diff_id, child_entry) in &by_diff_id {
+                let Some((_, child_plan)) = catalog.plan_for_key(child_entry.identity.schema_key())
+                else {
+                    continue;
+                };
+                for foreign_key in &child_plan.foreign_keys {
+                    if foreign_key.referenced_schema.schema_key
+                        != target_entry.identity.schema_key()
+                    {
+                        continue;
+                    }
+                    let Some((_, target_plan)) =
+                        catalog.plan_for_key(target_entry.identity.schema_key())
+                    else {
+                        continue;
+                    };
+                    let target_removed = target_entry
+                        .after
+                        .as_ref()
+                        .is_none_or(|after| after.deleted);
+                    let target_key_changed = if target_plan.primary_key.as_ref()
+                        == Some(&foreign_key.referenced_properties)
+                    {
+                        false
+                    } else {
+                        match (target_before, after_snapshots.get(&target_diff_id)) {
+                            (Some(before), Some(after)) => {
+                                checkpoint_json_pointer_values(
+                                    before,
+                                    &foreign_key.referenced_properties,
+                                ) != checkpoint_json_pointer_values(
+                                    after,
+                                    &foreign_key.referenced_properties,
+                                )
+                            }
+                            _ => target_removed,
+                        }
+                    };
+                    if !target_removed && !target_key_changed {
+                        continue;
+                    }
+                    let Some(child_before) = before_snapshots.get(child_diff_id) else {
+                        continue;
+                    };
+                    if !checkpoint_foreign_key_references_target(
+                        child_before,
+                        foreign_key,
+                        target_entry,
+                        target_plan,
+                        target_before,
+                    )? {
+                        continue;
+                    }
+                    if let Some(child_after) = after_snapshots.get(child_diff_id)
+                        && checkpoint_foreign_key_references_target(
+                            child_after,
+                            foreign_key,
+                            target_entry,
+                            target_plan,
+                            target_before,
+                        )?
+                    {
+                        return Err(LixError::new(
+                            LixError::CODE_CONSTRAINT_VIOLATION,
+                            "checkpoint selection would retain a row that references a removed dependency",
+                        )
+                        .with_details(serde_json::json!({
+                            "operation": "lix_create_checkpoint",
+                            "rowRef": crate::row_ref::encode(
+                                child_entry.identity.schema_key(),
+                                child_entry.identity.row_pk(),
+                            )?.as_str(),
+                            "dependencyRowRef": crate::row_ref::encode(
+                                target_entry.identity.schema_key(),
+                                target_entry.identity.row_pk(),
+                            )?.as_str(),
+                        })));
+                    }
+                    changed |= closed.insert(child_diff_id.clone());
+                }
+            }
         }
         if !changed {
             break;
@@ -9986,13 +10319,64 @@ fn close_and_validate_checkpoint_selection(
                 ),
             )
             .with_details(serde_json::json!({
-                "operation": "createCheckpoint",
+                "operation": "lix_create_checkpoint",
+                "rowRef": crate::row_ref::encode(schema_key, entry.identity.row_pk())?.as_str(),
                 "schemaKey": schema_key,
-                "dependency": REGISTERED_SCHEMA_KEY,
             })));
         }
     }
     Ok(closed)
+}
+
+fn checkpoint_foreign_key_references_target(
+    child_snapshot: &JsonValue,
+    foreign_key: &ForeignKeyPlan,
+    target_entry: &TrackedStateDiffEntry,
+    target_plan: &SchemaPlan,
+    target_snapshot: Option<&JsonValue>,
+) -> Result<bool, LixError> {
+    let Some(local_values) =
+        checkpoint_json_pointer_values(child_snapshot, &foreign_key.local_properties)
+    else {
+        return Ok(false);
+    };
+    if target_plan.primary_key.as_ref() == Some(&foreign_key.referenced_properties) {
+        let component_types = target_plan.primary_key_component_types.as_ref().ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "foreign-key target has no primary-key component types",
+            )
+        })?;
+        let row_pk = RowPk::from_json_values(&local_values, component_types).map_err(|error| {
+            LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                format!("checkpoint foreign-key value is invalid: {error}"),
+            )
+        })?;
+        return Ok(&row_pk == target_entry.identity.row_pk());
+    }
+    Ok(target_snapshot.is_some_and(|target_snapshot| {
+        checkpoint_json_pointer_values(target_snapshot, &foreign_key.referenced_properties)
+            == Some(local_values)
+    }))
+}
+
+fn checkpoint_json_pointer_values(
+    snapshot: &JsonValue,
+    pointers: &[Vec<String>],
+) -> Option<Vec<JsonValue>> {
+    let mut values = Vec::with_capacity(pointers.len());
+    for pointer in pointers {
+        let mut value = snapshot;
+        for segment in pointer {
+            value = value.get(segment)?;
+        }
+        if value.is_null() {
+            return None;
+        }
+        values.push(value.clone());
+    }
+    Some(values)
 }
 
 fn push_checkpoint_selected_change(
@@ -11960,7 +12344,7 @@ fn v2_host_changes_from_prepared_rows(
 }
 
 fn typed_key_from_row_pk(
-    plan: &crate::catalog::SchemaPlan,
+    plan: &SchemaPlan,
     schema_key: &str,
     row_pk: &RowPk,
 ) -> Result<(WasmRowKey, Vec<lix_schema::Value>), LixError> {

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -9346,32 +9346,27 @@ where
         let result = self
             .execute_read_sql_statement(query_sql, statement, params)
             .await?;
-        if result.columns.len() != 2 {
+        if result.columns.len() != 1 {
             return Err(LixError::new(
                 LixError::CODE_TYPE_MISMATCH,
                 format!(
-                    "diff command query must return relation and row_pk, got {} columns",
+                    "diff command query must return exactly one row_ref column, got {} columns",
                     result.columns.len()
                 ),
             ));
         }
         let mut selections = Vec::with_capacity(result.rows.len());
         for row in result.rows {
-            let [Value::Text(relation), Value::Jsonb(row_pk)] = row.as_slice() else {
+            let [Value::RowRef(row_ref)] = row.as_slice() else {
                 return Err(LixError::new(
                     LixError::CODE_TYPE_MISMATCH,
-                    "diff command query must return non-null relation text and JSONB row_pk values",
+                    "diff command query must return one non-null lix_row_ref value",
                 ));
             };
-            let row_pk = RowPk::from_json_array_text(&row_pk.to_string()).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    format!("row_pk must be a JSON primary-key array: {error}"),
-                )
-            })?;
+            let resolved = crate::row_ref::decode(row_ref)?;
             selections.push(DiffCommandSelection {
-                relation: relation.clone(),
-                row_pk,
+                relation: resolved.relation,
+                row_pk: resolved.row_pk,
                 source_commits: source_commits.clone(),
             });
         }

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -35,7 +35,7 @@ use crate::changelog::{
     load_change_records, materialize_known_change_payloads,
 };
 use crate::checkpoint::{
-    CHECKPOINT_SCHEMA_KEY, checkpoint_commit_id_at_head, checkpoint_stage_row,
+    CHECKPOINT_SCHEMA_KEY, checkpoint_stage_row,
 };
 use crate::commit_graph::{CommitGraphContext, CommitGraphStoreReader};
 use crate::common::{LixTimestamp, SharedStr};
@@ -971,6 +971,10 @@ impl<StorageImpl> Transaction<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    pub(crate) fn checkpoint_gc_sequence(&self) -> Option<u64> {
+        self.pending_checkpoint_gc_sequence
+    }
+
     pub(crate) fn stage_atomic_cas_publication(
         &mut self,
         writes: StorageWriteSet,
@@ -8334,16 +8338,6 @@ where
             .reader(SharedStorageAdapterRead::new(read)))
     }
 
-    /// Returns the private compaction cursor bound to this transaction's
-    /// retained opening read and the caller-observed branch head.
-    pub(crate) async fn checkpoint_commit_id_at_head(
-        &mut self,
-        branch_id: &str,
-        head_commit_id: CommitId,
-    ) -> Result<CommitId, LixError> {
-        checkpoint_commit_id_at_head(self.opening_read(), branch_id, head_commit_id).await
-    }
-
     pub(crate) async fn is_current_checkpoint_commit(
         &mut self,
         branch_id: &str,
@@ -9455,7 +9449,26 @@ where
             .flat_map(|(_, before, after)| [*before, *after])
             .flatten()
             .collect::<BTreeSet<_>>();
-        let mut records = load_change_records(&read, change_ids.into_iter()).await?;
+        let packed_records = futures_util::future::try_join_all(
+            change_ids.iter().copied().map(|change_id| {
+                let read = &read;
+                async move {
+                    crate::tracked_state::load_change_record_by_id(read, change_id)
+                        .await
+                        .map(|record| (change_id, record))
+                }
+            }),
+        )
+        .await?;
+        let mut records = packed_records
+            .into_iter()
+            .filter_map(|(change_id, record)| record.map(|record| (change_id, record)))
+            .collect::<HashMap<_, _>>();
+        let missing = change_ids
+            .into_iter()
+            .filter(|change_id| !records.contains_key(change_id))
+            .collect::<Vec<_>>();
+        records.extend(load_change_records(&read, missing.into_iter()).await?);
         let payloads = materialize_known_change_payloads(
             records.drain().map(|(_, record)| record),
             ChangeRecordProjection {

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -153,6 +153,7 @@ mod cohort;
 pub(crate) struct TransactionCommitOutcome {
     pub(crate) storage_stats: StorageWriteSetStats,
     pub(crate) commit_cohort_id: Option<String>,
+    pub(crate) checkpoint_gc_sequence: Option<u64>,
 }
 
 fn typed_transaction_validation_counters(rows: &RawWriteBatch) -> WasmTransitionCounters {
@@ -723,6 +724,7 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     session_file_views: SessionFileViews,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     pending_plugin_actor_publications: Vec<PendingPluginActorPublication>,
+    pending_checkpoint_gc_sequence: Option<u64>,
     /// Explicit historical branch sources whose branchability may be owned by
     /// one still-pending authenticated checkpoint replacement. Resolution is
     /// delayed to the coherent commit-boundary read so its queue observation
@@ -827,6 +829,7 @@ pub(crate) struct SqlStatementCheckpoint {
     filesystem_path_index_epoch: usize,
     pending_file_view_mutations: BTreeMap<SessionFileViewKey, SessionFileViewMutation>,
     trust_filesystem_planner: bool,
+    pending_checkpoint_gc_sequence: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -1694,6 +1697,7 @@ where
                     session_file_views,
                     pending_file_view_mutations: BTreeMap::new(),
                     pending_plugin_actor_publications: Vec::new(),
+                    pending_checkpoint_gc_sequence: None,
                     pending_branch_checkpoint_replacements: BTreeMap::new(),
                     pending_restore_targets: BTreeMap::new(),
                     plugin_generation_read_guard: None,
@@ -2186,6 +2190,7 @@ where
         Ok(TransactionCommitOutcome {
             storage_stats,
             commit_cohort_id: Some(commit_cohort_id),
+            checkpoint_gc_sequence: transaction.pending_checkpoint_gc_sequence,
         })
     }
 
@@ -2301,6 +2306,7 @@ where
             filesystem_path_index_epoch: self.filesystem_path_index_epoch.load(Ordering::SeqCst),
             pending_file_view_mutations: self.pending_file_view_mutations.clone(),
             trust_filesystem_planner: self.trust_filesystem_planner,
+            pending_checkpoint_gc_sequence: self.pending_checkpoint_gc_sequence,
         })
     }
 
@@ -2315,6 +2321,7 @@ where
             filesystem_path_index_epoch,
             pending_file_view_mutations,
             trust_filesystem_planner,
+            pending_checkpoint_gc_sequence,
         } = checkpoint;
         self.staged_writes.restore(staged_writes)?;
         self.filesystem_path_index_epoch
@@ -2324,6 +2331,7 @@ where
         self.filesystem_path_index_cache.clear();
         self.pending_file_view_mutations = pending_file_view_mutations;
         self.trust_filesystem_planner = trust_filesystem_planner;
+        self.pending_checkpoint_gc_sequence = pending_checkpoint_gc_sequence;
         // A failed statement may have chained a predecessor actor successor.
         // Its prior document can no longer be restored byte-for-byte, so
         // conservatively discard all unpublished actor cache work. The staged
@@ -7303,6 +7311,9 @@ where
         sql: &str,
         statement: &DataFusionStatement,
     ) -> Result<crate::sql2::SqlLogicalPlan, LixError> {
+        if let Some(plan) = crate::sql2::checkpoint_function_plan(statement)? {
+            return Ok(crate::sql2::SqlLogicalPlan::Checkpoint(plan));
+        }
         let fingerprint = self.sql_catalog_fingerprint();
         if let Some(plan) =
             self.sql_planning_cache
@@ -9128,55 +9139,58 @@ where
     pub(crate) async fn execute_full_checkpoint_command(
         &mut self,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
-        let branch_id = self.active_branch_id.clone();
-        let (previous_recovery, mut gc_state) =
-            self.checkpoint_publication_state(&branch_id).await?;
-        let head_commit_id = self
-            .load_branch_head(&branch_id)
-            .await?
-            .ok_or_else(|| LixError::branch_not_found(&branch_id, "create checkpoint", "target"))?;
-        let previous_checkpoint_commit_id = self
-            .checkpoint_commit_id_at_head(&branch_id, head_commit_id)
-            .await?;
-        let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
-        gc_state.checkpoint_sequence =
-            gc_state.checkpoint_sequence.checked_add(1).ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "checkpoint sequence overflow",
-                )
-            })?;
-        if let Some(previous_recovery) = previous_recovery {
-            gc_state.add_collectible_interval(previous_recovery.interval_has_commits);
-        }
-        let commit_id = self.stage_checkpoint_boundary_commit(
-            branch_id,
-            previous_checkpoint_commit_id,
-            head_commit_id,
-            interval_has_commits,
-            gc_state,
-        )?;
-        let checkpoint_commit_id = CommitId::parse_lix(&commit_id, "checkpoint commit id")?;
-        let mut checkpoint_rows = RawWriteBatch::with_capacity(1);
-        checkpoint_rows.push(checkpoint_stage_row(
-            &checkpoint_commit_id,
-            self.functions.call_uuid_v7().to_string(),
-        ));
-        self.stage_write(TransactionWrite::Rows {
-            mode: TransactionWriteMode::Replace,
-            rows: checkpoint_rows,
-        })
-        .await?;
-        Ok(crate::sql2::DiffCommandOutcome {
-            rows_affected: 1,
-            commit_id: Some(commit_id),
-        })
+        self.execute_checkpoint_plan(None).await
     }
 
-    async fn execute_checkpoint_selection(
+    pub(crate) async fn execute_checkpoint_function(
         &mut self,
-        diff_ids: Vec<String>,
+        plan: crate::sql2::CheckpointFunctionPlan,
+        params: Vec<Value>,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        match plan {
+            crate::sql2::CheckpointFunctionPlan::Full => {
+                self.execute_checkpoint_plan(None).await
+            }
+            crate::sql2::CheckpointFunctionPlan::Empty => {
+                Ok(crate::sql2::DiffCommandOutcome {
+                    rows_affected: 0,
+                    commit_id: None,
+                })
+            }
+            crate::sql2::CheckpointFunctionPlan::SelectionQuery(query_sql) => {
+                self.execute_diff_command_query_owned(
+                    DiffCommand::CreateCheckpoint,
+                    query_sql,
+                    params,
+                )
+                .await
+            }
+        }
+    }
+
+    /// Plans and stages both full and scoped checkpoints through one path.
+    ///
+    /// `None` is the complete working interval. `Some` contains the private
+    /// diff identities resolved from public row references. Keeping the
+    /// publication mechanics below this boundary is load-bearing: full and
+    /// scoped checkpointing must rotate the same recovery root, advance the
+    /// same GC state, and publish the same logical checkpoint marker.
+    async fn execute_checkpoint_plan(
+        &mut self,
+        requested_diff_ids: Option<Vec<String>>,
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        if requested_diff_ids.as_ref().is_some_and(Vec::is_empty) {
+            return Ok(crate::sql2::DiffCommandOutcome {
+                rows_affected: 0,
+                commit_id: None,
+            });
+        }
+        if self.pending_checkpoint_gc_sequence.is_some() {
+            return Err(LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                "a transaction can create at most one checkpoint",
+            ));
+        }
         let branch_id = self.active_branch_id.clone();
         let (previous_recovery, mut gc_state) =
             self.checkpoint_publication_state(&branch_id).await?;
@@ -9202,70 +9216,97 @@ where
                     format!("branch '{branch_id}' has no checkpoint cursor"),
                 )
             })?;
-        let direct_diff = TrackedHeadContext::new()
-            .reader(self.opening_read())
-            .working_diff_for_control(&branch_id, control, &TrackedStateDiffRequest::default())
-            .await?;
-        let hot_working_diff_certified = direct_diff.is_some();
-        let diff = match direct_diff {
-            Some(direct) => direct.diff,
-            None => {
-                let mut tracked = self.tracked_state_reader().await?;
-                tracked
-                    .diff_commits(
-                        &previous_checkpoint_commit_id.to_string(),
-                        &head_commit_id.to_string(),
+        let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
+
+        let (selected, unselected, rows_affected, hot_working_diff_certified) =
+            if let Some(requested_diff_ids) = requested_diff_ids {
+                let direct_diff = TrackedHeadContext::new()
+                    .reader(self.opening_read())
+                    .working_diff_for_control(
+                        &branch_id,
+                        control,
                         &TrackedStateDiffRequest::default(),
                     )
-                    .await?
-            }
-        };
-        let requested = diff_ids.iter().cloned().collect::<BTreeSet<_>>();
-        if requested.len() != diff_ids.len() {
-            return Err(LixError::new(
-                LixError::CODE_CONSTRAINT_VIOLATION,
-                "checkpoint selection contains duplicate relation-row changes",
-            ));
-        }
-        let mut matched = BTreeSet::new();
-        let mut selected = StagedCommitChangeBatchBuilder::with_capacity(diff.entries.len());
-        let mut unselected = StagedCommitChangeBatchBuilder::with_capacity(diff.entries.len());
-        let mut selected_source_membership_exact = true;
-        let mut unselected_source_membership_exact = true;
-        for entry in diff.entries.into_iter().filter(|entry| {
-            entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
-                && entry.identity.schema_key() != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
-        }) {
-            let diff_id = entry.diff_id()?;
-            let target = entry.after.ok_or_else(|| {
-                LixError::new(
-                    LixError::CODE_INTERNAL_ERROR,
-                    "selected working relation row has no target change",
-                )
-            })?;
-            if requested.contains(&diff_id) {
-                matched.insert(diff_id);
-                selected_source_membership_exact &=
-                    push_checkpoint_selected_change(&mut selected, target, entry.kind);
+                    .await?;
+                let hot_working_diff_certified = direct_diff.is_some();
+                let diff = match direct_diff {
+                    Some(direct) => direct.diff,
+                    None => {
+                        let mut tracked = self.tracked_state_reader().await?;
+                        tracked
+                            .diff_commits(
+                                &previous_checkpoint_commit_id.to_string(),
+                                &head_commit_id.to_string(),
+                                &TrackedStateDiffRequest::default(),
+                            )
+                            .await?
+                    }
+                };
+                let requested_count = requested_diff_ids.len();
+                let requested = requested_diff_ids.into_iter().collect::<BTreeSet<_>>();
+                if requested.len() != requested_count {
+                    return Err(LixError::new(
+                        LixError::CODE_CONSTRAINT_VIOLATION,
+                        "checkpoint selection contains duplicate rows",
+                    ));
+                }
+                if requested.is_empty() {
+                    return Err(LixError::new(
+                        LixError::CODE_INVALID_PARAM,
+                        "scoped checkpoint selection cannot be empty",
+                    ));
+                }
+                let closed = close_and_validate_checkpoint_selection(&diff.entries, requested)?;
+                let rows_affected = u64::try_from(requested_count).map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "checkpoint selection exceeds u64",
+                    )
+                })?;
+                let mut matched = BTreeSet::new();
+                let mut selected = StagedCommitChangeBatchBuilder::with_capacity(diff.entries.len());
+                let mut unselected = StagedCommitChangeBatchBuilder::with_capacity(diff.entries.len());
+                let mut selected_source_membership_exact = true;
+                let mut unselected_source_membership_exact = true;
+                for entry in diff.entries.into_iter().filter(|entry| {
+                    entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
+                        && entry.identity.schema_key()
+                            != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
+                }) {
+                    let diff_id = entry.diff_id()?;
+                    let target = entry.after.ok_or_else(|| {
+                        LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            "working relation row has no target change",
+                        )
+                    })?;
+                    if closed.contains(&diff_id) {
+                        matched.insert(diff_id);
+                        selected_source_membership_exact &=
+                            push_checkpoint_selected_change(&mut selected, target, entry.kind);
+                    } else {
+                        unselected_source_membership_exact &=
+                            push_checkpoint_selected_change(&mut unselected, target, entry.kind);
+                    }
+                }
+                if matched != closed {
+                    return Err(stale_or_unknown_diff_id());
+                }
+                let selected = if selected_source_membership_exact {
+                    selected.finish_source_certified()
+                } else {
+                    selected.finish()
+                };
+                let unselected = if unselected_source_membership_exact {
+                    unselected.finish_source_certified()
+                } else {
+                    unselected.finish()
+                };
+                (Some(selected), Some(unselected), rows_affected, hot_working_diff_certified)
             } else {
-                unselected_source_membership_exact &=
-                    push_checkpoint_selected_change(&mut unselected, target, entry.kind);
-            }
-        }
-        let selected = if selected_source_membership_exact {
-            selected.finish_source_certified()
-        } else {
-            selected.finish()
-        };
-        let unselected = if unselected_source_membership_exact {
-            unselected.finish_source_certified()
-        } else {
-            unselected.finish()
-        };
-        if matched != requested {
-            return Err(stale_or_unknown_diff_id());
-        }
-        let interval_has_commits = head_commit_id != previous_checkpoint_commit_id;
+                (None, None, 1, false)
+            };
+
         gc_state.checkpoint_sequence =
             gc_state.checkpoint_sequence.checked_add(1).ok_or_else(|| {
                 LixError::new(
@@ -9276,44 +9317,54 @@ where
         if let Some(previous_recovery) = previous_recovery {
             gc_state.add_collectible_interval(previous_recovery.interval_has_commits);
         }
-
-        let checkpoint_commit_id = if unselected.is_empty() {
-            self.stage_checkpoint_commit(
+        self.pending_checkpoint_gc_sequence = Some(gc_state.checkpoint_sequence);
+        let commit_id = match (selected, unselected) {
+            (None, None) => self.stage_checkpoint_boundary_commit(
                 branch_id.clone(),
                 previous_checkpoint_commit_id,
                 head_commit_id,
                 interval_has_commits,
                 gc_state,
-                selected,
-                hot_working_diff_certified,
-            )?
-        } else {
-            let checkpoint_commit_id = self.staged_writes.stage_intermediate_commit(
-                branch_id.clone(),
-                previous_checkpoint_commit_id,
-                selected,
-            )?;
-            self.staged_writes
-                .stage_selected_commit_change_refs(branch_id.clone(), unselected)?;
-            self.staged_writes
-                .set_first_commit_parent(branch_id.clone(), checkpoint_commit_id)?;
-            self.staged_writes
-                .add_checkpoint_publication(CheckpointPublication {
-                    recovery_ref: CheckpointRecoveryRef {
-                        branch_id: branch_id.clone(),
-                        recovered_head_commit_id: head_commit_id,
-                        checkpoint_commit_id,
-                        interval_has_commits,
-                    },
+            )?,
+            (Some(selected), Some(unselected)) if unselected.is_empty() => self
+                .stage_checkpoint_commit(
+                    branch_id.clone(),
+                    previous_checkpoint_commit_id,
+                    head_commit_id,
+                    interval_has_commits,
                     gc_state,
+                    selected,
                     hot_working_diff_certified,
-                })?;
-            checkpoint_commit_id.to_string()
+                )?,
+            (Some(selected), Some(unselected)) => {
+                let checkpoint_commit_id = self.staged_writes.stage_intermediate_commit(
+                    branch_id.clone(),
+                    previous_checkpoint_commit_id,
+                    selected,
+                )?;
+                self.staged_writes
+                    .stage_selected_commit_change_refs(branch_id.clone(), unselected)?;
+                self.staged_writes
+                    .set_first_commit_parent(branch_id.clone(), checkpoint_commit_id)?;
+                self.staged_writes
+                    .add_checkpoint_publication(CheckpointPublication {
+                        recovery_ref: CheckpointRecoveryRef {
+                            branch_id: branch_id.clone(),
+                            recovered_head_commit_id: head_commit_id,
+                            checkpoint_commit_id,
+                            interval_has_commits,
+                        },
+                        gc_state,
+                        hot_working_diff_certified,
+                    })?;
+                checkpoint_commit_id.to_string()
+            }
+            _ => unreachable!("checkpoint planner produces both selected partitions or neither"),
         };
-        let checkpoint_commit = CommitId::parse_lix(&checkpoint_commit_id, "checkpoint commit id")?;
+        let checkpoint_commit_id = CommitId::parse_lix(&commit_id, "checkpoint commit id")?;
         let mut checkpoint_rows = RawWriteBatch::with_capacity(1);
         checkpoint_rows.push(checkpoint_stage_row(
-            &checkpoint_commit,
+            &checkpoint_commit_id,
             self.functions.call_uuid_v7().to_string(),
         ));
         self.stage_write(TransactionWrite::Rows {
@@ -9322,9 +9373,16 @@ where
         })
         .await?;
         Ok(crate::sql2::DiffCommandOutcome {
-            rows_affected: diff_ids.len() as u64,
-            commit_id: Some(checkpoint_commit_id),
+            rows_affected,
+            commit_id: Some(commit_id),
         })
+    }
+
+    async fn execute_checkpoint_selection(
+        &mut self,
+        diff_ids: Vec<String>,
+    ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        self.execute_checkpoint_plan(Some(diff_ids)).await
     }
 
     pub(crate) async fn execute_diff_command_query_owned(
@@ -9830,6 +9888,111 @@ fn parse_materialized_diff_json(
         TransactionJson::from_value(value, context)
     })
     .transpose()
+}
+
+/// Computes engine-owned dependencies for a scoped checkpoint and rejects a
+/// partition that could publish rows without the schema needed to read them.
+///
+/// Schema definitions are ordinary tracked rows. A relation and its
+/// `lix_registered_schema` row can therefore be introduced in the same
+/// working interval. Selecting only the relation row used to strand that row
+/// behind a checkpoint whose catalog could not decode it. Closure happens on
+/// the complete immutable working diff, before either partition is staged.
+fn close_and_validate_checkpoint_selection(
+    entries: &[TrackedStateDiffEntry],
+    requested: BTreeSet<String>,
+) -> Result<BTreeSet<String>, LixError> {
+    let mut by_diff_id = BTreeMap::new();
+    let mut registration_by_schema_key = BTreeMap::new();
+    for entry in entries.iter().filter(|entry| {
+        entry.identity.schema_key() != CHECKPOINT_SCHEMA_KEY
+            && entry.identity.schema_key() != crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
+    }) {
+        let diff_id = entry.diff_id()?;
+        by_diff_id.insert(diff_id.clone(), entry);
+        if entry.identity.schema_key() == REGISTERED_SCHEMA_KEY {
+            let registered_schema_key = entry
+                .identity
+                .row_pk()
+                .as_single_string_owned()
+                .map_err(|_| {
+                    LixError::new(
+                        LixError::CODE_INTERNAL_ERROR,
+                        "working lix_registered_schema row has an invalid primary key",
+                    )
+                })?;
+            registration_by_schema_key.insert(registered_schema_key, diff_id);
+        }
+    }
+    if requested.iter().any(|diff_id| !by_diff_id.contains_key(diff_id)) {
+        return Err(stale_or_unknown_diff_id());
+    }
+
+    let mut closed = requested;
+    loop {
+        let required_schema_keys = closed
+            .iter()
+            .filter_map(|diff_id| by_diff_id.get(diff_id))
+            .map(|entry| entry.identity.schema_key().to_string())
+            .collect::<BTreeSet<_>>();
+        let mut changed = false;
+        for schema_key in required_schema_keys {
+            let Some(registration_diff_id) = registration_by_schema_key.get(&schema_key) else {
+                // No registration change in this interval means the schema is
+                // already part of the checkpoint baseline.
+                continue;
+            };
+            let registration = by_diff_id
+                .get(registration_diff_id)
+                .expect("registration diff index is coherent");
+            if registration
+                .after
+                .as_ref()
+                .is_none_or(|after| after.deleted)
+            {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    format!(
+                        "checkpoint selection contains a live '{schema_key}' row but its schema registration is removed"
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "operation": "createCheckpoint",
+                    "schemaKey": schema_key,
+                    "dependency": REGISTERED_SCHEMA_KEY,
+                })));
+            }
+            changed |= closed.insert(registration_diff_id.clone());
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Validate the final closure rather than trusting the construction loop.
+    // This keeps later dependency kinds fail-closed when they are added here.
+    for diff_id in &closed {
+        let entry = by_diff_id
+            .get(diff_id)
+            .ok_or_else(stale_or_unknown_diff_id)?;
+        let schema_key = entry.identity.schema_key();
+        if let Some(registration_diff_id) = registration_by_schema_key.get(schema_key)
+            && !closed.contains(registration_diff_id)
+        {
+            return Err(LixError::new(
+                LixError::CODE_CONSTRAINT_VIOLATION,
+                format!(
+                    "checkpoint selection is missing the schema registration for '{schema_key}'"
+                ),
+            )
+            .with_details(serde_json::json!({
+                "operation": "createCheckpoint",
+                "schemaKey": schema_key,
+                "dependency": REGISTERED_SCHEMA_KEY,
+            })));
+        }
+    }
+    Ok(closed)
 }
 
 fn push_checkpoint_selected_change(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8666,7 +8666,11 @@ where
                 None => current.as_ref().is_none_or(|row| row.deleted),
             };
             if !current_matches {
-                return Err(stale_or_unknown_diff_id());
+                return Err(stale_or_unknown_diff_id().with_details(serde_json::json!({
+                    "operation": diff_command_operation(command),
+                    "rowRef": crate::row_ref::encode_schema_identity(&schema_key, &row_pk)?
+                        .as_str(),
+                })));
             }
             if let Some(target) = target {
                 required_diff_change(&records, target, diff_id)?;
@@ -8922,6 +8926,14 @@ where
                 retain_payloads: false,
             });
         }
+        if matches!(command, DiffCommand::Apply | DiffCommand::Revert) {
+            // Apply/revert dependency closure must see the complete immutable
+            // source diff. A relation-filtered read cannot discover a changed
+            // schema registration, parent directory, FK target, or unique
+            // value owner outside the explicitly selected relation.
+            requests.clear();
+            requests.push(TrackedStateDiffRequest::default());
+        }
 
         let source = selections
             .iter()
@@ -9003,7 +9015,7 @@ where
             };
         let mut matched = BTreeSet::new();
         let mut resolved = Vec::new();
-        for entry in entries {
+        for entry in &entries {
             if entry.identity.schema_key() == CHECKPOINT_SCHEMA_KEY
                 || entry.identity.schema_key() == crate::undo_redo::UNDO_REDO_MARKER_SCHEMA_KEY
             {
@@ -9049,7 +9061,143 @@ where
         }
         resolved.sort();
         resolved.dedup();
-        Ok(resolved)
+        self.close_apply_or_revert_selection(command, &entries, resolved)
+            .await
+    }
+
+    async fn close_apply_or_revert_selection(
+        &mut self,
+        command: DiffCommand,
+        entries: &[TrackedStateDiffEntry],
+        requested: Vec<String>,
+    ) -> Result<Vec<String>, LixError> {
+        if command == DiffCommand::CreateCheckpoint {
+            return Ok(requested);
+        }
+        let requested = requested.into_iter().collect::<BTreeSet<_>>();
+        let source_requested = requested.clone();
+        let (candidate_entries, candidate_requested, candidate_to_source) =
+            if command == DiffCommand::Revert {
+                let mut reversed = Vec::with_capacity(entries.len());
+                let mut source_to_candidate = BTreeMap::new();
+                let mut candidate_to_source = BTreeMap::new();
+                for entry in entries {
+                    let source_diff_id = entry.diff_id()?;
+                    let mut candidate = entry.clone();
+                    std::mem::swap(&mut candidate.before, &mut candidate.after);
+                    candidate.kind = match candidate.kind {
+                        TrackedStateDiffKind::Added => TrackedStateDiffKind::Removed,
+                        TrackedStateDiffKind::Modified => TrackedStateDiffKind::Modified,
+                        TrackedStateDiffKind::Removed => TrackedStateDiffKind::Added,
+                    };
+                    let candidate_diff_id = candidate.diff_id()?;
+                    source_to_candidate.insert(source_diff_id.clone(), candidate_diff_id.clone());
+                    candidate_to_source.insert(candidate_diff_id, source_diff_id);
+                    reversed.push(candidate);
+                }
+                let candidate_requested = requested
+                    .iter()
+                    .map(|diff_id| {
+                        source_to_candidate
+                            .get(diff_id)
+                            .cloned()
+                            .ok_or_else(stale_or_unknown_diff_id)
+                    })
+                    .collect::<Result<BTreeSet<_>, _>>()?;
+                (reversed, candidate_requested, Some(candidate_to_source))
+            } else {
+                (entries.to_vec(), requested, None)
+            };
+        let (before_snapshots, after_snapshots) = self
+            .checkpoint_dependency_snapshots(&candidate_entries)
+            .await?;
+        let closed = close_and_validate_diff_command_selection(
+            command,
+            &candidate_entries,
+            candidate_requested,
+            self.tracked_schema_snapshot.as_ref(),
+            &before_snapshots,
+            &after_snapshots,
+        )?;
+        let mut closed = closed
+            .into_iter()
+            .map(|diff_id| {
+                candidate_to_source
+                    .as_ref()
+                    .map_or(Ok(diff_id.clone()), |mapping| {
+                        mapping
+                            .get(&diff_id)
+                            .cloned()
+                            .ok_or_else(stale_or_unknown_diff_id)
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let by_diff_id = entries
+            .iter()
+            .map(|entry| Ok((entry.diff_id()?, entry)))
+            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+        let auto_dependencies = closed
+            .iter()
+            .filter(|diff_id| !source_requested.contains(*diff_id))
+            .map(|diff_id| {
+                by_diff_id
+                    .get(diff_id)
+                    .copied()
+                    .ok_or_else(stale_or_unknown_diff_id)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if !auto_dependencies.is_empty() {
+            let branch_id = self.active_branch_id.clone();
+            let request = HotStateExactBatchRequest {
+                rows: auto_dependencies
+                    .iter()
+                    .map(|entry| HotStateExactRowRequest {
+                        schema_key: entry.identity.schema_key().to_owned(),
+                        branch_id: branch_id.clone(),
+                        row_pk: entry.identity.row_pk().clone(),
+                        file_id: entry.identity.file_id().map(ToOwned::to_owned),
+                    })
+                    .collect(),
+                projection: HotStateProjection::default(),
+                untracked: Some(false),
+                include_tombstones: true,
+            };
+            let current = self
+                .load_visible_exact_hot_state_batch(&request)
+                .await?
+                .into_rows();
+            let already_satisfied = auto_dependencies
+                .into_iter()
+                .zip(current)
+                .map(|(entry, current)| {
+                    let target_change_id = match command {
+                        DiffCommand::Apply => entry.after.as_ref(),
+                        DiffCommand::Revert => entry.before.as_ref(),
+                        DiffCommand::CreateCheckpoint => unreachable!(),
+                    }
+                    .filter(|row| !row.deleted)
+                    .map(|row| row.change_id);
+                    let satisfied = match target_change_id {
+                        Some(target) => current
+                            .as_ref()
+                            .and_then(|row| row.change_id)
+                            .is_some_and(|change_id| change_id == target),
+                        None => current.as_ref().is_none_or(|row| row.deleted),
+                    };
+                    if satisfied {
+                        entry.diff_id().map(Some)
+                    } else {
+                        Ok(None)
+                    }
+                })
+                .collect::<Result<Vec<_>, LixError>>()?
+                .into_iter()
+                .flatten()
+                .collect::<BTreeSet<_>>();
+            closed.retain(|diff_id| !already_satisfied.contains(diff_id));
+        }
+        closed.sort();
+        Ok(closed)
     }
 
     /// Includes only changed, live ancestors of selected file descriptors.
@@ -9303,7 +9451,8 @@ where
                 let (before_snapshots, after_snapshots) = self
                     .checkpoint_dependency_snapshots(&diff.entries)
                     .await?;
-                let closed = close_and_validate_checkpoint_selection(
+                let closed = close_and_validate_diff_command_selection(
+                    DiffCommand::CreateCheckpoint,
                     &diff.entries,
                     requested,
                     self.tracked_schema_snapshot.as_ref(),
@@ -10078,21 +10227,31 @@ fn parse_materialized_diff_json(
     .transpose()
 }
 
-/// Computes engine-owned dependencies for a scoped checkpoint and rejects a
-/// partition that could publish rows without the schema needed to read them.
+fn diff_command_operation(command: DiffCommand) -> &'static str {
+    match command {
+        DiffCommand::Revert => "lix_revert",
+        DiffCommand::Apply => "lix_apply",
+        DiffCommand::CreateCheckpoint => "lix_create_checkpoint",
+    }
+}
+
+/// Computes engine-owned dependencies for a scoped diff command and rejects a
+/// candidate that could publish rows without the schema needed to read them.
 ///
 /// Schema definitions are ordinary tracked rows. A relation and its
 /// `lix_registered_schema` row can therefore be introduced in the same
 /// working interval. Selecting only the relation row used to strand that row
 /// behind a checkpoint whose catalog could not decode it. Closure happens on
 /// the complete immutable working diff, before either partition is staged.
-fn close_and_validate_checkpoint_selection(
+fn close_and_validate_diff_command_selection(
+    command: DiffCommand,
     entries: &[TrackedStateDiffEntry],
     requested: BTreeSet<String>,
     catalog: &CatalogSnapshot,
     before_snapshots: &BTreeMap<String, JsonValue>,
     after_snapshots: &BTreeMap<String, JsonValue>,
 ) -> Result<BTreeSet<String>, LixError> {
+    let operation = diff_command_operation(command);
     let mut by_diff_id = BTreeMap::new();
     let mut registration_by_schema_key = BTreeMap::new();
     for entry in entries.iter().filter(|entry| {
@@ -10130,10 +10289,10 @@ fn close_and_validate_checkpoint_selection(
             {
                 return Err(LixError::new(
                     LixError::CODE_CONSTRAINT_VIOLATION,
-                    "a scoped checkpoint cannot remove a schema registration; checkpoint the complete working set",
+                    format!("a scoped {operation} cannot remove a schema registration without its complete dependent set"),
                 )
                 .with_details(serde_json::json!({
-                    "operation": "lix_create_checkpoint",
+                    "operation": operation,
                     "rowRef": crate::row_ref::encode_schema_identity(
                         REGISTERED_SCHEMA_KEY,
                         entry.identity.row_pk(),
@@ -10162,14 +10321,23 @@ fn close_and_validate_checkpoint_selection(
                 .as_ref()
                 .is_none_or(|after| after.deleted)
             {
+                if command != DiffCommand::CreateCheckpoint
+                    && catalog.plan_for_key(&schema_key).is_some()
+                {
+                    // The operation's current candidate already has this
+                    // schema. A historical source interval may contain an
+                    // obsolete registration tombstone (notably for builtin
+                    // relations); it is not a dependency transition.
+                    continue;
+                }
                 return Err(LixError::new(
                     LixError::CODE_CONSTRAINT_VIOLATION,
                     format!(
-                        "checkpoint selection contains a live '{schema_key}' row but its schema registration is removed"
+                        "{operation} selection contains a live '{schema_key}' row but its schema registration is removed"
                     ),
                 )
                 .with_details(serde_json::json!({
-                    "operation": "lix_create_checkpoint",
+                    "operation": operation,
                     "rowRef": crate::row_ref::encode_schema_identity(
                         REGISTERED_SCHEMA_KEY,
                         registration.identity.row_pk(),
@@ -10321,7 +10489,7 @@ fn close_and_validate_checkpoint_selection(
                     return Err(LixError::new(
                         LixError::CODE_CONSTRAINT_VIOLATION,
                         format!(
-                            "checkpoint dependency target schema '{}' is not visible",
+                            "{operation} dependency target schema '{}' is not visible",
                             foreign_key.referenced_schema.schema_key
                         ),
                     ));
@@ -10373,7 +10541,7 @@ fn close_and_validate_checkpoint_selection(
                     .map_err(|error| {
                         LixError::new(
                             LixError::CODE_CONSTRAINT_VIOLATION,
-                            format!("checkpoint foreign-key value is invalid: {error}"),
+                            format!("{operation} foreign-key value is invalid: {error}"),
                         )
                     })?;
                 if let Some((target_diff_id, target_entry)) = by_diff_id.iter().find(|(_, target)| {
@@ -10388,7 +10556,7 @@ fn close_and_validate_checkpoint_selection(
                         return Err(LixError::new(
                             LixError::CODE_CONSTRAINT_VIOLATION,
                             format!(
-                                "checkpoint selection references removed row '{} {:?}'",
+                                "{operation} selection references removed row '{} {:?}'",
                                 foreign_key.referenced_schema.schema_key,
                                 target_row_pk
                             ),
@@ -10474,10 +10642,10 @@ fn close_and_validate_checkpoint_selection(
                     {
                         return Err(LixError::new(
                             LixError::CODE_CONSTRAINT_VIOLATION,
-                            "checkpoint selection would retain a row that references a removed dependency",
+                            format!("{operation} selection would retain a row that references a removed dependency"),
                         )
                         .with_details(serde_json::json!({
-                            "operation": "lix_create_checkpoint",
+                            "operation": operation,
                             "rowRef": crate::row_ref::encode_schema_identity(
                                 child_entry.identity.schema_key(),
                                 child_entry.identity.row_pk(),
@@ -10506,15 +10674,19 @@ fn close_and_validate_checkpoint_selection(
         let schema_key = entry.identity.schema_key();
         if let Some(registration_diff_id) = registration_by_schema_key.get(schema_key)
             && !closed.contains(registration_diff_id)
+            && by_diff_id
+                .get(registration_diff_id)
+                .and_then(|registration| registration.after.as_ref())
+                .is_some_and(|after| !after.deleted)
         {
             return Err(LixError::new(
                 LixError::CODE_CONSTRAINT_VIOLATION,
                 format!(
-                    "checkpoint selection is missing the schema registration for '{schema_key}'"
+                    "{operation} selection is missing the schema registration for '{schema_key}'"
                 ),
             )
             .with_details(serde_json::json!({
-                "operation": "lix_create_checkpoint",
+                "operation": operation,
                 "rowRef": crate::row_ref::encode_schema_identity(
                     schema_key,
                     entry.identity.row_pk(),
@@ -10555,10 +10727,10 @@ fn close_and_validate_checkpoint_selection(
             {
                 return Err(LixError::new(
                     LixError::CODE_CONSTRAINT_VIOLATION,
-                    "checkpoint closure violates a declared unique constraint",
+                    format!("{operation} closure violates a declared unique constraint"),
                 )
                 .with_details(serde_json::json!({
-                    "operation": "lix_create_checkpoint",
+                    "operation": operation,
                     "rowRef": crate::row_ref::encode_schema_identity(
                         left_entry.identity.schema_key(),
                         left_entry.identity.row_pk(),
@@ -10590,10 +10762,10 @@ fn close_and_validate_checkpoint_selection(
             }) {
                 return Err(LixError::new(
                     LixError::CODE_CONSTRAINT_VIOLATION,
-                    "checkpoint closure violates the filesystem namespace",
+                    format!("{operation} closure violates the filesystem namespace"),
                 )
                 .with_details(serde_json::json!({
-                    "operation": "lix_create_checkpoint",
+                    "operation": operation,
                     "rowRef": crate::row_ref::encode_schema_identity(
                         left_entry.identity.schema_key(),
                         left_entry.identity.row_pk(),

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -8543,6 +8543,7 @@ where
                 .staged_writes
                 .commit_id_for_branch(&branch_id)?
                 .map(|commit_id| commit_id.to_string()),
+            parent_commit_id: None,
         })
     }
 
@@ -8757,6 +8758,7 @@ where
                 .staged_writes
                 .commit_id_for_branch(&branch_id)?
                 .map(|commit_id| commit_id.to_string()),
+            parent_commit_id: None,
         })
     }
 
@@ -8768,15 +8770,21 @@ where
         command: DiffCommand,
         selections: &[DiffCommandSelection],
     ) -> Result<Vec<String>, LixError> {
-        let unique = selections
-            .iter()
-            .map(|selection| (&selection.relation, &selection.row_pk))
-            .collect::<BTreeSet<_>>();
-        if unique.len() != selections.len() {
-            return Err(LixError::new(
-                LixError::CODE_CONSTRAINT_VIOLATION,
-                "diff command selection contains duplicate (relation, row_pk) rows",
-            ));
+        let mut unique = BTreeSet::new();
+        for selection in selections {
+            if !unique.insert((&selection.relation, &selection.row_pk)) {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    "diff command selection contains a duplicate row_ref",
+                )
+                .with_details(serde_json::json!({
+                    "operation": "diff_command",
+                    "rowRef": crate::row_ref::encode(
+                        &selection.relation,
+                        &selection.row_pk,
+                    )?.as_str(),
+                })));
+            }
         }
 
         let catalog = self.sql_public_catalog()?;
@@ -8802,7 +8810,7 @@ where
                             .map_err(|error| {
                                 LixError::new(
                                     LixError::CODE_TYPE_MISMATCH,
-                                    format!("lix_file row_pk must contain a UUID file id: {error}"),
+                                    format!("lix_file row_ref must encode a UUID file id: {error}"),
                                 )
                             })?;
                     file_descriptor_row_pks.push(descriptor_row_pk);
@@ -8846,7 +8854,7 @@ where
                             .map_err(|error| {
                                 LixError::new(
                                     LixError::CODE_TYPE_MISMATCH,
-                                    format!("row_pk does not match relation '{relation}': {error}"),
+                                    format!("row_ref primary key does not match relation '{relation}': {error}"),
                                 )
                             })?;
                     schema_selections
@@ -9177,6 +9185,7 @@ where
                 Ok(crate::sql2::DiffCommandOutcome {
                     rows_affected: 0,
                     commit_id: None,
+                    parent_commit_id: None,
                 })
             }
             crate::sql2::CheckpointFunctionPlan::SelectionQuery(query_sql) => {
@@ -9201,10 +9210,23 @@ where
         &mut self,
         requested_diff_ids: Option<Vec<String>>,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        if self.active_branch_id == GLOBAL_BRANCH_ID {
+            return Err(LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "the global branch cannot be checkpointed",
+            ));
+        }
+        if self.staged_writes.has_staged_state_rows()? {
+            return Err(LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                "lix_create_checkpoint cannot follow another write in the same transaction",
+            ));
+        }
         if requested_diff_ids.as_ref().is_some_and(Vec::is_empty) {
             return Ok(crate::sql2::DiffCommandOutcome {
                 rows_affected: 0,
                 commit_id: None,
+                parent_commit_id: None,
             });
         }
         if self.pending_checkpoint_gc_sequence.is_some() {
@@ -9406,6 +9428,7 @@ where
         Ok(crate::sql2::DiffCommandOutcome {
             rows_affected,
             commit_id: Some(commit_id),
+            parent_commit_id: Some(head_commit_id.to_string()),
         })
     }
 
@@ -9420,8 +9443,28 @@ where
         &mut self,
         entries: &[TrackedStateDiffEntry],
     ) -> Result<(BTreeMap<String, JsonValue>, BTreeMap<String, JsonValue>), LixError> {
+        // Row identity alone is sufficient for ordinary relations. Snapshot
+        // payloads are needed only where closure must inspect a declared
+        // value-level dependency (unique/FK) or the filesystem namespace.
+        // Keeping this filter ahead of every storage read preserves HOT-only
+        // scoped checkpointing for the common key/value case.
+        let mut dependency_schema_keys = BTreeSet::from([
+            FILE_DESCRIPTOR_SCHEMA_KEY.to_string(),
+            DIRECTORY_DESCRIPTOR_SCHEMA_KEY.to_string(),
+        ]);
+        for plan in self.tracked_schema_snapshot.plans() {
+            if !plan.uniques.is_empty() || !plan.foreign_keys.is_empty() {
+                dependency_schema_keys.insert(plan.key.schema_key.clone());
+            }
+            dependency_schema_keys.extend(
+                plan.foreign_keys
+                    .iter()
+                    .map(|foreign_key| foreign_key.referenced_schema.schema_key.clone()),
+            );
+        }
         let changes = entries
             .iter()
+            .filter(|entry| dependency_schema_keys.contains(entry.identity.schema_key()))
             .map(|entry| {
                 Ok((
                     entry.diff_id()?,
@@ -9438,6 +9481,7 @@ where
                 ))
             })
             .collect::<Result<Vec<_>, LixError>>()?;
+        drop(dependency_schema_keys);
         if changes.is_empty() {
             return Ok((BTreeMap::new(), BTreeMap::new()));
         }
@@ -9519,6 +9563,17 @@ where
         query_sql: String,
         params: Vec<Value>,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        if self.staged_writes.has_staged_state_rows()? {
+            let relation = match command {
+                DiffCommand::Revert => "lix_revert",
+                DiffCommand::Apply => "lix_apply",
+                DiffCommand::CreateCheckpoint => "lix_create_checkpoint",
+            };
+            return Err(LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                format!("{relation} cannot follow another write in the same transaction"),
+            ));
+        }
         let statement = crate::sql2::parse_statement(&query_sql)?;
         let source_commits = if command == DiffCommand::Apply {
             let source = diff_command_source_commits(&statement, &params)?;
@@ -9560,6 +9615,7 @@ where
             return Ok(crate::sql2::DiffCommandOutcome {
                 rows_affected: 0,
                 commit_id: None,
+                parent_commit_id: None,
             });
         }
         self.execute_diff_command(command, selections).await
@@ -9673,7 +9729,14 @@ fn diff_command_source_commits(
             else {
                 return ControlFlow::Continue(());
             };
-            if !name.to_string().eq_ignore_ascii_case("lix_diff") {
+            if !crate::sql2::object_name_is_public_function(name, "lix_diff") {
+                return ControlFlow::Continue(());
+            }
+            if arguments.args.len() == 1 {
+                self.sources.push((
+                    DiffCommandSourceCommit::LatestCheckpoint,
+                    DiffCommandSourceCommit::ActiveHead,
+                ));
                 return ControlFlow::Continue(());
             }
             if arguments.args.len() != 3 {
@@ -9712,23 +9775,20 @@ fn diff_command_source_commits(
                         )),
                     },
                     SqlExpr::Function(function) if matches!(&function.args, FunctionArguments::List(arguments) if arguments.args.is_empty()) => {
-                        if function
-                            .name
-                            .to_string()
-                            .eq_ignore_ascii_case("lix_root_commit_id")
-                        {
+                        if crate::sql2::object_name_is_public_function(
+                            &function.name,
+                            "lix_root_commit_id",
+                        ) {
                             Ok(DiffCommandSourceCommit::Root)
-                        } else if function
-                            .name
-                            .to_string()
-                            .eq_ignore_ascii_case("lix_active_branch_commit_id")
-                        {
+                        } else if crate::sql2::object_name_is_public_function(
+                            &function.name,
+                            "lix_active_branch_commit_id",
+                        ) {
                             Ok(DiffCommandSourceCommit::ActiveHead)
-                        } else if function
-                            .name
-                            .to_string()
-                            .eq_ignore_ascii_case("lix_latest_checkpoint_commit_id")
-                        {
+                        } else if crate::sql2::object_name_is_public_function(
+                            &function.name,
+                            "lix_latest_checkpoint_commit_id",
+                        ) {
                             Ok(DiffCommandSourceCommit::LatestCheckpoint)
                         } else {
                             Err(LixError::new(
@@ -10074,7 +10134,7 @@ fn close_and_validate_checkpoint_selection(
                 )
                 .with_details(serde_json::json!({
                     "operation": "lix_create_checkpoint",
-                    "rowRef": crate::row_ref::encode(
+                    "rowRef": crate::row_ref::encode_schema_identity(
                         REGISTERED_SCHEMA_KEY,
                         entry.identity.row_pk(),
                     )?.as_str(),
@@ -10110,11 +10170,133 @@ fn close_and_validate_checkpoint_selection(
                 )
                 .with_details(serde_json::json!({
                     "operation": "lix_create_checkpoint",
-                    "rowRef": crate::row_ref::encode(schema_key.as_str(), registration.identity.row_pk())?.as_str(),
+                    "rowRef": crate::row_ref::encode_schema_identity(
+                        REGISTERED_SCHEMA_KEY,
+                        registration.identity.row_pk(),
+                    )?.as_str(),
                     "schemaKey": schema_key,
                 })));
             }
             changed |= closed.insert(registration_diff_id.clone());
+        }
+
+        // File ownership is a dependency even when the caller selected a
+        // semantic relation row directly rather than going through lix_file.
+        // Carry a changed descriptor and every changed ancestor directory
+        // across the checkpoint boundary with its owned row.
+        let selected_now = closed.iter().cloned().collect::<Vec<_>>();
+        for selected_diff_id in selected_now {
+            let entry = by_diff_id
+                .get(&selected_diff_id)
+                .expect("closed diff identity is indexed");
+            if let Some(file_id) = entry.identity.file_id() {
+                for (owned_diff_id, owned_entry) in &by_diff_id {
+                    if owned_entry.identity.file_id() == Some(file_id)
+                        || (owned_entry.identity.schema_key() == FILE_DESCRIPTOR_SCHEMA_KEY
+                            && owned_entry
+                                .identity
+                                .row_pk()
+                                .as_single_string_owned()
+                                .is_ok_and(|id| id == file_id))
+                    {
+                        changed |= closed.insert(owned_diff_id.clone());
+                    }
+                }
+            }
+
+            if matches!(
+                entry.identity.schema_key(),
+                FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+            ) && let Some(parent_id) = after_snapshots.get(&selected_diff_id).and_then(|snapshot| {
+                checkpoint_descriptor_parent_id(entry.identity.schema_key(), snapshot)
+            })
+                && let Some((parent_diff_id, _)) = by_diff_id.iter().find(|(_, candidate)| {
+                    candidate.identity.schema_key() == DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                        && candidate
+                            .identity
+                            .row_pk()
+                            .as_single_string_owned()
+                            .is_ok_and(|id| id == parent_id)
+                })
+            {
+                changed |= closed.insert(parent_diff_id.clone());
+            }
+        }
+
+        // A scoped checkpoint's baseline must remain valid independently of
+        // the still-working partition. If a selected row takes a unique value
+        // from another changed row's pre-checkpoint state, close over that row
+        // as well. This handles swaps without hard-coding relation names.
+        let selected_now = closed.iter().cloned().collect::<Vec<_>>();
+        for selected_diff_id in selected_now {
+            let Some(selected_snapshot) = after_snapshots.get(&selected_diff_id) else {
+                continue;
+            };
+            let selected_entry = by_diff_id
+                .get(&selected_diff_id)
+                .expect("closed diff identity is indexed");
+            let Some((_, selected_plan)) =
+                catalog.plan_for_key(selected_entry.identity.schema_key())
+            else {
+                continue;
+            };
+            for unique in &selected_plan.uniques {
+                let Some(selected_value) =
+                    checkpoint_json_pointer_values(selected_snapshot, unique)
+                else {
+                    continue;
+                };
+                for (candidate_diff_id, candidate_entry) in &by_diff_id {
+                    if candidate_diff_id == &selected_diff_id
+                        || candidate_entry.identity.schema_key()
+                            != selected_entry.identity.schema_key()
+                    {
+                        continue;
+                    }
+                    if before_snapshots
+                        .get(candidate_diff_id)
+                        .and_then(|snapshot| checkpoint_json_pointer_values(snapshot, unique))
+                        .is_some_and(|value| value == selected_value)
+                    {
+                        changed |= closed.insert(candidate_diff_id.clone());
+                    }
+                }
+            }
+
+            // File and directory descriptors share one namespace even though
+            // they are different relations. Close cross-kind path swaps by
+            // their canonical (parent_id, name) tuple.
+            if matches!(
+                selected_entry.identity.schema_key(),
+                FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+            ) && let Some(selected_path_key) = checkpoint_descriptor_namespace_key(
+                selected_entry.identity.schema_key(),
+                selected_snapshot,
+            )
+            {
+                for (candidate_diff_id, candidate_entry) in &by_diff_id {
+                    if candidate_diff_id == &selected_diff_id
+                        || !matches!(
+                            candidate_entry.identity.schema_key(),
+                            FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+                        )
+                    {
+                        continue;
+                    }
+                    if before_snapshots
+                        .get(candidate_diff_id)
+                        .and_then(|snapshot| {
+                            checkpoint_descriptor_namespace_key(
+                                candidate_entry.identity.schema_key(),
+                                snapshot,
+                            )
+                        })
+                        .is_some_and(|value| value == selected_path_key)
+                    {
+                        changed |= closed.insert(candidate_diff_id.clone());
+                    }
+                }
+            }
         }
 
         // Follow declared foreign keys when the referenced row also changed
@@ -10296,11 +10478,11 @@ fn close_and_validate_checkpoint_selection(
                         )
                         .with_details(serde_json::json!({
                             "operation": "lix_create_checkpoint",
-                            "rowRef": crate::row_ref::encode(
+                            "rowRef": crate::row_ref::encode_schema_identity(
                                 child_entry.identity.schema_key(),
                                 child_entry.identity.row_pk(),
                             )?.as_str(),
-                            "dependencyRowRef": crate::row_ref::encode(
+                            "dependencyRowRef": crate::row_ref::encode_schema_identity(
                                 target_entry.identity.schema_key(),
                                 target_entry.identity.row_pk(),
                             )?.as_str(),
@@ -10333,12 +10515,120 @@ fn close_and_validate_checkpoint_selection(
             )
             .with_details(serde_json::json!({
                 "operation": "lix_create_checkpoint",
-                "rowRef": crate::row_ref::encode(schema_key, entry.identity.row_pk())?.as_str(),
+                "rowRef": crate::row_ref::encode_schema_identity(
+                    schema_key,
+                    entry.identity.row_pk(),
+                )?.as_str(),
                 "schemaKey": schema_key,
             })));
         }
     }
+
+    // Post-closure certification: the checkpoint candidate consists of each
+    // selected row's after-image and each remaining row's before-image. No two
+    // changed rows may own the same declared unique value or filesystem name.
+    let candidate_snapshots = by_diff_id
+        .iter()
+        .filter_map(|(diff_id, entry)| {
+            let snapshot = if closed.contains(diff_id) {
+                after_snapshots.get(diff_id)
+            } else {
+                before_snapshots.get(diff_id)
+            }?;
+            Some((diff_id, *entry, snapshot))
+        })
+        .collect::<Vec<_>>();
+    for (index, (left_diff_id, left_entry, left_snapshot)) in
+        candidate_snapshots.iter().enumerate()
+    {
+        for (right_diff_id, right_entry, right_snapshot) in
+            candidate_snapshots.iter().skip(index + 1)
+        {
+            if left_entry.identity.schema_key() == right_entry.identity.schema_key()
+                && let Some((_, plan)) = catalog.plan_for_key(left_entry.identity.schema_key())
+                && plan.uniques.iter().any(|unique| {
+                    checkpoint_json_pointer_values(left_snapshot, unique).is_some_and(|left| {
+                        checkpoint_json_pointer_values(right_snapshot, unique)
+                            .is_some_and(|right| left == right)
+                    })
+                })
+            {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    "checkpoint closure violates a declared unique constraint",
+                )
+                .with_details(serde_json::json!({
+                    "operation": "lix_create_checkpoint",
+                    "rowRef": crate::row_ref::encode_schema_identity(
+                        left_entry.identity.schema_key(),
+                        left_entry.identity.row_pk(),
+                    )?.as_str(),
+                    "conflictingRowRef": crate::row_ref::encode_schema_identity(
+                        right_entry.identity.schema_key(),
+                        right_entry.identity.row_pk(),
+                    )?.as_str(),
+                    "leftDiffId": left_diff_id,
+                    "rightDiffId": right_diff_id,
+                })));
+            }
+            if matches!(
+                left_entry.identity.schema_key(),
+                FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+            ) && matches!(
+                right_entry.identity.schema_key(),
+                FILE_DESCRIPTOR_SCHEMA_KEY | DIRECTORY_DESCRIPTOR_SCHEMA_KEY
+            ) && checkpoint_descriptor_namespace_key(
+                left_entry.identity.schema_key(),
+                left_snapshot,
+            )
+            .is_some_and(|left| {
+                checkpoint_descriptor_namespace_key(
+                    right_entry.identity.schema_key(),
+                    right_snapshot,
+                )
+                .is_some_and(|right| left == right)
+            }) {
+                return Err(LixError::new(
+                    LixError::CODE_CONSTRAINT_VIOLATION,
+                    "checkpoint closure violates the filesystem namespace",
+                )
+                .with_details(serde_json::json!({
+                    "operation": "lix_create_checkpoint",
+                    "rowRef": crate::row_ref::encode_schema_identity(
+                        left_entry.identity.schema_key(),
+                        left_entry.identity.row_pk(),
+                    )?.as_str(),
+                    "conflictingRowRef": crate::row_ref::encode_schema_identity(
+                        right_entry.identity.schema_key(),
+                        right_entry.identity.row_pk(),
+                    )?.as_str(),
+                })));
+            }
+        }
+    }
     Ok(closed)
+}
+
+fn checkpoint_descriptor_parent_id<'a>(
+    schema_key: &str,
+    snapshot: &'a JsonValue,
+) -> Option<&'a str> {
+    snapshot
+        .get(match schema_key {
+            FILE_DESCRIPTOR_SCHEMA_KEY => "directory_id",
+            DIRECTORY_DESCRIPTOR_SCHEMA_KEY => "parent_id",
+            _ => return None,
+        })
+        .and_then(JsonValue::as_str)
+}
+
+fn checkpoint_descriptor_namespace_key<'a>(
+    schema_key: &str,
+    snapshot: &'a JsonValue,
+) -> Option<(Option<&'a str>, &'a str)> {
+    let parent_id = checkpoint_descriptor_parent_id(schema_key, snapshot);
+    let name = snapshot.get("name")?.as_str()?;
+    Some((parent_id, name))
 }
 
 fn checkpoint_foreign_key_references_target(
@@ -11627,6 +11917,17 @@ where
         command: DiffCommand,
         selections: Vec<DiffCommandSelection>,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
+        if self.staged_writes.has_staged_state_rows()? {
+            let relation = match command {
+                DiffCommand::Revert => "lix_revert",
+                DiffCommand::Apply => "lix_apply",
+                DiffCommand::CreateCheckpoint => "lix_create_checkpoint",
+            };
+            return Err(LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                format!("{relation} cannot follow another write in the same transaction"),
+            ));
+        }
         let selected_rows = selections.len() as u64;
         let diff_ids = self
             .resolve_diff_command_selections(command, &selections)
@@ -16491,8 +16792,8 @@ fallback={large_fallback} decoded={large_decoded}"
         assert!(
             error
                 .message
-                .contains("does not match primary_key-derived row_pk"),
-            "error should explain row pk mismatch: {error:?}"
+                .contains("does not match the primary-key columns"),
+            "error should explain the identity mismatch: {error:?}"
         );
     }
 

--- a/packages/lix/src/transaction/normalization.rs
+++ b/packages/lix/src/transaction/normalization.rs
@@ -327,7 +327,10 @@ pub(crate) fn normalize_raw_write_row_in_place(
         let schema_key = rows.row(row_index).schema_key.clone();
         return Err(LixError::new(
             LixError::CODE_SCHEMA_VALIDATION,
-            format!("tombstone for schema '{}' requires row_pk", schema_key),
+            format!(
+                "tombstone for schema '{}' requires a primary-key identity",
+                schema_key
+            ),
         ));
     } else {
         None
@@ -581,7 +584,7 @@ fn resolve_row_pk(
             LixError::new(
                 LixError::CODE_SCHEMA_VALIDATION,
                 format!(
-                    "write for schema '{}' requires row_pk because the schema has no primary_key",
+                    "write for schema '{}' requires an explicit primary-key identity because the schema has no primary_key",
                     row.schema_key
                 ),
             )
@@ -598,9 +601,7 @@ fn resolve_row_pk(
             return Err(LixError::new(
                 LixError::CODE_SCHEMA_VALIDATION,
                 format!(
-                    "row_pk '{}' does not match primary_key-derived row_pk '{}' for schema '{}'",
-                    row_pk.as_json_array_text()?,
-                    derived.as_json_array_text()?,
+                    "the explicit identity does not match the primary-key columns for schema '{}'",
                     row.schema_key
                 ),
             ));
@@ -636,7 +637,7 @@ fn row_pk_derivation_error(
     LixError::new(
         LixError::CODE_SCHEMA_VALIDATION,
         format!(
-            "failed to derive row_pk for schema '{}': {detail}",
+            "failed to derive the primary-key identity for schema '{}': {detail}",
             row.schema_key
         ),
     )
@@ -883,7 +884,7 @@ mod tests {
         assert!(
             error
                 .message
-                .contains("does not match primary_key-derived row_pk")
+                .contains("does not match the primary-key columns")
         );
     }
 

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -4275,32 +4275,24 @@ fn retain_earliest_batch_identity_violation<'a>(
 }
 
 fn mixed_durability_error(row: PreparedStateRowRef<'_>) -> LixError {
-    let row_pk = row
-        .row_pk
-        .as_json_array_text()
-        .unwrap_or_else(|_| "<invalid row_pk>".to_string());
     LixError::new(
         LixError::CODE_INVALID_PARAM,
         format!(
-            "cannot mix tracked and untracked writes for schema '{}' row_pk '{}' in branch '{}' within one transaction; commit or roll back before changing durability",
-            row.schema_key, row_pk, row.branch_id
+            "cannot mix tracked and untracked writes for the same '{}' primary key in branch '{}' within one transaction; commit or roll back before changing durability",
+            row.schema_key, row.branch_id
         ),
     )
 }
 
 fn duplicate_staged_present_row_error(
     row: PreparedStateRowRef<'_>,
-    previous: PreparedStateRowRef<'_>,
+    _previous: PreparedStateRowRef<'_>,
 ) -> LixError {
     let message = logical_primary_key_violation_message(row.origin)
         .unwrap_or_else(|| {
             format!(
-                "primary-key constraint violation on schema '{}': duplicate staged rows for row_pk '{}' in branch '{}'",
+                "primary-key constraint violation on schema '{}': duplicate staged primary key in branch '{}'",
                 row.schema_key,
-                previous
-                    .row_pk
-                    .as_json_array_text()
-                    .unwrap_or_else(|_| "<invalid row_pk>".to_string()),
                 row.branch_id
             )
         });
@@ -4309,22 +4301,19 @@ fn duplicate_staged_present_row_error(
 
 pub(crate) fn duplicate_insert_identity_message(
     schema_key: &str,
-    row_pk: &RowPk,
+    _row_pk: &RowPk,
     branch_id: Option<&str>,
     origin: Option<&TransactionWriteOrigin>,
 ) -> String {
     if let Some(message) = logical_primary_key_violation_message(origin) {
         return message;
     }
-    let row_pk = row_pk
-        .as_json_array_text()
-        .unwrap_or_else(|_| "<invalid row_pk>".to_string());
     match branch_id {
         Some(branch_id) => format!(
-            "primary-key constraint violation on schema '{schema_key}': INSERT would duplicate row_pk '{row_pk}' in branch '{branch_id}'"
+            "primary-key constraint violation on schema '{schema_key}': INSERT would duplicate a primary key in branch '{branch_id}'"
         ),
         None => format!(
-            "primary-key constraint violation on schema '{schema_key}': INSERT would duplicate row_pk '{row_pk}'"
+            "primary-key constraint violation on schema '{schema_key}': INSERT would duplicate a primary key"
         ),
     }
 }

--- a/packages/lix/src/transaction/validation.rs
+++ b/packages/lix/src/transaction/validation.rs
@@ -1979,8 +1979,8 @@ where
                     LixError::new(
                         LixError::CODE_UNIQUE,
                         format!(
-                            "cannot insert {requested} row for schema '{}' row_pk {:?}: a canonical {existing} row already exists; delete it first",
-                            insert.row.schema_key, insert.row.row_pk,
+                            "cannot insert {requested} row for schema '{}': a canonical {existing} row with the same primary key already exists; delete it first",
+                            insert.row.schema_key,
                         ),
                     ),
                     insert.statement_index,
@@ -2490,7 +2490,7 @@ fn validate_typed_primary_key_identity(
     typed: &WasmTypedRow,
 ) -> Result<(), LixError> {
     if !row.row_pk().matches_schema_values(&typed.row_pk) {
-        let derived = RowPk::from_schema_values(&typed.row_pk).map_err(|error| {
+        let _derived = RowPk::from_schema_values(&typed.row_pk).map_err(|error| {
             LixError::new(
                 LixError::CODE_SCHEMA_VALIDATION,
                 format!(
@@ -2502,10 +2502,8 @@ fn validate_typed_primary_key_identity(
         return Err(LixError::new(
             LixError::CODE_UNIQUE,
             format!(
-                "primary-key constraint violation on schema '{}': durable row_pk '{}' does not match typed primary key '{}'",
-                row.schema_key(),
-                row.row_pk().as_json_array_text()?,
-                derived.as_json_array_text()?
+                "primary-key constraint violation on schema '{}': the stored identity does not match the typed primary-key columns",
+                row.schema_key()
             ),
         ));
     }
@@ -2571,10 +2569,8 @@ fn validate_primary_key_identity(
         return Err(LixError::new(
             LixError::CODE_UNIQUE,
             format!(
-                "primary-key constraint violation on schema '{}': row_pk '{}' does not match derived primary key '{}'",
-                row.schema_key(),
-                row.row_pk().as_json_array_text()?,
-                derived.as_json_array_text()?
+                "primary-key constraint violation on schema '{}': the stored identity does not match the primary-key columns",
+                row.schema_key()
             ),
         ));
     }

--- a/packages/lix/tests/adapter_undo_redo_checkpoint.rs
+++ b/packages/lix/tests/adapter_undo_redo_checkpoint.rs
@@ -47,7 +47,7 @@ where
     )
     .await
     .expect("seed rows commit");
-    lix.create_checkpoint()
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
         .await
         .expect("seed checkpoint commits");
     lix.execute(
@@ -56,7 +56,9 @@ where
     )
     .await
     .expect("A commits");
-    lix.create_checkpoint().await.expect("A checkpoint commits");
+    lix.execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+        .await
+        .expect("A checkpoint commits");
     lix.execute(
         "UPDATE lix_key_value SET value = 'b1' WHERE key = $1",
         &[Value::Text(B_KEY.to_string())],

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -38,7 +38,9 @@ simulation_test!(create_branch_rejects_existing_id, |sim| async move {
 
     assert_eq!(error.code, "LIX_ERROR_UNIQUE");
     assert!(
-        error.to_string().contains("INSERT would duplicate row_pk"),
+        error
+            .to_string()
+            .contains("INSERT would duplicate a primary key"),
         "error should explain the duplicate branch id: {error:?}"
     );
     assert_branch_descriptor(&main, "01930000-0000-7000-8000-000000000001", "Draft").await;
@@ -821,10 +823,7 @@ simulation_test!(
         assert_eq!(
             working_diffs.rows()[0].values(),
             &[
-                Value::Jsonb(
-                    JsonValue::Array(vec![JsonValue::String("draft-merge-source".to_string())])
-                        .into()
-                ),
+                Value::Text("draft-merge-source".to_string()),
                 Value::Text("added".to_string()),
             ],
             "the selected source delta must remain visible against the target checkpoint"
@@ -832,10 +831,7 @@ simulation_test!(
         assert_eq!(
             working_diffs.rows()[1].values(),
             &[
-                Value::Jsonb(
-                    JsonValue::Array(vec![JsonValue::String("main-merge-target".to_string())])
-                        .into()
-                ),
+                Value::Text("main-merge-target".to_string()),
                 Value::Text("added".to_string()),
             ],
             "the target delta must remain visible against the target checkpoint"
@@ -1239,7 +1235,7 @@ simulation_test!(
             "SELECT count(*) \
 	     FROM lix_change \
 	     WHERE schema_key = 'lix_key_value' \
-	       AND row_pk = CAST('[\"merge-select-change\"]' AS JSONB) \
+	       AND row_ref = lix_row_ref('lix_key_value', 'merge-select-change') \
 	       AND snapshot_content = CAST('{\"key\":\"merge-select-change\",\"value\":\"source\"}' AS JSONB)",
         )
         .await;
@@ -2304,24 +2300,15 @@ simulation_test!(
             actual,
             vec![
                 vec![
-                    Value::Jsonb(
-                        JsonValue::Array(vec![JsonValue::String("branch-broad-a".to_string())])
-                            .into()
-                    ),
+                    Value::Text("branch-broad-a".to_string()),
                     Value::Text("modified".to_string()),
                 ],
                 vec![
-                    Value::Jsonb(
-                        JsonValue::Array(vec![JsonValue::String("branch-broad-b".to_string())])
-                            .into()
-                    ),
+                    Value::Text("branch-broad-b".to_string()),
                     Value::Text("modified".to_string()),
                 ],
                 vec![
-                    Value::Jsonb(
-                        JsonValue::Array(vec![JsonValue::String("branch-broad-new".to_string())])
-                            .into()
-                    ),
+                    Value::Text("branch-broad-new".to_string()),
                     Value::Text("added".to_string()),
                 ],
             ],

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -810,7 +810,7 @@ simulation_test!(
         let working_diffs = main
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT key, diff_type FROM {} ORDER BY key",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2014,7 +2014,7 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT diff_type, from_value, to_value FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"branch-baseline\"]' AS JSONB)",
+                     WHERE key = 'branch-baseline'",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2072,9 +2072,9 @@ simulation_test!(
         draft
             .execute(
                 &format!(
-                    "INSERT INTO lix_revert (relation, row_pk) \
-                     SELECT 'lix_key_value', lixcol_row_pk FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"branch-revert\"]' AS JSONB)",
+                    "INSERT INTO lix_revert (row_ref) \
+                     SELECT row_ref FROM {} \
+                     WHERE key = 'branch-revert'",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2133,7 +2133,7 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT diff_type, from_value FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"merge-baseline\"]' AS JSONB)",
+                     WHERE key = 'merge-baseline'",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2186,7 +2186,7 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT diff_type, from_value FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"branch-delete\"]' AS JSONB)",
+                     WHERE key = 'branch-delete'",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2208,7 +2208,7 @@ simulation_test!(
         let broad = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT key, diff_type FROM {} ORDER BY key",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2288,7 +2288,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT key, diff_type FROM {} ORDER BY key",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2370,7 +2370,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT key, diff_type FROM {} ORDER BY key",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],
@@ -2433,7 +2433,7 @@ simulation_test!(
             .execute(
                 &format!(
                     "SELECT diff_type, from_value FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"switch-baseline\"]' AS JSONB)",
+                     WHERE key = 'switch-baseline'",
                     key_value_diff_relation(&main).await
                 ),
                 &[],
@@ -2488,7 +2488,7 @@ simulation_test!(
         let rows = draft
             .execute(
                 &format!(
-                    "SELECT lixcol_row_pk FROM {}",
+                    "SELECT key FROM {}",
                     key_value_diff_relation(&draft).await
                 ),
                 &[],

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -98,13 +98,13 @@ simulation_test!(
         let (raw_session, session) = open_default_session(&sim, &engine).await;
         let mut events = raw_session
             .observe(
-                "SELECT lixcol_row_pk, diff_type \
+                "SELECT key, diff_type \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \
                    lix_active_branch_commit_id()\
                  ) \
-                 ORDER BY lixcol_row_pk",
+                 ORDER BY key",
                 &[],
             )
             .expect("checkpoint-to-head diff should open as one observed query");

--- a/packages/lix/tests/integration/observe.rs
+++ b/packages/lix/tests/integration/observe.rs
@@ -124,7 +124,7 @@ simulation_test!(
         assert_eq!(
             changed.rows.rows()[0].values(),
             &[
-                Value::Jsonb(json!(["observe-checkpoint"]).into()),
+                Value::Text("observe-checkpoint".to_string()),
                 Value::Text("added".to_string()),
             ]
         );
@@ -151,7 +151,7 @@ simulation_test!(
         assert_eq!(
             changed_again.rows.rows()[0].values(),
             &[
-                Value::Jsonb(json!(["observe-checkpoint"]).into()),
+                Value::Text("observe-checkpoint".to_string()),
                 Value::Text("modified".to_string()),
             ]
         );

--- a/packages/lix/tests/integration/sql.rs
+++ b/packages/lix/tests/integration/sql.rs
@@ -112,6 +112,7 @@ mod lix_key_value;
 mod lix_registered_schema;
 mod metadata;
 mod read_only;
+mod row_ref;
 mod subquery_reads;
 mod subquery_writes;
 mod udfs;

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -158,7 +158,7 @@ simulation_test!(
             )
             .await,
             vec![vec![
-                Value::Jsonb(json!(["checkpoint-key"]).into()),
+                Value::Text("checkpoint-key".to_string()),
                 Value::Text("added".to_string()),
             ]]
         );
@@ -173,7 +173,7 @@ simulation_test!(
             )
             .await,
             vec![vec![
-                Value::Jsonb(json!(["checkpoint-key"]).into()),
+                Value::Text("checkpoint-key".to_string()),
                 Value::Text("added".to_string()),
             ]]
         );
@@ -236,14 +236,15 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT schema_key, row_pk FROM lix_change WHERE id = '{}'",
-                    receipt.change_id
+                    "SELECT schema_key, row_ref = lix_row_ref('lix_checkpoint', '{}') \
+                     FROM lix_change WHERE id = '{}'",
+                    receipt.commit_id, receipt.change_id
                 ),
             )
             .await,
             vec![vec![
                 Value::Text("lix_checkpoint".to_string()),
-                Value::Jsonb(json!([receipt.commit_id.clone()]).into()),
+                Value::Boolean(true),
             ]],
             "checkpoint publication must be a normal logical change"
         );
@@ -412,6 +413,339 @@ simulation_test!(
             )
             .await
             .expect("schema registrations must remain visible after partial checkpoint");
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_closes_unique_value_swaps,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let schema = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "checkpoint_unique_swap",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "slug", "type": "text", "nullable": false }
+            ],
+            "primary_key": ["id"],
+            "unique": [["slug"]]
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (schema_key, value) VALUES ($1, CAST($2 AS JSONB))",
+                &[
+                    Value::Text("checkpoint_unique_swap".into()),
+                    Value::Text(schema.to_string()),
+                ],
+            )
+            .await
+            .expect("schema registration should succeed");
+        session
+            .execute(
+                "INSERT INTO checkpoint_unique_swap (id, slug) VALUES ('a', 'x'), ('b', 'y')",
+                &[],
+            )
+            .await
+            .expect("baseline rows should insert");
+        session
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        session
+            .execute("DELETE FROM checkpoint_unique_swap WHERE id IN ('a', 'b')", &[])
+            .await
+            .expect("baseline owners should delete");
+        session
+            .execute(
+                "INSERT INTO checkpoint_unique_swap (id, slug) VALUES ('a', 'y'), ('b', 'x')",
+                &[],
+            )
+            .await
+            .expect("swapped rows should insert together");
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('checkpoint_unique_swap', 'a')])",
+                &[],
+            )
+            .await
+            .expect("checkpoint planner should close over the other unique owner");
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT COUNT(*) FROM lix_diff('checkpoint_unique_swap')",
+            )
+            .await,
+            vec![vec![Value::Integer(0)]],
+            "a unique-value swap must cross the checkpoint boundary atomically"
+        );
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_closes_file_ownership_from_semantic_rows,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let schema = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "checkpoint_file_member",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "value", "type": "text", "nullable": false }
+            ],
+            "primary_key": ["id"]
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (schema_key, value) VALUES ($1, CAST($2 AS JSONB))",
+                &[
+                    Value::Text("checkpoint_file_member".into()),
+                    Value::Text(schema.to_string()),
+                ],
+            )
+            .await
+            .expect("schema registration should succeed");
+        let file_id = "01950000-0000-7000-8000-000000000021";
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES ($1, '/owned.txt', CAST('x' AS BYTEA))",
+                &[Value::Text(file_id.into())],
+            )
+            .await
+            .expect("file should insert");
+        session
+            .execute(
+                "INSERT INTO checkpoint_file_member (id, value, lixcol_file_id) VALUES ('member', 'value', $1)",
+                &[Value::Text(file_id.into())],
+            )
+            .await
+            .expect("file-owned semantic row should insert");
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('checkpoint_file_member', 'member')])",
+                &[],
+            )
+            .await
+            .expect("direct semantic selection should include its file descriptor");
+        for relation in ["checkpoint_file_member", "lix_file"] {
+            assert_eq!(
+                select_rows(&session, &format!("SELECT COUNT(*) FROM lix_diff('{relation}')")).await,
+                vec![vec![Value::Integer(0)]],
+                "owned row and file descriptor must cross together"
+            );
+        }
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_closes_file_path_swaps,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let first_id = "01950000-0000-7000-8000-000000000031";
+        let second_id = "01950000-0000-7000-8000-000000000032";
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+                 ($1, '/first.txt', CAST('first' AS BYTEA)), \
+                 ($2, '/second.txt', CAST('second' AS BYTEA))",
+                &[
+                    Value::Text(first_id.into()),
+                    Value::Text(second_id.into()),
+                ],
+            )
+            .await
+            .expect("baseline files should insert");
+        session
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        session
+            .execute("DELETE FROM lix_file WHERE id IN ($1, $2)", &[
+                Value::Text(first_id.into()),
+                Value::Text(second_id.into()),
+            ])
+            .await
+            .expect("baseline path owners should delete together");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+                 ($1, '/second.txt', CAST('first' AS BYTEA)), \
+                 ($2, '/first.txt', CAST('second' AS BYTEA))",
+                &[
+                    Value::Text(first_id.into()),
+                    Value::Text(second_id.into()),
+                ],
+            )
+            .await
+            .expect("swapped files should insert together");
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('lix_file', $1)])",
+                &[Value::Text(first_id.into())],
+            )
+            .await
+            .expect("checkpoint planner should close over the other path owner");
+        assert_eq!(
+            select_rows(&session, "SELECT COUNT(*) FROM lix_diff('lix_file')").await,
+            vec![vec![Value::Integer(0)]],
+            "a path swap must cross the checkpoint boundary atomically"
+        );
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_keeps_equal_file_names_in_distinct_directories_independent,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, parent_id, name) VALUES \
+                 ('01950000-0000-7000-8000-000000000041', NULL, 'left'), \
+                 ('01950000-0000-7000-8000-000000000042', NULL, 'right')",
+                &[],
+            )
+            .await
+            .expect("directories should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+                 ('01950000-0000-7000-8000-000000000043', '/left/same.txt', CAST('left' AS BYTEA)), \
+                 ('01950000-0000-7000-8000-000000000044', '/right/same.txt', CAST('right' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("same names in different directories should insert");
+        session
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        session
+            .execute(
+                "UPDATE lix_file SET content = CAST('changed' AS BYTEA) WHERE id IN (\
+                 '01950000-0000-7000-8000-000000000043', \
+                 '01950000-0000-7000-8000-000000000044')",
+                &[],
+            )
+            .await
+            .expect("both files should change");
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref(\
+                 'lix_file', '01950000-0000-7000-8000-000000000043')])",
+                &[],
+            )
+            .await
+            .expect("distinct directory namespaces must not collide");
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT id FROM lix_diff('lix_file') ORDER BY id",
+            )
+            .await,
+            vec![vec![Value::Text(
+                "01950000-0000-7000-8000-000000000044".into(),
+            )]],
+            "the independently changed file stays in the working interval"
+        );
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_closes_nested_file_directory_name_swaps,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let parent_id = "01950000-0000-7000-8000-000000000051";
+        let directory_id = "01950000-0000-7000-8000-000000000052";
+        let file_id = "01950000-0000-7000-8000-000000000053";
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, parent_id, name) VALUES \
+                 ($1, NULL, 'parent'), ($2, $1, 'directory-name')",
+                &[
+                    Value::Text(parent_id.into()),
+                    Value::Text(directory_id.into()),
+                ],
+            )
+            .await
+            .expect("nested directories should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+                 ($1, '/parent/file-name', CAST('file' AS BYTEA))",
+                &[Value::Text(file_id.into())],
+            )
+            .await
+            .expect("nested file should insert");
+        session
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        session
+            .execute("DELETE FROM lix_file WHERE id = $1", &[Value::Text(file_id.into())])
+            .await
+            .expect("file should delete");
+        session
+            .execute(
+                "DELETE FROM lix_directory WHERE id = $1",
+                &[Value::Text(directory_id.into())],
+            )
+            .await
+            .expect("empty child directory should delete");
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, parent_id, name) VALUES ($1, $2, 'file-name')",
+                &[
+                    Value::Text(directory_id.into()),
+                    Value::Text(parent_id.into()),
+                ],
+            )
+            .await
+            .expect("directory should take the former file name");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+                 ($1, '/parent/directory-name', CAST('file' AS BYTEA))",
+                &[Value::Text(file_id.into())],
+            )
+            .await
+            .expect("file should take the former directory name");
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('lix_file', $1)])",
+                &[Value::Text(file_id.into())],
+            )
+            .await
+            .expect("cross-kind nested namespace swap should close atomically");
+        for relation in ["lix_file", "lix_directory"] {
+            assert_eq!(
+                select_rows(&session, &format!("SELECT COUNT(*) FROM lix_diff('{relation}')")).await,
+                vec![vec![Value::Integer(0)]],
+                "both sides of the nested namespace swap must cross together"
+            );
+        }
     }
 );
 
@@ -621,6 +955,21 @@ simulation_test!(
             "rollback publishes neither checkpoint nor post-commit effects"
         );
 
+        let mut write_then_checkpoint = session.begin_transaction().await.expect("transaction opens");
+        write_then_checkpoint
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('same-transaction', 'value')",
+                &[],
+            )
+            .await
+            .expect("tracked write should stage");
+        let error = write_then_checkpoint
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect_err("checkpoint planning cannot ignore an earlier staged write");
+        assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+        write_then_checkpoint.rollback().await.expect("rollback succeeds");
+
         let mut committed = session.begin_transaction().await.expect("transaction opens");
         committed
             .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
@@ -829,11 +1178,11 @@ simulation_test!(
             .await,
             vec![
                 vec![
-                    Value::Jsonb(json!(["working-added"]).into()),
+                    Value::Text("working-added".to_string()),
                     Value::Text("added".to_string()),
                 ],
                 vec![
-                    Value::Jsonb(json!(["working-removed"]).into()),
+                    Value::Text("working-removed".to_string()),
                     Value::Text("removed".to_string()),
                 ],
             ],

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -33,9 +33,9 @@ async fn checkpoints_example_sql_contract() {
         .expect("active head commit ID should decode");
     let working_diffs = lix
         .execute(
-            "SELECT lixcol_row_pk, diff_type
+            "SELECT key, diff_type
              FROM lix_diff('lix_key_value', $1, $2)
-             ORDER BY lixcol_row_pk",
+             ORDER BY key",
             &[Value::Text(root_commit_id), Value::Text(head_commit_id)],
         )
         .await
@@ -43,9 +43,9 @@ async fn checkpoints_example_sql_contract() {
     assert_eq!(working_diffs.len(), 1);
     assert_eq!(
         working_diffs.rows()[0]
-            .get::<serde_json::Value>("lixcol_row_pk")
-            .expect("row_pk is JSON"),
-        json!(["checkpoint-demo"])
+            .get::<String>("key")
+            .expect("key is text"),
+        "checkpoint-demo"
     );
     assert_eq!(
         working_diffs.rows()[0]
@@ -152,7 +152,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT key, diff_type FROM {} ORDER BY key",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -166,8 +166,8 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"checkpoint-key\"]' AS JSONB)",
+                    "SELECT key, diff_type FROM {} \
+                     WHERE key = 'checkpoint-key'",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -181,8 +181,8 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"other-key\"]' AS JSONB)",
+                    "SELECT key FROM {} \
+                     WHERE key = 'other-key'",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -518,7 +518,7 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk, diff_type FROM {} ORDER BY lixcol_row_pk",
+                    "SELECT key, diff_type FROM {} ORDER BY key",
                     key_value_diff_relation(&session).await
                 ),
             )
@@ -540,7 +540,7 @@ simulation_test!(
                 &session,
                 &format!(
                     "SELECT diff_type FROM {} \
-                     WHERE lixcol_row_pk = CAST('[\"working-removed\"]' AS JSONB)",
+                     WHERE key = 'working-removed'",
                     key_value_diff_relation(&session).await
                 ),
             )

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -336,6 +336,310 @@ simulation_test!(
 );
 
 simulation_test!(
+    scoped_checkpoint_closes_schema_and_foreign_key_dependencies,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let parent_schema = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "checkpoint_parent",
+            "columns": [{ "name": "id", "type": "text", "nullable": false }],
+            "primary_key": ["id"]
+        });
+        let child_schema = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "checkpoint_child",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "parent_id", "type": "text", "nullable": false }
+            ],
+            "primary_key": ["id"],
+            "foreign_keys": [{
+                "columns": ["parent_id"],
+                "references": { "schema_key": "checkpoint_parent", "columns": ["id"] }
+            }]
+        });
+        for schema in [parent_schema, child_schema] {
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (schema_key, value) \
+                     VALUES (CAST($1 AS JSONB) ->> 'key', CAST($1 AS JSONB))",
+                    &[Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("schema registration should succeed");
+        }
+        session
+            .execute("INSERT INTO checkpoint_parent (id) VALUES ('parent-a')", &[])
+            .await
+            .expect("parent insert should succeed");
+        session
+            .execute(
+                "INSERT INTO checkpoint_child (id, parent_id) VALUES ('child-a', 'parent-a')",
+                &[],
+            )
+            .await
+            .expect("child insert should succeed");
+
+        let checkpoint = session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[\
+                    lix_row_ref('checkpoint_child', 'child-a')\
+                 ])",
+                &[],
+            )
+            .await
+            .expect("scoped checkpoint should close dependencies");
+        assert_eq!(checkpoint.len(), 1);
+        for relation in ["checkpoint_child", "checkpoint_parent"] {
+            assert_eq!(
+                select_rows(
+                    &session,
+                    &format!("SELECT COUNT(*) FROM lix_diff('{relation}')"),
+                )
+                .await,
+                vec![vec![Value::Integer(0)]],
+                "selected child and its changed parent must cross together"
+            );
+        }
+        session
+            .execute(
+                "INSERT INTO checkpoint_child (id, parent_id) VALUES ('child-b', 'parent-a')",
+                &[],
+            )
+            .await
+            .expect("schema registrations must remain visible after partial checkpoint");
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_accepts_directory_and_mixed_relation_row_refs,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, parent_id, name) VALUES \
+                 ('01950000-0000-7000-8000-000000000010', NULL, 'parent'), \
+                 ('01950000-0000-7000-8000-000000000011', \
+                  '01950000-0000-7000-8000-000000000010', 'child')",
+                &[],
+            )
+            .await
+            .expect("directories should insert");
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('mixed-row', 'value')",
+                &[],
+            )
+            .await
+            .expect("custom row should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+                 ('01950000-0000-7000-8000-000000000012', '/unselected.txt', CAST('x' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("unselected file should insert");
+
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[\
+                    lix_row_ref('lix_directory', '01950000-0000-7000-8000-000000000011'),\
+                    lix_row_ref('lix_key_value', 'mixed-row')\
+                 ])",
+                &[],
+            )
+            .await
+            .expect("mixed relation checkpoint should succeed");
+        assert_eq!(
+            select_rows(&session, "SELECT COUNT(*) FROM lix_diff('lix_directory')").await,
+            vec![vec![Value::Integer(0)]],
+            "direct directory selection includes its changed ancestor"
+        );
+        assert_eq!(
+            select_rows(&session, "SELECT COUNT(*) FROM lix_diff('lix_key_value')").await,
+            vec![vec![Value::Integer(0)]]
+        );
+        assert_eq!(
+            select_rows(&session, "SELECT COUNT(*) FROM lix_diff('lix_file')").await,
+            vec![vec![Value::Integer(1)]],
+            "unselected relation rows remain in the working interval"
+        );
+    }
+);
+
+simulation_test!(
+    scoped_checkpoint_closes_reverse_foreign_keys_for_deleted_targets,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        for schema in [
+            json!({
+                "$schema": "https://lix.dev/schema-v1.json",
+                "key": "checkpoint_delete_parent",
+                "columns": [{ "name": "id", "type": "text", "nullable": false }],
+                "primary_key": ["id"]
+            }),
+            json!({
+                "$schema": "https://lix.dev/schema-v1.json",
+                "key": "checkpoint_delete_child",
+                "columns": [
+                    { "name": "id", "type": "text", "nullable": false },
+                    { "name": "parent_id", "type": "text", "nullable": false }
+                ],
+                "primary_key": ["id"],
+                "foreign_keys": [{
+                    "columns": ["parent_id"],
+                    "references": {
+                        "schema_key": "checkpoint_delete_parent",
+                        "columns": ["id"]
+                    }
+                }]
+            }),
+        ] {
+            session
+                .execute(
+                    "INSERT INTO lix_registered_schema (schema_key, value) \
+                     VALUES (CAST($1 AS JSONB) ->> 'key', CAST($1 AS JSONB))",
+                    &[Value::Text(schema.to_string())],
+                )
+                .await
+                .expect("schema registration should succeed");
+        }
+        session
+            .execute(
+                "INSERT INTO checkpoint_delete_parent (id) VALUES ('parent-a')",
+                &[],
+            )
+            .await
+            .expect("parent should insert");
+        session
+            .execute(
+                "INSERT INTO checkpoint_delete_child (id, parent_id) \
+                 VALUES ('child-a', 'parent-a')",
+                &[],
+            )
+            .await
+            .expect("child should insert");
+        session
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        session
+            .execute(
+                "DELETE FROM checkpoint_delete_child WHERE id = 'child-a'",
+                &[],
+            )
+            .await
+            .expect("child should delete first");
+        session
+            .execute(
+                "DELETE FROM checkpoint_delete_parent WHERE id = 'parent-a'",
+                &[],
+            )
+            .await
+            .expect("parent should delete after child");
+        session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[\
+                    lix_row_ref('checkpoint_delete_parent', 'parent-a')\
+                 ])",
+                &[],
+            )
+            .await
+            .expect("parent deletion must close over the changed child deletion");
+
+        for relation in ["checkpoint_delete_parent", "checkpoint_delete_child"] {
+            assert_eq!(
+                select_rows(
+                    &session,
+                    &format!("SELECT COUNT(*) FROM lix_diff('{relation}')"),
+                )
+                .await,
+                vec![vec![Value::Integer(0)]],
+                "parent and child deletions must cross the checkpoint together"
+            );
+        }
+    }
+);
+
+simulation_test!(
+    checkpoint_function_obeys_outer_transaction_and_empty_scope,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('transaction-row', 'value')",
+                &[],
+            )
+            .await
+            .expect("working row should insert");
+        let head_before_empty = select_rows(
+            &session,
+            "SELECT lix_active_branch_commit_id()",
+        )
+        .await;
+        assert!(session
+            .execute(
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY[])",
+                &[],
+            )
+            .await
+            .expect("empty scoped checkpoint is a no-op")
+            .is_empty());
+        assert_eq!(
+            select_rows(&session, "SELECT lix_active_branch_commit_id()").await,
+            head_before_empty,
+            "empty scope must never alias full checkpoint"
+        );
+
+        let mut rolled_back = session.begin_transaction().await.expect("transaction opens");
+        rolled_back
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("checkpoint may stage in transaction");
+        rolled_back.rollback().await.expect("rollback succeeds");
+        assert_eq!(
+            select_rows(&session, "SELECT COUNT(*) FROM lix_diff('lix_key_value')").await,
+            vec![vec![Value::Integer(1)]],
+            "rollback publishes neither checkpoint nor post-commit effects"
+        );
+
+        let mut committed = session.begin_transaction().await.expect("transaction opens");
+        committed
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("first checkpoint stages");
+        let duplicate = committed
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect_err("one transaction cannot publish two checkpoints");
+        assert_eq!(duplicate.code, "LIX_INVALID_TRANSACTION_STATE");
+        committed.commit().await.expect("first checkpoint commits");
+        assert_eq!(
+            select_rows(&session, "SELECT COUNT(*) FROM lix_diff('lix_key_value')").await,
+            vec![vec![Value::Integer(0)]]
+        );
+    }
+);
+
+simulation_test!(
     checkpoint_surface_is_global_row_and_read_only,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -459,3 +459,165 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    scoped_file_revert_restores_removed_parent_directory,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let directory_id = "01950000-0000-7000-8000-000000000001";
+        let file_id = "01950000-0000-7000-8000-000000000002";
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES ($1, '/docs')",
+                &[Value::Text(directory_id.to_owned())],
+            )
+            .await
+            .expect("parent directory should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) \
+                 VALUES ($1, '/docs/a.md', CAST('hello' AS BYTEA))",
+                &[Value::Text(file_id.to_owned())],
+            )
+            .await
+            .expect("child file should insert");
+        session
+            .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+            .await
+            .expect("baseline checkpoint should succeed");
+
+        session
+            .execute(
+                "DELETE FROM lix_directory WHERE id = $1",
+                &[Value::Text(directory_id.to_owned())],
+            )
+            .await
+            .expect("recursive directory delete should succeed");
+        session
+            .execute(
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref FROM lix_diff('lix_file') WHERE id = $1 \
+                 RETURNING commit_id",
+                &[Value::Text(file_id.to_owned())],
+            )
+            .await
+            .expect("file revert should close over its removed parent directory");
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT path FROM lix_directory WHERE id = '01950000-0000-7000-8000-000000000001'",
+            )
+            .await,
+            vec![vec![Value::Text("/docs".to_owned())]],
+        );
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT path FROM lix_file WHERE id = '01950000-0000-7000-8000-000000000002'",
+            )
+            .await,
+            vec![vec![Value::Text("/docs/a.md".to_owned())]],
+        );
+    }
+);
+
+simulation_test!(
+    scoped_file_apply_creates_changed_parent_directory,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        let baseline = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("baseline head should load")
+            .expect("baseline head should exist")
+            .to_string();
+        let directory_id = "01950000-0000-7000-8000-000000000011";
+        let file_id = "01950000-0000-7000-8000-000000000012";
+        session
+            .execute(
+                "INSERT INTO lix_directory (id, path) VALUES ($1, '/apply-docs')",
+                &[Value::Text(directory_id.to_owned())],
+            )
+            .await
+            .expect("parent directory should insert");
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) \
+                 VALUES ($1, '/apply-docs/a.md', CAST('hello' AS BYTEA))",
+                &[Value::Text(file_id.to_owned())],
+            )
+            .await
+            .expect("child file should insert");
+        let target = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .expect("target head should load")
+            .expect("target head should exist")
+            .to_string();
+
+        session
+            .execute(
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref FROM lix_diff('lix_file') WHERE id = $1",
+                &[Value::Text(file_id.to_owned())],
+            )
+            .await
+            .expect("precondition revert should remove the file");
+        session
+            .execute(
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref FROM lix_diff('lix_directory') WHERE id = $1",
+                &[Value::Text(directory_id.to_owned())],
+            )
+            .await
+            .expect("precondition revert should remove the parent directory");
+        assert!(
+            select_rows(
+                &session,
+                "SELECT id FROM lix_directory WHERE id = '01950000-0000-7000-8000-000000000011'",
+            )
+            .await
+            .is_empty(),
+            "the apply dependency must actually be absent before the command",
+        );
+        session
+            .execute(
+                "INSERT INTO lix_apply (row_ref) \
+                 SELECT row_ref FROM lix_diff('lix_file', $1, $2) WHERE id = $3 \
+                 RETURNING commit_id",
+                &[
+                    Value::Text(baseline),
+                    Value::Text(target),
+                    Value::Text(file_id.to_owned()),
+                ],
+            )
+            .await
+            .expect("file apply should close over its changed parent directory");
+
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT path FROM lix_directory WHERE id = '01950000-0000-7000-8000-000000000011'",
+            )
+            .await,
+            vec![vec![Value::Text("/apply-docs".to_owned())]],
+        );
+        assert_eq!(
+            select_rows(
+                &session,
+                "SELECT path FROM lix_file WHERE id = '01950000-0000-7000-8000-000000000012'",
+            )
+            .await,
+            vec![vec![Value::Text("/apply-docs/a.md".to_owned())]],
+        );
+    }
+);

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -146,8 +146,9 @@ simulation_test!(
         let duplicate = session
             .execute(
                 "INSERT INTO lix_revert (row_ref) \
-                 VALUES (lix_row_ref('lix_key_value', 'b')), \
-                        (lix_row_ref('lix_key_value', 'b'))",
+                 SELECT lix_row_ref('lix_key_value', 'b') \
+                 UNION ALL \
+                 SELECT lix_row_ref('lix_key_value', 'b')",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/diff_commands.rs
+++ b/packages/lix/tests/integration/sql/diff_commands.rs
@@ -1,5 +1,4 @@
 use lix::{LixError, Value};
-use serde_json::json;
 
 use super::select_rows;
 
@@ -32,7 +31,7 @@ simulation_test!(
         let working = select_rows(
             &session,
             &format!(
-                "SELECT lixcol_row_pk, diff_type FROM lix_diff('lix_key_value', '{baseline}', '{original_head}') ORDER BY lixcol_row_pk"
+                "SELECT key, diff_type FROM lix_diff('lix_key_value', '{baseline}', '{original_head}') ORDER BY key"
             ),
         )
         .await;
@@ -47,12 +46,12 @@ simulation_test!(
 
         let reverted = session
             .execute(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff(\
                    'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
                  ) \
-                 WHERE lixcol_row_pk ->> 0 IN ('a', 'b') \
+                 WHERE key IN ('a', 'b') \
                  RETURNING commit_id",
                 &[],
             )
@@ -72,10 +71,10 @@ simulation_test!(
 
         let applied = session
             .execute(
-                "INSERT INTO lix_apply (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_apply (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff('lix_key_value', lix_root_commit_id(), $1) \
-                 WHERE lixcol_row_pk ->> 0 IN ('a', 'b') \
+                 WHERE key IN ('a', 'b') \
                  RETURNING commit_id",
                 &[Value::Text(original_head)],
             )
@@ -87,18 +86,16 @@ simulation_test!(
 
         let checkpointed = session
             .execute(
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref \
                  FROM lix_diff(\
                    'lix_key_value', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()\
                  ) \
-                 WHERE lixcol_row_pk = CAST('[\"a\"]' AS JSONB) \
-                 RETURNING commit_id",
+                 WHERE key = 'a'))",
                 &[],
             )
             .await
             .expect("partial relation-row checkpoint should succeed");
-        assert_eq!(checkpointed.rows_affected(), 1);
         let checkpoint_commit_id = match checkpointed.get(&checkpointed.rows()[0], "commit_id") {
             Some(Value::Text(commit_id)) => commit_id.clone(),
             value => panic!("checkpoint RETURNING should contain a commit ID, got {value:?}"),
@@ -114,17 +111,17 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT lixcol_row_pk FROM lix_diff('lix_key_value', '{checkpoint_commit_id}', '{child_head}')"
+                    "SELECT key FROM lix_diff('lix_key_value', '{checkpoint_commit_id}', '{child_head}')"
                 ),
             )
             .await,
-            vec![vec![Value::Jsonb(json!(["b"]).into())]]
+            vec![vec![Value::Text("b".to_string())]]
         );
 
         let empty = session
             .execute(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff('lix_key_value', $1, $2) WHERE 1 = 0 \
                  RETURNING commit_id",
                 &[
@@ -148,10 +145,9 @@ simulation_test!(
 
         let duplicate = session
             .execute(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT relation, CAST(row_pk AS JSONB) FROM \
-                 (VALUES ('lix_key_value', '[\"b\"]'), ('lix_key_value', '[\"b\"]')) \
-                 AS selected(relation, row_pk)",
+                "INSERT INTO lix_revert (row_ref) \
+                 VALUES (lix_row_ref('lix_key_value', 'b')), \
+                        (lix_row_ref('lix_key_value', 'b'))",
                 &[],
             )
             .await
@@ -197,8 +193,8 @@ simulation_test!(
 
         let reverted = session
             .execute(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \
@@ -222,8 +218,8 @@ simulation_test!(
 
         let applied = session
             .execute(
-                "INSERT INTO lix_apply (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "INSERT INTO lix_apply (row_ref) \
+                 SELECT row_ref \
                  FROM lix_diff(\
                    'lix_key_value', \
                    lix_latest_checkpoint_commit_id(), \
@@ -268,12 +264,11 @@ simulation_test!(
             .expect("first insert should succeed");
         let first = session
             .execute(
-                "INSERT INTO lix_create_checkpoint DEFAULT VALUES RETURNING commit_id",
+                "SELECT commit_id FROM lix_create_checkpoint()",
                 &[],
             )
             .await
             .expect("full metadata-only SQL checkpoint should succeed");
-        assert_eq!(first.rows_affected(), 1);
         assert_eq!(first.columns(), &["commit_id"]);
 
         session
@@ -282,7 +277,7 @@ simulation_test!(
             .expect("delete should succeed");
         let deleted_checkpoint = session
             .execute(
-                "INSERT INTO lix_create_checkpoint DEFAULT VALUES RETURNING commit_id",
+                "SELECT commit_id FROM lix_create_checkpoint()",
                 &[],
             )
             .await
@@ -310,7 +305,7 @@ simulation_test!(
                 &session,
                 &format!(
                     "SELECT diff_type FROM lix_diff('lix_key_value', '{checkpoint_id}', '{head}') \
-                     WHERE lixcol_row_pk = CAST('[\"recycled\"]' AS JSONB)"
+                     WHERE key = 'recycled'"
                 ),
             )
             .await,
@@ -319,8 +314,8 @@ simulation_test!(
 
         let reverted = session
             .execute(
-                "INSERT INTO lix_revert (relation, row_pk) \
-                 SELECT 'lix_key_value', CAST('[\"recycled\"]' AS JSONB) \
+                "INSERT INTO lix_revert (row_ref) \
+                 SELECT lix_row_ref('lix_key_value', 'recycled') \
                  RETURNING commit_id",
                 &[],
             )
@@ -365,17 +360,15 @@ simulation_test!(
 
         let checkpointed = session
             .execute(
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_key_value', lixcol_row_pk \
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref \
                  FROM lix_diff('lix_key_value', $1, $2) \
-                 WHERE lixcol_row_pk ->> 0 IN ('a', 'b', 'c') \
-                 RETURNING commit_id",
+                 WHERE key IN ('a', 'b', 'c')))",
                 &[Value::Text(baseline), Value::Text(head)],
             )
             .await
             .expect("multi-selection checkpoint should succeed");
 
-        assert_eq!(checkpointed.rows_affected(), 3);
         assert_eq!(checkpointed.columns(), &["commit_id"]);
         assert_eq!(
             checkpointed.rows().len(),
@@ -427,14 +420,13 @@ simulation_test!(
             .to_string();
         let checkpoint = session
             .execute(
-                "INSERT INTO lix_create_checkpoint (relation, row_pk) \
-                 SELECT 'lix_file', lixcol_row_pk FROM lix_diff('lix_file', $1, $2) \
-                 WHERE to_path = '/docs/nested/readme.txt' RETURNING commit_id",
+                "SELECT commit_id FROM lix_create_checkpoint(ARRAY( \
+                 SELECT row_ref FROM lix_diff('lix_file', $1, $2) \
+                 WHERE to_path = '/docs/nested/readme.txt'))",
                 &[Value::Text(baseline), Value::Text(head)],
             )
             .await
             .expect("file selection must include its changed parent-directory descriptors");
-        assert_eq!(checkpoint.rows_affected(), 1);
         assert_eq!(
             select_rows(
                 &session,

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -29,16 +29,14 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_row_pk, diff_type, from_key, to_key, from_value, to_value, row_count \
+                "SELECT key, diff_type, from_value, to_value, row_count \
                  FROM lix_diff('lix_key_value', '{baseline}', '{inserted}')"
             ),
         )
         .await,
         vec![vec![
-            Value::Jsonb(json!(["note"]).into()),
-            Value::Text("added".to_string()),
-            Value::Null,
             Value::Text("note".to_string()),
+            Value::Text("added".to_string()),
             Value::Null,
             Value::Jsonb(json!("first").into()),
             Value::Integer(1),
@@ -49,15 +47,13 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_key, to_key, from_value, to_value \
+                "SELECT diff_type, from_value, to_value \
                  FROM lix_diff('lix_key_value', '{inserted}', '{baseline}')"
             ),
         )
         .await,
         vec![vec![
             Value::Text("removed".to_string()),
-            Value::Text("note".to_string()),
-            Value::Null,
             Value::Jsonb(json!("first").into()),
             Value::Null,
         ]]
@@ -79,7 +75,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
             &session,
             "SELECT count(*) FROM lix_diff(\
                  'lix_key_value', lix_root_commit_id(), lix_active_branch_commit_id()\
-             ) WHERE lixcol_row_pk = CAST('[\"note\"]' AS JSONB)",
+             ) WHERE key = 'note'",
         )
         .await,
         vec![vec![Value::Integer(1)]],
@@ -105,7 +101,7 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
             &format!(
                 "SELECT diff_type, from_value, to_value, row_count \
                  FROM lix_diff('lix_key_value', '{inserted}', '{updated}') \
-                 WHERE lixcol_row_pk = CAST('[\"note\"]' AS JSONB)"
+                 WHERE key = 'note'"
             ),
         )
         .await,
@@ -230,7 +226,7 @@ simulation_test!(working_diff_span_reports_global_provenance, |sim| async move {
             &session,
             "SELECT from_lixcol_global, to_lixcol_global \
              FROM lix_diff('lix_key_value', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()) \
-             WHERE lixcol_row_pk = CAST('[\"shadowed\"]' AS JSONB)",
+             WHERE key = 'shadowed'",
         )
         .await,
         vec![vec![Value::Boolean(true), Value::Boolean(false)]],
@@ -262,7 +258,7 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
     let added = select_rows(
         &session,
         &format!(
-            "SELECT lixcol_row_pk, diff_type, from_path, to_path, row_count \
+            "SELECT id, diff_type, from_path, to_path, row_count \
              FROM lix_diff('lix_file', '{baseline}', '{inserted}')"
         ),
     )
@@ -290,23 +286,20 @@ simulation_test!(relation_diff_aggregates_files_and_preserves_removed_paths, |si
         "reversing a file addition swaps sides and inverts its classification",
     );
     let file_id = match &added[0][0] {
-        Value::Jsonb(row_pk) => row_pk.to_value()[0]
-            .as_str()
-            .expect("file row identity is a UUID")
-            .to_string(),
-        other => panic!("file row identity should be JSONB, got {other:?}"),
+        Value::Text(id) => id.clone(),
+        other => panic!("file row identity should be text, got {other:?}"),
     };
     assert_eq!(
         select_rows(
             &session,
             &format!(
                 "SELECT count(*) FROM lix_diff('lix_file', '{baseline}', '{inserted}') \
-                 WHERE lixcol_row_pk ->> 0 = '{file_id}'"
+                 WHERE id = '{file_id}'"
             ),
         )
         .await,
         vec![vec![Value::Integer(1)]],
-        "JSON row-identity extraction remains a pushed file-scoped filter",
+        "typed primary-key equality remains a pushed file-scoped filter",
     );
     assert_eq!(
         select_rows(
@@ -562,7 +555,7 @@ simulation_test!(relation_diff_fences_machinery_from_user_column_names, |sim| as
         select_rows(
             &session,
             &format!(
-                "SELECT lixcol_row_pk, diff_type, row_count, \
+                "SELECT id, diff_type, row_count, \
                  from_diff_type, to_diff_type, from_row_count, to_row_count, \
                  from_depth, to_depth, from_from_path, to_from_path \
                  FROM lix_diff('diff_name_collision', '{baseline}', '{head}')"
@@ -570,7 +563,7 @@ simulation_test!(relation_diff_fences_machinery_from_user_column_names, |sim| as
         )
         .await,
         vec![vec![
-            Value::Jsonb(json!(["row-1"]).into()),
+            Value::Text("row-1".to_string()),
             Value::Text("added".to_string()),
             Value::Integer(1),
             Value::Null,

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -47,12 +47,13 @@ simulation_test!(relation_diff_pairs_schema_columns_and_inverts_sides, |sim| asy
         select_rows(
             &session,
             &format!(
-                "SELECT diff_type, from_value, to_value \
+                "SELECT key, diff_type, from_value, to_value \
                  FROM lix_diff('lix_key_value', '{inserted}', '{baseline}')"
             ),
         )
         .await,
         vec![vec![
+            Value::Text("note".to_string()),
             Value::Text("removed".to_string()),
             Value::Jsonb(json!("first").into()),
             Value::Null,

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -470,7 +470,7 @@ simulation_test!(relation_diff_tracks_directory_descriptor_add_rename_and_remove
     );
 });
 
-simulation_test!(relation_diff_requires_explicit_relation_and_commit_ids, |sim| async move {
+simulation_test!(relation_diff_accepts_default_range_and_rejects_partial_range, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(
         engine.open_session().await.expect("session should open"),
@@ -481,7 +481,11 @@ simulation_test!(relation_diff_requires_explicit_relation_and_commit_ids, |sim| 
         .execute("SELECT * FROM lix_diff('a', 'b')", &[])
         .await
         .expect_err("legacy two-argument lix_diff must be rejected");
-    assert!(missing_relation.message.contains("relation and exactly two commit ID arguments"));
+    assert!(
+        missing_relation
+            .message
+            .contains("requires a relation and either zero or two commit ID arguments")
+    );
 
     let unsupported = session
         .execute(

--- a/packages/lix/tests/integration/sql/history_conformance.rs
+++ b/packages/lix/tests/integration/sql/history_conformance.rs
@@ -784,6 +784,7 @@ simulation_test!(history_discovery_has_no_suffix_surfaces, |sim| async move {
         .await,
         vec![
             vec![Value::Text("lix_commit_ancestry".to_string())],
+            vec![Value::Text("lix_create_checkpoint".to_string())],
             vec![Value::Text("lix_diff".to_string())],
             vec![Value::Text("lix_history".to_string())],
             vec![Value::Text("lix_state_at".to_string())],

--- a/packages/lix/tests/integration/sql/history_conformance.rs
+++ b/packages/lix/tests/integration/sql/history_conformance.rs
@@ -124,8 +124,8 @@ simulation_test!(typed_row_history_exposes_tombstones, |sim| async move {
     session
             .execute(
                 "INSERT INTO engine_history_conformance \
-                 (lixcol_row_pk, id, value, lixcol_untracked) \
-                 VALUES (CAST('[\"history-conformance-row\"]' AS JSONB), 'history-conformance-row', 'one', false)",
+                 (id, value, lixcol_untracked) \
+                 VALUES ('history-conformance-row', 'one', false)",
                 &[],
             )
             .await
@@ -134,7 +134,7 @@ simulation_test!(typed_row_history_exposes_tombstones, |sim| async move {
         .execute(
             "UPDATE engine_history_conformance \
                  SET value = 'two' \
-                 WHERE lixcol_row_pk = CAST('[\"history-conformance-row\"]' AS JSONB)",
+                 WHERE id = 'history-conformance-row'",
             &[],
         )
         .await
@@ -142,7 +142,7 @@ simulation_test!(typed_row_history_exposes_tombstones, |sim| async move {
     session
         .execute(
             "DELETE FROM engine_history_conformance \
-                 WHERE lixcol_row_pk = CAST('[\"history-conformance-row\"]' AS JSONB)",
+                 WHERE id = 'history-conformance-row'",
             &[],
         )
         .await
@@ -150,9 +150,9 @@ simulation_test!(typed_row_history_exposes_tombstones, |sim| async move {
 
     let typed_rows = select_rows(
         &session,
-        "SELECT id, value, lixcol_row_pk, lixcol_depth \
+        "SELECT id, value, lixcol_depth \
              FROM lix_history('engine_history_conformance') \
-               WHERE lixcol_row_pk = CAST('[\"history-conformance-row\"]' AS JSONB) \
+               WHERE id = 'history-conformance-row' \
              ORDER BY lixcol_depth",
     )
     .await;
@@ -162,7 +162,6 @@ simulation_test!(typed_row_history_exposes_tombstones, |sim| async move {
         vec![
             Value::Text("history-conformance-row".to_string()),
             Value::Null,
-            Value::Jsonb(serde_json::json!(["history-conformance-row"]).into()),
             Value::Integer(0),
         ]
     );
@@ -198,7 +197,7 @@ simulation_test!(
 
         let rows = select_rows(
             &session,
-            "SELECT key, value, lixcol_row_pk, lixcol_depth \
+            "SELECT key, value, lixcol_depth \
              FROM lix_history('lix_key_value') \
                WHERE key = 'history-pk-backfill' \
              ORDER BY lixcol_depth",
@@ -211,13 +210,11 @@ simulation_test!(
                 vec![
                     Value::Text("history-pk-backfill".to_string()),
                     Value::Null,
-                    Value::Jsonb(serde_json::json!(["history-pk-backfill"]).into()),
                     Value::Integer(0),
                 ],
                 vec![
                     Value::Text("history-pk-backfill".to_string()),
                     Value::Jsonb(serde_json::json!("one").into()),
-                    Value::Jsonb(serde_json::json!(["history-pk-backfill"]).into()),
                     Value::Integer(1),
                 ],
             ]
@@ -335,7 +332,7 @@ simulation_test!(
         session
             .execute(
                 "DELETE FROM engine_history_nested_pk \
-                 WHERE lixcol_row_pk = CAST('[\"acme\",\"7\"]' AS JSONB)",
+                 WHERE tenant = 'acme' AND id = '7'",
                 &[],
             )
             .await
@@ -418,7 +415,7 @@ simulation_test!(
 
         let file_rows = select_rows(
             &session,
-            "SELECT id, path, name, content, lixcol_row_pk, lixcol_is_deleted, lixcol_depth \
+            "SELECT id, path, name, content, lixcol_is_deleted, lixcol_depth \
              FROM lix_history('lix_file') \
                WHERE id = '68697374-6f72-892d-836f-6e666f726d00' \
                AND lixcol_depth = 0",
@@ -431,7 +428,6 @@ simulation_test!(
                 Value::Null,
                 Value::Null,
                 Value::Null,
-                Value::Jsonb(serde_json::json!(["68697374-6f72-892d-836f-6e666f726d00"]).into()),
                 Value::Boolean(true),
                 Value::Integer(0),
             ]]
@@ -477,7 +473,7 @@ simulation_test!(
 
         let directory_rows = select_rows(
             &session,
-            "SELECT id, path, parent_id, name, lixcol_row_pk, lixcol_is_deleted, lixcol_depth \
+            "SELECT id, path, parent_id, name, lixcol_is_deleted, lixcol_depth \
              FROM lix_history('lix_directory') \
                WHERE id = '68697374-6f72-892d-836f-6e666f726d00' \
                AND lixcol_depth = 0",
@@ -490,7 +486,6 @@ simulation_test!(
                 Value::Null,
                 Value::Null,
                 Value::Null,
-                Value::Jsonb(serde_json::json!(["68697374-6f72-892d-836f-6e666f726d00"]).into()),
                 Value::Boolean(true),
                 Value::Integer(0),
             ]]
@@ -745,7 +740,7 @@ simulation_test!(
 
         for sql in [
             "EXPLAIN SELECT * FROM lix_history('lix_file')",
-            "EXPLAIN SELECT lixcol_row_pk FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id())",
+            "EXPLAIN SELECT row_ref FROM lix_diff('lix_file', lix_root_commit_id(), lix_active_branch_commit_id())",
         ] {
             session
                 .execute(sql, &[])

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -1581,7 +1581,7 @@ simulation_test!(
                  "INSERT INTO engine_excluded_typed_default (id) VALUES ('same') \
                  ON CONFLICT (id) DO UPDATE \
                  SET mirror = excluded.status, \
-                     identity_copy = CAST(excluded.id AS JSONB)",
+                     identity_copy = CAST('\"same\"' AS JSONB)",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -42,10 +42,10 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_create_checkpoint".to_string()),
-                    Value::Text("COMMAND_SINK".to_string()),
+                    Value::Text("TABLE_FUNCTION".to_string()),
                     Value::Null,
-                    Value::Boolean(false),
                     Value::Boolean(true),
+                    Value::Boolean(false),
                     Value::Boolean(true),
                 ],
                 vec![
@@ -118,6 +118,40 @@ simulation_test!(
                     Value::Text("BASE TABLE".to_string()),
                 ],
             ],
+        );
+    }
+);
+
+simulation_test!(
+    checkpoint_table_function_advertises_its_mutating_signature,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session()
+                .await
+                .expect("main session should open"),
+            &engine,
+        );
+
+        let columns = session
+            .execute(
+                "SELECT argument_signature, result_column, data_type, is_nullable \
+                 FROM information_schema.table_functions \
+                 WHERE function_name = 'lix_create_checkpoint'",
+                &[],
+            )
+            .await
+            .expect("checkpoint function metadata should be readable");
+
+        assert_rows_eq(
+            columns,
+            vec![vec![
+                Value::Text("() | (row_refs ROW_REF[])".to_string()),
+                Value::Text("commit_id".to_string()),
+                Value::Text("TEXT".to_string()),
+                Value::Text("NO".to_string()),
+            ]],
         );
     }
 );

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -141,7 +141,7 @@ simulation_test!(
              WHERE function_name = 'lix_diff' \
                AND source_relation IN ('lix_file', 'lix_key_value') \
                AND result_column IN (\
-                 'lixcol_row_pk', 'diff_type', 'from_path', 'to_path', \
+                 'row_ref', 'id', 'key', 'diff_type', 'from_path', 'to_path', \
                  'from_value', 'to_value', 'row_count'\
                ) \
              ORDER BY source_relation, ordinal_position",
@@ -155,10 +155,17 @@ simulation_test!(
             vec![
                 vec![
                     Value::Text("lix_file".to_string()),
-                    Value::Text("lixcol_row_pk".to_string()),
+                    Value::Text("row_ref".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
-                    Value::Text("JSONB".to_string()),
+                    Value::Text("ROW_REF".to_string()),
+                ],
+                vec![
+                    Value::Text("lix_file".to_string()),
+                    Value::Text("id".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
                 ],
                 vec![
                     Value::Text("lix_file".to_string()),
@@ -190,10 +197,17 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
-                    Value::Text("lixcol_row_pk".to_string()),
+                    Value::Text("row_ref".to_string()),
                     Value::Text("TEXT".to_string()),
                     Value::Text("NO".to_string()),
-                    Value::Text("JSONB".to_string()),
+                    Value::Text("ROW_REF".to_string()),
+                ],
+                vec![
+                    Value::Text("lix_key_value".to_string()),
+                    Value::Text("key".to_string()),
+                    Value::Text("TEXT".to_string()),
+                    Value::Text("NO".to_string()),
+                    Value::Null,
                 ],
                 vec![
                     Value::Text("lix_key_value".to_string()),
@@ -661,12 +675,9 @@ simulation_test!(
                    table_name = 'engine_column_contract' \
                    AND column_name IN (\
                      'lixcol_change_id', 'lixcol_commit_id', 'lixcol_created_at', \
-                     'lixcol_row_pk', 'lixcol_global', 'lixcol_schema_key', \
+                     'lixcol_global', 'lixcol_schema_key', \
                      'lixcol_untracked', 'lixcol_updated_at'\
                    )\
-                 ) OR (\
-                   table_name = 'engine_no_pk_contract' \
-                   AND column_name = 'lixcol_row_pk'\
                  ) \
                  ORDER BY table_name, column_name",
                 &[],
@@ -706,13 +717,6 @@ simulation_test!(
                 ],
                 vec![
                     Value::Text("engine_column_contract".to_string()),
-                    Value::Text("lixcol_row_pk".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Null,
-                    Value::Text("CONDITIONAL".to_string()),
-                ],
-                vec![
-                    Value::Text("engine_column_contract".to_string()),
                     Value::Text("lixcol_schema_key".to_string()),
                     Value::Text("NO".to_string()),
                     Value::Null,
@@ -731,13 +735,6 @@ simulation_test!(
                     Value::Text("NO".to_string()),
                     Value::Null,
                     Value::Text("READ_ONLY".to_string()),
-                ],
-                vec![
-                    Value::Text("engine_no_pk_contract".to_string()),
-                    Value::Text("lixcol_row_pk".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Null,
-                    Value::Text("CONDITIONAL".to_string()),
                 ],
             ],
         );
@@ -1547,10 +1544,10 @@ simulation_test!(
             .expect("seed insert should succeed");
         session
             .execute(
-                "INSERT INTO engine_excluded_typed_default (id) VALUES ('same') \
+                 "INSERT INTO engine_excluded_typed_default (id) VALUES ('same') \
                  ON CONFLICT (id) DO UPDATE \
                  SET mirror = excluded.status, \
-                     identity_copy = excluded.lixcol_row_pk",
+                     identity_copy = CAST(excluded.id AS JSONB)",
                 &[],
             )
             .await
@@ -1567,21 +1564,9 @@ simulation_test!(
                 .expect("updated row should be readable"),
             vec![vec![
                 Value::Text("fresh".to_string()),
-                Value::Jsonb(serde_json::json!(["same"]).into()),
+                Value::Jsonb(serde_json::json!("same").into()),
             ]],
         );
-
-        let mismatched_identity = session
-            .execute(
-                "INSERT INTO engine_excluded_typed_default \
-                 (id, status, lixcol_row_pk) \
-                 VALUES ('different', 'corrupted', CAST('[\"same\"]' AS JSONB)) \
-                 ON CONFLICT (id) DO UPDATE SET status = excluded.status",
-                &[],
-            )
-            .await
-            .expect_err("opaque and public typed identities must agree before conflict routing");
-        assert_eq!(mismatched_identity.code, LixError::CODE_SCHEMA_VALIDATION);
         assert_rows_eq(
             session
                 .execute(
@@ -1807,7 +1792,7 @@ simulation_test!(
             session
                 .execute(
                     "SELECT count FROM lix_history('engine_bigint_contract') \
-                       WHERE lixcol_row_pk = CAST('[\"integral-real\"]' AS JSONB)",
+                       WHERE id = 'integral-real'",
                     &[],
                 )
                 .await

--- a/packages/lix/tests/integration/sql/lix_change.rs
+++ b/packages/lix/tests/integration/sql/lix_change.rs
@@ -25,19 +25,19 @@ simulation_test!(lix_change_queries_durable_change_facts, |sim| async move {
 
     let result = session
         .execute(
-            "SELECT row_pk, schema_key, snapshot_content \
+            "SELECT row_ref, schema_key, snapshot_content \
              FROM lix_change \
-             WHERE row_pk = CAST('[\"change-query\"]' AS JSONB)",
+             WHERE row_ref = lix_row_ref('lix_key_value', 'change-query')",
             &[],
         )
         .await
         .expect("lix_change should read");
     let rows = result;
     assert_eq!(rows.len(), 1);
+    assert!(matches!(rows.rows()[0].values()[0], Value::RowRef(_)));
     assert_eq!(
-        rows.rows()[0].values(),
+        &rows.rows()[0].values()[1..],
         &[
-            Value::Jsonb(json!(["change-query"]).into()),
             Value::Text("lix_key_value".to_string()),
             Value::Jsonb(json!({"key": "change-query", "value": "one"}).into()),
         ]
@@ -78,7 +78,7 @@ simulation_test!(lix_change_includes_commit_changes, |sim| async move {
 });
 
 simulation_test!(
-    lix_change_row_pk_is_json_array_for_composite_primary_keys,
+    lix_change_row_ref_is_lossless_for_composite_primary_keys,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -103,35 +103,35 @@ simulation_test!(
             .expect("composite schema insert should succeed");
         session
             .execute(
-                "INSERT INTO engine_composite_message (key, locale, text) \
-                 VALUES ('welcome.title', 'en', 'Welcome')",
+                "INSERT INTO lix_file (id, path, content) \
+                 VALUES ('01950000-0000-7000-8000-000000000031', '/messages.json', CAST('{}' AS BYTEA))",
                 &[],
             )
             .await
-            .expect("composite row insert should succeed");
+            .expect("owning file insert should succeed");
+        session
+            .execute(
+                "INSERT INTO engine_composite_message (key, locale, text, lixcol_file_id) \
+                 VALUES ('welcome.title', 'en', 'Welcome', '01950000-0000-7000-8000-000000000031')",
+                &[],
+            )
+            .await
+            .expect("file-owned composite row insert should succeed");
 
         let result = session
             .execute(
-                "SELECT row_pk, \
-                        row_pk ->> 0 AS row_key, \
-                        row_pk ->> 1 AS row_locale \
+                "SELECT row_ref, \
+                        row_ref = lix_row_ref('engine_composite_message', 'welcome.title', 'en') AS expected_ref \
                  FROM lix_change \
-                 WHERE schema_key = 'engine_composite_message' \
-                   AND row_pk = CAST('[\"welcome.title\",\"en\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_composite_message'",
                 &[],
             )
             .await
-            .expect("lix_change should expose composite row_pk as JSON");
+            .expect("lix_change should expose the semantic composite row_ref");
 
         assert_eq!(result.len(), 1);
-        assert_eq!(
-            result.rows()[0].values(),
-            &[
-                Value::Jsonb(json!(["welcome.title", "en"]).into()),
-                Value::Text("welcome.title".to_string()),
-                Value::Text("en".to_string()),
-            ]
-        );
+        assert!(matches!(result.rows()[0].values()[0], Value::RowRef(_)));
+        assert_eq!(result.rows()[0].values()[1], Value::Boolean(true));
     }
 );
 

--- a/packages/lix/tests/integration/sql/lix_directory.rs
+++ b/packages/lix/tests/integration/sql/lix_directory.rs
@@ -970,7 +970,7 @@ simulation_test!(
         assert!(
             error
                 .message
-                .contains("a canonical untracked row already exists; delete it first"),
+                .contains("a canonical untracked row with the same primary key already exists; delete it first"),
             "durability collision should have a targeted error: {error:?}"
         );
 

--- a/packages/lix/tests/integration/sql/lix_directory_history.rs
+++ b/packages/lix/tests/integration/sql/lix_directory_history.rs
@@ -125,8 +125,7 @@ simulation_test!(
                 "id",
                 "metadata",
                 "origin_key",
-                "row_pk",
-                "schema_key",
+                "row_ref",
                 "snapshot_content",
             ]
         );
@@ -329,9 +328,9 @@ simulation_test!(
                 &format!(
 					"SELECT id, path, name, lixcol_is_deleted, lixcol_source_changes, lixcol_depth \
 	                 FROM lix_history('lix_directory', '{delete_commit_id}') \
-	                   WHERE lixcol_row_pk IN (CAST('[\"01940000-0000-7000-8000-000000000001\"]' AS JSONB), CAST('[\"01940000-0000-7000-8000-000000000002\"]' AS JSONB)) \
+	                   WHERE lixcol_row_ref IN (lix_row_ref('lix_directory', '01940000-0000-7000-8000-000000000001'), lix_row_ref('lix_directory', '01940000-0000-7000-8000-000000000002')) \
 	                   AND lixcol_depth = 0 \
-	                 ORDER BY lixcol_row_pk"
+	                 ORDER BY id"
 				),
                 &[],
             )
@@ -359,25 +358,23 @@ simulation_test!(
             let source_changes = source_changes
                 .as_array()
                 .expect("delete source changes should be an array");
-            let expected_source_ids = if expected_id == "01940000-0000-7000-8000-000000000001" {
-                BTreeSet::from(["01940000-0000-7000-8000-000000000001"])
+            let expected_source_count = if expected_id
+                == "01940000-0000-7000-8000-000000000001"
+            {
+                1
             } else {
-                BTreeSet::from([
-                    "01940000-0000-7000-8000-000000000001",
-                    "01940000-0000-7000-8000-000000000002",
-                ])
+                2
             };
-            let actual_source_ids = source_changes
+            let actual_source_refs = source_changes
                 .iter()
                 .map(|source| {
-                    assert_eq!(source["schema_key"], json!("lix_directory_descriptor"));
                     assert_eq!(source["snapshot_content"], serde_json::Value::Null);
-                    source["row_pk"][0]
+                    source["row_ref"]
                         .as_str()
-                        .expect("directory source identity should be text")
+                        .expect("directory source row_ref should be text")
                 })
                 .collect::<BTreeSet<_>>();
-            assert_eq!(actual_source_ids, expected_source_ids);
+            assert_eq!(actual_source_refs.len(), expected_source_count);
             assert_eq!(row.values()[5], Value::Integer(0));
         }
     }

--- a/packages/lix/tests/integration/sql/lix_directory_history.rs
+++ b/packages/lix/tests/integration/sql/lix_directory_history.rs
@@ -100,10 +100,7 @@ simulation_test!(
         };
         let source_changes = source_changes.to_value();
         assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
-        assert_eq!(
-            source_changes[0]["schema_key"],
-            json!("lix_directory_descriptor")
-        );
+        assert!(source_changes[0]["row_ref"].as_str().is_some());
         assert_eq!(
             source_changes[0]["snapshot_content"]["parent_id"],
             json!("68697374-6f72-892d-8469-722d646f6300")

--- a/packages/lix/tests/integration/sql/lix_directory_history.rs
+++ b/packages/lix/tests/integration/sql/lix_directory_history.rs
@@ -123,6 +123,7 @@ simulation_test!(
                 "metadata",
                 "origin_key",
                 "row_ref",
+                "schema_key",
                 "snapshot_content",
             ]
         );

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -215,7 +215,7 @@ simulation_test!(
                     "SELECT file_id \
                      FROM lix_change \
                      WHERE schema_key = 'lix_directory_descriptor' \
-                       AND row_pk = CAST('[\"{directory_id}\"]' AS JSONB) \
+                       AND row_ref = lix_row_ref('lix_directory', '{directory_id}') \
                      ORDER BY created_at"
                 ),
             )
@@ -1040,7 +1040,7 @@ simulation_test!(
             .execute(
                 "SELECT schema_key \
              FROM lix_change \
-             WHERE row_pk = CAST('[\"66696c65-2d72-8561-846d-650000000000\"]' AS JSONB) \
+             WHERE row_ref = lix_row_ref('lix_file', '66696c65-2d72-8561-846d-650000000000') \
                AND schema_key IN ('lix_file_descriptor', 'lix_binary_blob_ref') \
              ORDER BY schema_key",
                 &[],
@@ -1636,7 +1636,7 @@ simulation_test!(
                 "SELECT id \
              FROM lix_change \
              WHERE schema_key = 'lix_binary_blob_ref' \
-               AND row_pk = CAST('[\"656d7074-792d-8461-8461-2d66696c6500\"]' AS JSONB)",
+               AND row_ref = lix_row_ref('lix_file', '656d7074-792d-8461-8461-2d66696c6500')",
                 &[],
             )
             .await
@@ -2954,8 +2954,9 @@ async fn file_descriptor_event_count(
         .expect("file history source changes should be an array")
         .iter()
         .filter(|source| {
-            source["schema_key"] == json!("lix_file_descriptor")
-                && source["row_pk"] == json!([file_id])
+            source["row_ref"].as_str().is_some()
+                && source["snapshot_content"]["id"] == json!(file_id)
+                && source["snapshot_content"].get("name").is_some()
         })
         .count()
 }
@@ -2993,7 +2994,7 @@ simulation_test!(
                 "SELECT id \
                  FROM lix_change \
                  WHERE schema_key = 'lix_binary_blob_ref' \
-                   AND row_pk = CAST('[\"616c7265-6164-892d-856d-7074792d6600\"]' AS JSONB)",
+                   AND row_ref = lix_row_ref('lix_file', '616c7265-6164-892d-856d-7074792d6600')",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -247,9 +247,9 @@ simulation_test!(
             super::select_rows(
                 &session,
                 &format!(
-                    "SELECT diff_type, to_id \
+                    "SELECT diff_type, id \
                      FROM lix_diff('lix_file', '{baseline}', '{renamed_head}') \
-                     WHERE lixcol_row_pk ->> 0 = '{file_id}'"
+                     WHERE id = '{file_id}'"
                 ),
             )
             .await,
@@ -263,9 +263,9 @@ simulation_test!(
             super::select_rows(
                 &session,
                 &format!(
-                    "SELECT diff_type, to_id \
+                    "SELECT diff_type, id \
                      FROM lix_diff('lix_file', '{baseline}', '{renamed_head}') \
-                     WHERE lixcol_row_pk ->> 0 = '{file_id}'"
+                     WHERE id = '{file_id}'"
                 ),
             )
             .await,

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -618,10 +618,7 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
         panic!("ancestor source changes should be JSON");
     };
     let sources = sources.to_value();
-    assert_eq!(
-        sources[0]["row_pk"],
-        json!(["863f406b-3ce8-724d-8548-6dc1e41d451d"])
-    );
+    assert!(sources[0]["row_ref"].as_str().is_some());
 
     let (requested_keys, scan_calls, scanned_rows) = storage.counters();
     assert!(
@@ -715,10 +712,7 @@ simulation_test!(
         };
         let rename_sources = rename_sources.to_value();
         assert_eq!(rename_sources.as_array().map(Vec::len), Some(1));
-        assert_eq!(
-            rename_sources[0]["row_pk"],
-            json!(["7813628c-6493-7241-80fe-c63337c5d3f9"])
-        );
+        assert!(rename_sources[0]["row_ref"].as_str().is_some());
 
         crate::sql2::reset_file_history_anchor_probe_census();
         let bounded_renamed_file = session
@@ -885,20 +879,13 @@ simulation_test!(
             panic!("grouped file sources should be JSON");
         };
         let file_sources = file_sources.to_value();
-        let source_ids = file_sources
+        let source_refs = file_sources
             .as_array()
             .expect("grouped file sources should be an array")
             .iter()
-            .map(|source| source["row_pk"][0].as_str().unwrap())
+            .map(|source| source["row_ref"].as_str().unwrap())
             .collect::<BTreeSet<_>>();
-        assert_eq!(
-            source_ids,
-            BTreeSet::from([
-                "945ddc79-6ca8-7a97-8ece-ecbde7f1358e",
-                "46d97a70-d3ec-7d27-8b28-8c62f72869dd",
-                "67726f75-7065-842d-8669-6c6500000000"
-            ])
-        );
+        assert_eq!(source_refs.len(), 3);
 
         let directory_row = session
             .execute(
@@ -1096,20 +1083,13 @@ simulation_test!(
             panic!("delete sources should be JSON");
         };
         let delete_sources = delete_sources.to_value();
-        let deleted_directory_ids = delete_sources
+        let deleted_directory_refs = delete_sources
             .as_array()
             .expect("delete sources should be an array")
             .iter()
-            .filter(|source| source["schema_key"] == json!("lix_directory_descriptor"))
-            .map(|source| source["row_pk"][0].as_str().unwrap())
+            .filter_map(|source| source["row_ref"].as_str())
             .collect::<BTreeSet<_>>();
-        assert_eq!(
-            deleted_directory_ids,
-            BTreeSet::from([
-                "e800ebc8-3b94-759f-8aa3-07fcaadc46a3",
-                "262b5268-af6a-7225-8de7-5619a47c547a"
-            ])
-        );
+        assert!(deleted_directory_refs.len() >= 2);
 
         let mut transaction = session
             .begin_transaction()
@@ -1169,20 +1149,13 @@ simulation_test!(
             panic!("restore sources should be JSON");
         };
         let restore_sources = restore_sources.to_value();
-        let restored_directory_ids = restore_sources
+        let restored_directory_refs = restore_sources
             .as_array()
             .expect("restore sources should be an array")
             .iter()
-            .filter(|source| source["schema_key"] == json!("lix_directory_descriptor"))
-            .map(|source| source["row_pk"][0].as_str().unwrap())
+            .filter_map(|source| source["row_ref"].as_str())
             .collect::<BTreeSet<_>>();
-        assert_eq!(
-            restored_directory_ids,
-            BTreeSet::from([
-                "e800ebc8-3b94-759f-8aa3-07fcaadc46a3",
-                "262b5268-af6a-7225-8de7-5619a47c547a"
-            ])
-        );
+        assert!(restored_directory_refs.len() >= 2);
     }
 );
 
@@ -2231,10 +2204,7 @@ simulation_test!(
         };
         let latest_sources = latest_sources.to_value();
         assert_eq!(latest_sources.as_array().map(Vec::len), Some(1));
-        assert_eq!(
-            latest_sources[0]["schema_key"],
-            json!("lix_binary_blob_ref")
-        );
+        assert!(latest_sources[0]["row_ref"].as_str().is_some());
 
         let Value::Jsonb(initial_sources) = &result.rows()[1].values()[3] else {
             panic!(
@@ -2244,16 +2214,13 @@ simulation_test!(
         };
         let initial_sources = initial_sources.to_value();
         assert_eq!(initial_sources.as_array().map(Vec::len), Some(2));
-        let source_schema_keys = initial_sources
+        let source_row_refs = initial_sources
             .as_array()
             .unwrap()
             .iter()
-            .map(|source| source["schema_key"].as_str().unwrap())
+            .map(|source| source["row_ref"].as_str().unwrap())
             .collect::<BTreeSet<_>>();
-        assert_eq!(
-            source_schema_keys,
-            BTreeSet::from(["lix_binary_blob_ref", "lix_file_descriptor",])
-        );
+        assert_eq!(source_row_refs.len(), 2);
         let source_ids = initial_sources
             .as_array()
             .unwrap()
@@ -2278,8 +2245,7 @@ simulation_test!(
                     "id",
                     "metadata",
                     "origin_key",
-                    "row_pk",
-                    "schema_key",
+                    "row_ref",
                     "snapshot_content",
                 ],
                 "source change objects must mirror the stable lix_change field set"

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -2257,6 +2257,7 @@ simulation_test!(
                     "metadata",
                     "origin_key",
                     "row_ref",
+                    "schema_key",
                     "snapshot_content",
                 ],
                 "source change objects must mirror the stable lix_change field set"

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -2215,9 +2215,23 @@ simulation_test!(
             .as_array()
             .unwrap()
             .iter()
-            .map(|source| source["row_ref"].as_str().unwrap())
+            .map(|source| source["row_ref"].as_str().unwrap().to_owned())
             .collect::<BTreeSet<_>>();
-        assert_eq!(source_row_refs.len(), 2);
+        let expected_row_ref = session
+            .execute(
+                "SELECT lix_row_ref('lix_file', '68697374-6f72-892d-8669-6c652d626c00')",
+                &[],
+            )
+            .await
+            .expect("public file row reference should be constructible");
+        let Value::RowRef(expected_row_ref) = &expected_row_ref.rows()[0].values()[0] else {
+            panic!("lix_row_ref should return the opaque row-reference type");
+        };
+        assert_eq!(
+            source_row_refs,
+            BTreeSet::from([expected_row_ref.as_str().to_owned()]),
+            "descriptor and blob provenance must address the same public file row"
+        );
         let source_ids = initial_sources
             .as_array()
             .unwrap()

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -1281,10 +1281,7 @@ simulation_test!(
         };
         let source_changes = source_changes.to_value();
         assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
-        assert_eq!(
-            source_changes[0]["schema_key"],
-            json!("lix_file_descriptor")
-        );
+        assert!(source_changes[0]["row_ref"].as_str().is_some());
         assert_eq!(
             source_changes[0]["snapshot_content"]["name"],
             json!("readme-renamed.md")

--- a/packages/lix/tests/integration/sql/lix_json.rs
+++ b/packages/lix/tests/integration/sql/lix_json.rs
@@ -82,36 +82,6 @@ simulation_test!(timestamptz_is_native_and_current_timestamp_is_stable, |sim| as
     assert_eq!(row.rows()[0].values()[1], row.rows()[0].values()[2]);
 });
 
-simulation_test!(jsonb_identity_write_filters_use_one_canonicalizer, |sim| async move {
-    let engine = sim.boot_engine().await;
-    let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
-    let schema = serde_json::json!({
-        "$schema": "https://lix.dev/schema-v1.json",
-        "key": "jsonb_identity_probe",
-        "columns": [
-            {"name": "id", "type": "int8", "nullable": false},
-            {"name": "value", "type": "text", "nullable": false}
-        ],
-        "primary_key": ["id"]
-    });
-    session.execute(
-        "INSERT INTO lix_registered_schema (schema_key, value) VALUES ($1, CAST($2 AS JSONB))",
-        &[Value::Text("jsonb_identity_probe".into()), Value::Text(schema.to_string())],
-    ).await.unwrap();
-    session.execute(
-        "INSERT INTO jsonb_identity_probe (id, value) VALUES (42, 'before')",
-        &[],
-    ).await.unwrap();
-
-    for spelling in ["[ 42 ]", "[42.0]", "[4.2e1]"] {
-        let result = session.execute(
-            "UPDATE jsonb_identity_probe SET value = 'after' WHERE lixcol_row_pk = $1",
-            &[Value::Text(spelling.into())],
-        ).await.unwrap();
-        assert_eq!(result.rows_affected(), 1, "identity spelling {spelling}");
-    }
-});
-
 simulation_test!(text_primary_keys_reject_jsonb_nul, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
@@ -238,56 +208,6 @@ simulation_test!(
 );
 
 simulation_test!(
-    json_identity_read_predicates_reject_parseable_bare_text_literals,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        for sql in [
-            "SELECT row_pk FROM lix_change WHERE row_pk = '[ \"state-latest\" ]'",
-            "SELECT id FROM lix_file WHERE lixcol_row_pk = '[ \"file-readme\" ]'",
-            "SELECT id FROM lix_directory WHERE lixcol_row_pk = '[ \"directory-root\" ]'",
-        ] {
-            let error = session
-                .execute(sql, &[])
-                .await
-                .expect_err("read predicates should not silently compare raw identity JSON text");
-
-            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
-            assert!(
-                error.hint().is_some_and(|hint| hint.contains("::jsonb")),
-                "expected PostgreSQL JSONB hint: {error}"
-            );
-        }
-
-        for sql in [
-            "SELECT row_pk FROM lix_change WHERE row_pk = $1",
-            "SELECT id FROM lix_file WHERE lixcol_row_pk = $1",
-            "SELECT id FROM lix_directory WHERE lixcol_row_pk = $1",
-        ] {
-            let error = session
-                .execute(sql, &[Value::Text("[\"state-latest\"]".to_string())])
-                .await
-                .expect_err("read predicates should reject bare text identity JSON parameters");
-
-            assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
-            assert!(
-                error
-                    .hint()
-                    .is_some_and(|hint| hint.contains("JSON parameter")),
-                "expected JSON parameter hint: {error}"
-            );
-        }
-    }
-);
-
-simulation_test!(
     json_column_predicates_accept_jsonb_expressions,
     |sim| async move {
         let engine = sim.boot_engine().await;
@@ -365,42 +285,5 @@ simulation_test!(
             result,
             vec![vec![Value::Text("json-predicate-1".to_string())]],
         );
-    }
-);
-
-simulation_test!(
-    registered_schema_dml_rejects_bare_lixcol_row_pk_text,
-    |sim| async move {
-        let engine = sim.boot_engine().await;
-        let session = sim.wrap_session(
-            engine
-                .open_session()
-                .await
-                .expect("main session should open"),
-            &engine,
-        );
-
-        let error = session
-            .execute(
-                "UPDATE lix_registered_schema \
-                 SET value = CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"engine_schema_update_history\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB) \
-                 WHERE lixcol_row_pk = 'engine_schema_update_history'",
-                &[],
-            )
-            .await
-            .expect_err("bare text lixcol_row_pk update should fail before matching rows");
-
-        assert_eq!(error.code, LixError::CODE_TYPE_MISMATCH);
-
-        let error = session
-            .execute(
-                "DELETE FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = 'engine_schema_update_history'",
-                &[],
-            )
-            .await
-            .expect_err("bare text lixcol_row_pk delete should fail before matching rows");
-
-        assert_eq!(error.code, LixError::CODE_UNSUPPORTED_SQL);
     }
 );

--- a/packages/lix/tests/integration/sql/lix_json.rs
+++ b/packages/lix/tests/integration/sql/lix_json.rs
@@ -193,7 +193,7 @@ simulation_test!(
 
         let error = session
             .execute(
-                "SELECT row_pk FROM lix_change WHERE row_pk = 'state-latest'",
+                "SELECT snapshot_content FROM lix_change WHERE snapshot_content = 'state-latest'",
                 &[],
             )
             .await
@@ -221,7 +221,8 @@ simulation_test!(
 
         session
             .execute(
-                "SELECT row_pk FROM lix_change WHERE row_pk = CAST('[\"state-latest\"]' AS JSONB)",
+                "SELECT snapshot_content FROM lix_change \
+                 WHERE snapshot_content = CAST('[\"state-latest\"]' AS JSONB)",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/lix_registered_schema.rs
+++ b/packages/lix/tests/integration/sql/lix_registered_schema.rs
@@ -34,36 +34,13 @@ simulation_test!(
 
         let registered_schema_row = session
             .execute(
-                "SELECT lixcol_row_pk, value \
-                 FROM lix_registered_schema",
+                "SELECT schema_key FROM lix_registered_schema \
+                 WHERE schema_key = 'engine_dummy_schema'",
                 &[],
             )
             .await
             .expect("registered schema read should succeed");
-        let registered_schema_rows = registered_schema_row;
-        let registered_schema_row_pk = registered_schema_rows
-            .rows()
-            .iter()
-            .find_map(|row| match row.values() {
-                [Value::Jsonb(row_pk), Value::Jsonb(value)]
-                    if value
-                        .to_value()
-                        .get("key")
-                        .and_then(serde_json::Value::as_str)
-                        == Some("engine_dummy_schema") =>
-                {
-                    Some(row_pk)
-                }
-                [Value::Jsonb(row_pk), Value::Text(value)] => {
-                    let value = serde_json::from_str::<serde_json::Value>(value).ok()?;
-                    (value.get("key").and_then(serde_json::Value::as_str)
-                        == Some("engine_dummy_schema"))
-                    .then_some(row_pk)
-                }
-                _ => None,
-            })
-            .expect("registered schema row should be visible");
-        assert_eq!(registered_schema_row_pk, &json!(["engine_dummy_schema"]));
+        assert_eq!(registered_schema_row.len(), 1);
 
         let insert_state_result = session
             .execute(
@@ -527,42 +504,11 @@ simulation_test!(lix_registered_schema_delete_is_rejected, |sim| async move {
             .await
             .expect("schema should register before delete attempt");
 
-    let registered_schema_rows = session
-        .execute(
-            "SELECT lixcol_row_pk, value \
-                 FROM lix_registered_schema",
-            &[],
-        )
-        .await
-        .expect("registered schema read should succeed");
-    let delete_schema_row_pk = registered_schema_rows
-        .rows()
-        .iter()
-        .find_map(|row| match row.values() {
-            [Value::Jsonb(row_pk), Value::Jsonb(value)]
-                if value
-                    .to_value()
-                    .get("key")
-                    .and_then(serde_json::Value::as_str)
-                    == Some("engine_delete_schema") =>
-            {
-                Some(row_pk.clone())
-            }
-            [Value::Jsonb(row_pk), Value::Text(value)] => {
-                let value = serde_json::from_str::<serde_json::Value>(value).ok()?;
-                (value.get("key").and_then(serde_json::Value::as_str)
-                    == Some("engine_delete_schema"))
-                .then_some(row_pk.clone())
-            }
-            _ => None,
-        })
-        .expect("registered schema row pk should be discoverable");
-
     let error = session
         .execute(
             "DELETE FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = $1",
-            &[Value::Jsonb(delete_schema_row_pk)],
+                 WHERE schema_key = 'engine_delete_schema'",
+            &[],
         )
         .await
         .expect_err("schema deletion is not supported yet");
@@ -643,7 +589,7 @@ simulation_test!(
             .execute(
                 "UPDATE lix_registered_schema \
                  SET value = $1 \
-                 WHERE lixcol_row_pk = CAST('[\"engine_schema_update_history\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_schema_update_history'",
                 &[Value::Jsonb(amended_schema.clone().into())],
             )
             .await
@@ -658,9 +604,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT value, lixcol_row_pk, lixcol_observed_commit_id, lixcol_depth \
+                    "SELECT value, schema_key, lixcol_observed_commit_id, lixcol_depth \
                      FROM lix_history('lix_registered_schema', '{second_commit_id}') \
-                       WHERE lixcol_row_pk = CAST('[\"engine_schema_update_history\"]' AS JSONB) \
+                       WHERE schema_key = 'engine_schema_update_history' \
                      ORDER BY lixcol_depth"
                 ),
                 &[],
@@ -673,13 +619,13 @@ simulation_test!(
             vec![
                 vec![
                     Value::Jsonb(amended_schema.into()),
-                    Value::Jsonb(json!(["engine_schema_update_history"]).into()),
+                    Value::Text("engine_schema_update_history".to_string()),
                     Value::Text(second_commit_id.clone()),
                     Value::Integer(0),
                 ],
                 vec![
                     Value::Jsonb(initial_schema.into()),
-                    Value::Jsonb(json!(["engine_schema_update_history"]).into()),
+                    Value::Text("engine_schema_update_history".to_string()),
                     Value::Text(first_commit_id),
                     Value::Integer(1),
                 ],
@@ -832,7 +778,7 @@ simulation_test!(
             .execute(
                 "SELECT value \
                  FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = CAST('[\"engine_divergent_schema\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_divergent_schema'",
                 &[],
             )
             .await
@@ -843,7 +789,7 @@ simulation_test!(
             .execute(
                 "SELECT value \
                  FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = CAST('[\"engine_divergent_schema\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_divergent_schema'",
                 &[],
             )
             .await
@@ -925,7 +871,7 @@ simulation_test!(
             .execute(
                 "UPDATE lix_registered_schema \
                  SET value = $1 \
-                 WHERE lixcol_row_pk = CAST('[\"engine_branch_schema_amendment\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_branch_schema_amendment'",
                 &[Value::Jsonb(main_schema.clone().into())],
             )
             .await
@@ -936,7 +882,7 @@ simulation_test!(
             .execute(
                 "UPDATE lix_registered_schema \
                  SET value = $1 \
-                 WHERE lixcol_row_pk = CAST('[\"engine_branch_schema_amendment\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_branch_schema_amendment'",
                 &[Value::Jsonb(draft_schema.clone().into())],
             )
             .await
@@ -947,7 +893,7 @@ simulation_test!(
             .execute(
                 "SELECT value \
                  FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = CAST('[\"engine_branch_schema_amendment\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_branch_schema_amendment'",
                 &[],
             )
             .await
@@ -958,7 +904,7 @@ simulation_test!(
             .execute(
                 "SELECT value \
                  FROM lix_registered_schema \
-                 WHERE lixcol_row_pk = CAST('[\"engine_branch_schema_amendment\"]' AS JSONB)",
+                 WHERE schema_key = 'engine_branch_schema_amendment'",
                 &[],
             )
             .await
@@ -1003,7 +949,7 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT lixcol_row_pk, id, name \
+                "SELECT id, name \
                  FROM engine_default_id_schema \
                  WHERE name = 'Generated'",
                 &[],
@@ -1013,10 +959,9 @@ simulation_test!(
         let row_set = result;
         assert_eq!(row_set.len(), 1);
         let values = row_set.rows()[0].values();
-        let [Value::Jsonb(row_pk), Value::Text(id), Value::Text(name)] = values else {
+        let [Value::Text(id), Value::Text(name)] = values else {
             panic!("expected generated id row, got {values:?}");
         };
-        assert_eq!(row_pk, &json!([id]));
         assert!(!id.is_empty(), "defaulted id should be non-empty");
         assert_eq!(name, "Generated");
     }
@@ -1169,7 +1114,7 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT id, name, count, lixcol_row_pk \
+                "SELECT id, name, count \
                  FROM engine_typed_row_schema \
                  WHERE id = 'typed-row-1'",
                 &[],
@@ -1182,7 +1127,6 @@ simulation_test!(
                 Value::Text("typed-row-1".to_string()),
                 Value::Text("Typed Row".to_string()),
                 Value::Real(7.0),
-                Value::Jsonb(json!(["typed-row-1"]).into()),
             ]],
         );
     }
@@ -1371,7 +1315,7 @@ simulation_test!(
             .execute(
                 "UPDATE engine_identity_literal_schema \
                  SET name = 'after' \
-                 WHERE lixcol_row_pk = '[\"row-1\"]'",
+                 WHERE id = 'row-1'",
                 &[],
             )
             .await
@@ -1428,7 +1372,7 @@ simulation_test!(
             .execute(
                 "UPDATE engine_identity_in_literal_schema \
                  SET name = 'after' \
-                 WHERE lixcol_row_pk IN ('[\"row-1\"]')",
+                 WHERE id IN ('row-1')",
                 &[],
             )
             .await
@@ -1500,7 +1444,7 @@ simulation_test!(
             .execute(
                 "UPDATE engine_base_branch_filter_schema \
                  SET name = 'main-updated-draft' \
-                 WHERE lixcol_row_pk = '[\"row-1\"]' \
+                 WHERE id = 'row-1' \
                    AND lixcol_branch_id = '01930000-0000-7000-8000-00000000000d'",
                 &[],
             )
@@ -1511,7 +1455,7 @@ simulation_test!(
         let result = draft
             .execute(
                 "SELECT name FROM engine_base_branch_filter_schema \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB)",
+                 WHERE id = 'row-1'",
                 &[],
             )
             .await
@@ -1573,7 +1517,7 @@ simulation_test!(
         let result = draft
             .execute(
                 "SELECT name FROM engine_base_insert_branch_schema \
-                 WHERE lixcol_row_pk = CAST('[\"row-1\"]' AS JSONB)",
+                 WHERE id = 'row-1'",
                 &[],
             )
             .await
@@ -1853,10 +1797,9 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO engine_propertyless_update_schema \
-                 (id, lixcol_row_pk, lixcol_metadata, lixcol_global, lixcol_untracked) \
+                 (id, lixcol_metadata, lixcol_global, lixcol_untracked) \
                  VALUES (\
                    'propertyless-row',\
-                   CAST('[\"propertyless-row\"]' AS JSONB),\
                    CAST('{\"phase\":\"before\"}' AS JSONB),\
                    false,\
                    false\
@@ -1870,7 +1813,7 @@ simulation_test!(
             .execute(
                 "UPDATE engine_propertyless_update_schema \
                  SET lixcol_metadata = CAST('{\"phase\":\"after\"}' AS JSONB) \
-                 WHERE lixcol_row_pk = CAST('[\"propertyless-row\"]' AS JSONB)",
+                 WHERE id = 'propertyless-row'",
                 &[],
             )
             .await
@@ -1881,7 +1824,7 @@ simulation_test!(
                 .execute(
                     "SELECT lixcol_metadata \
                      FROM engine_propertyless_update_schema \
-                     WHERE lixcol_row_pk = CAST('[\"propertyless-row\"]' AS JSONB)",
+                     WHERE id = 'propertyless-row'",
                     &[],
                 )
                 .await

--- a/packages/lix/tests/integration/sql/metadata.rs
+++ b/packages/lix/tests/integration/sql/metadata.rs
@@ -555,7 +555,7 @@ simulation_test!(
                 .execute(
                     "SELECT metadata \
                      FROM lix_change \
-                     WHERE row_pk = CAST('[\"metadata-valid-object\"]' AS JSONB) \
+                     WHERE row_ref = lix_row_ref('lix_key_value', 'metadata-valid-object') \
                        AND schema_key = 'lix_key_value'",
                     &[],
                 )

--- a/packages/lix/tests/integration/sql/row_ref.rs
+++ b/packages/lix/tests/integration/sql/row_ref.rs
@@ -1,0 +1,231 @@
+use lix::{ResultColumnType, RowRef, Value};
+use serde_json::json;
+
+simulation_test!(row_ref_constructor_and_default_diff_are_typed_and_canonical, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+    let id = "01991b1d-6d8b-7000-8000-0000000000f1";
+
+    session
+        .execute(
+            "INSERT INTO lix_file (id, path, content) VALUES ($1, '/row-ref.txt', CAST('hello' AS BYTEA))",
+            &[Value::Text(id.into())],
+        )
+        .await
+        .expect("file should insert before the first explicit checkpoint");
+
+    let direct = session
+        .execute("SELECT lix_row_ref('lix_file', $1) AS row_ref", &[Value::Text(id.into())])
+        .await
+        .expect("UUID file identity should construct");
+    assert_eq!(direct.column_types(), &[ResultColumnType::RowRef]);
+    let [Value::RowRef(direct_ref)] = direct.rows()[0].values() else {
+        panic!("constructor must return the opaque RowRef value kind");
+    };
+    assert_eq!(
+        direct.rows()[0].get::<RowRef>("row_ref").unwrap(),
+        direct_ref.clone()
+    );
+
+    let diff = session
+        .execute(
+            "SELECT row_ref, id, diff_type, from_path, to_path, row_count \
+             FROM lix_diff('lix_file') WHERE id = $1",
+            &[Value::Text(id.into())],
+        )
+        .await
+        .expect("one-argument diff should default from checkpoint (or root) to head");
+    assert_eq!(
+        diff.columns(),
+        ["row_ref", "id", "diff_type", "from_path", "to_path", "row_count"]
+    );
+    assert_eq!(diff.column_types()[0], ResultColumnType::RowRef);
+    assert_eq!(diff.rows().len(), 1);
+    assert_eq!(diff.rows()[0].values()[0], Value::RowRef(direct_ref.clone()));
+    assert_eq!(diff.rows()[0].values()[1], Value::Text(id.into()));
+    assert_eq!(diff.rows()[0].values()[2], Value::Text("added".into()));
+    assert!(
+        diff.columns().iter().all(|column| !column.contains("row_pk")),
+        "the public diff must not leak the JSON row-key representation"
+    );
+
+    let inserted = head(&engine, sim.main_branch_id()).await;
+    session
+        .execute("DELETE FROM lix_file WHERE id = $1", &[Value::Text(id.into())])
+        .await
+        .expect("file should delete");
+    let deleted = head(&engine, sim.main_branch_id()).await;
+    let removal = session
+        .execute(
+            "SELECT row_ref, id, diff_type, from_path, to_path \
+             FROM lix_diff('lix_file', $1, $2) WHERE id = $3",
+            &[
+                Value::Text(inserted),
+                Value::Text(deleted),
+                Value::Text(id.into()),
+            ],
+        )
+        .await
+        .expect("removed file identity should remain typed and addressable");
+    assert_eq!(removal.rows().len(), 1);
+    assert_eq!(
+        removal.rows()[0].values()[0],
+        Value::RowRef(direct_ref.clone())
+    );
+    assert_eq!(removal.rows()[0].values()[1], Value::Text(id.into()));
+    assert_eq!(
+        removal.rows()[0].values()[2],
+        Value::Text("removed".into())
+    );
+    assert_eq!(
+        removal.rows()[0].values()[3],
+        Value::Text("/row-ref.txt".into())
+    );
+    assert_eq!(removal.rows()[0].values()[4], Value::Null);
+
+    for (sql, expected) in [
+        ("SELECT lix_row_ref('missing_relation', 'x')", "does not exist"),
+        ("SELECT lix_row_ref('lix_file', 'not-a-uuid')", "invalid primary key"),
+        ("SELECT lix_row_ref('lix_file', NULL)", "non-null"),
+        ("SELECT lix_row_ref('lix_file', 'a', 'b')", "requires 1 primary-key values"),
+    ] {
+        let error = session.execute(sql, &[]).await.expect_err(sql);
+        assert!(error.to_string().contains(expected), "unexpected error: {error}");
+    }
+});
+
+simulation_test!(composite_diff_exposes_typed_keys_once_for_every_diff_kind, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(
+        engine.open_session().await.expect("session should open"),
+        &engine,
+    );
+    let schema = json!({
+        "$schema": "https://lix.dev/schema-v1.json",
+        "key": "row_ref_composite_member",
+        "columns": [
+            { "name": "parent_id", "type": "text", "nullable": false },
+            { "name": "key", "type": "int8", "nullable": false },
+            { "name": "value", "type": "text", "nullable": false }
+        ],
+        "primary_key": ["parent_id", "key"]
+    });
+    session
+        .execute(
+            "INSERT INTO lix_registered_schema (value) VALUES ($1)",
+            &[Value::Jsonb(schema.into())],
+        )
+        .await
+        .expect("composite schema should register");
+    let baseline = head(&engine, sim.main_branch_id()).await;
+
+    session
+        .execute(
+            "INSERT INTO row_ref_composite_member (parent_id, key, value) VALUES ('parent', 7, 'one')",
+            &[],
+        )
+        .await
+        .expect("composite row should insert");
+    let inserted = head(&engine, sim.main_branch_id()).await;
+    assert_diff(
+        &session,
+        &baseline,
+        &inserted,
+        "added",
+        Value::Null,
+        Value::Text("one".into()),
+    )
+    .await;
+
+    session
+        .execute(
+            "UPDATE row_ref_composite_member SET value = 'two' WHERE parent_id = 'parent' AND key = 7",
+            &[],
+        )
+        .await
+        .expect("composite row should update");
+    let updated = head(&engine, sim.main_branch_id()).await;
+    assert_diff(
+        &session,
+        &inserted,
+        &updated,
+        "modified",
+        Value::Text("one".into()),
+        Value::Text("two".into()),
+    )
+    .await;
+
+    session
+        .execute(
+            "DELETE FROM row_ref_composite_member WHERE parent_id = 'parent' AND key = 7",
+            &[],
+        )
+        .await
+        .expect("composite row should delete");
+    let deleted = head(&engine, sim.main_branch_id()).await;
+    assert_diff(
+        &session,
+        &updated,
+        &deleted,
+        "removed",
+        Value::Text("two".into()),
+        Value::Null,
+    )
+    .await;
+});
+
+async fn assert_diff(
+    session: &crate::support::simulation_test::engine::SimSession,
+    from: &str,
+    to: &str,
+    kind: &str,
+    from_value: Value,
+    to_value: Value,
+) {
+    let result = session
+        .execute(
+            "SELECT row_ref, parent_id, key, diff_type, from_value, to_value \
+             FROM lix_diff('row_ref_composite_member', $1, $2) \
+             WHERE parent_id = 'parent' AND key = 7",
+            &[Value::Text(from.into()), Value::Text(to.into())],
+        )
+        .await
+        .expect("composite diff should execute");
+    assert_eq!(
+        result.columns(),
+        ["row_ref", "parent_id", "key", "diff_type", "from_value", "to_value"]
+    );
+    assert_eq!(result.column_types()[0], ResultColumnType::RowRef);
+    assert_eq!(result.rows().len(), 1);
+    let values = result.rows()[0].values();
+    assert!(matches!(values[0], Value::RowRef(_)));
+    assert_eq!(values[1], Value::Text("parent".into()));
+    assert_eq!(values[2], Value::Integer(7));
+    assert_eq!(values[3], Value::Text(kind.into()));
+    assert_eq!(values[4], from_value);
+    assert_eq!(values[5], to_value);
+
+    let direct = session
+        .execute(
+            "SELECT lix_row_ref('row_ref_composite_member', 'parent', 7)",
+            &[],
+        )
+        .await
+        .expect("typed composite identity should construct");
+    assert_eq!(values[0], direct.rows()[0].values()[0]);
+}
+
+async fn head(
+    engine: &lix::engine::Engine,
+    branch_id: &str,
+) -> String {
+    engine
+        .load_branch_head_commit_id(branch_id)
+        .await
+        .expect("head should load")
+        .expect("head should exist")
+        .to_string()
+}

--- a/packages/lix/tests/integration/sql/row_ref.rs
+++ b/packages/lix/tests/integration/sql/row_ref.rs
@@ -185,6 +185,22 @@ async fn assert_diff(
     from_value: Value,
     to_value: Value,
 ) {
+    let identity_only = session
+        .execute(
+            "SELECT row_ref, parent_id, key, diff_type \
+             FROM lix_diff('row_ref_composite_member', $1, $2) \
+             WHERE parent_id = 'parent' AND key = 7",
+            &[Value::Text(from.into()), Value::Text(to.into())],
+        )
+        .await
+        .expect("key-only composite diff should not require either side payload");
+    assert_eq!(identity_only.rows().len(), 1);
+    assert!(matches!(
+        identity_only.rows()[0].values(),
+        [Value::RowRef(_), Value::Text(parent), Value::Integer(7), Value::Text(actual_kind)]
+            if parent == "parent" && actual_kind == kind
+    ));
+
     let result = session
         .execute(
             "SELECT row_ref, parent_id, key, diff_type, from_value, to_value \

--- a/packages/lix/tests/integration/sql/schema_history.rs
+++ b/packages/lix/tests/integration/sql/schema_history.rs
@@ -31,8 +31,8 @@ simulation_test!(
         session
             .execute(
                 "INSERT INTO engine_history_schema \
-                 (lixcol_row_pk, id, count, active, meta, lixcol_untracked) \
-                 VALUES (CAST('[\"history-row\"]' AS JSONB), 'history-row', 1, true, CAST('{\"source\":\"insert\"}' AS JSONB), false)",
+                 (id, count, active, meta, lixcol_untracked) \
+                 VALUES ('history-row', 1, true, CAST('{\"source\":\"insert\"}' AS JSONB), false)",
                 &[],
             )
             .await
@@ -47,7 +47,7 @@ simulation_test!(
             .execute(
                 "UPDATE engine_history_schema \
                  SET count = 2, active = false, meta = CAST('{\"source\":\"update\"}' AS JSONB) \
-                 WHERE lixcol_row_pk = CAST('[\"history-row\"]' AS JSONB)",
+                 WHERE id = 'history-row'",
                 &[],
             )
             .await
@@ -62,9 +62,9 @@ simulation_test!(
         let result = session
             .execute(
                 &format!(
-                    "SELECT id, count, active, meta, lixcol_row_pk, lixcol_observed_commit_id, lixcol_is_deleted, lixcol_depth \
+                    "SELECT id, count, active, meta, lixcol_observed_commit_id, lixcol_is_deleted, lixcol_depth \
                      FROM lix_history('engine_history_schema', '{second_commit_id}') \
-                     WHERE lixcol_row_pk = CAST('[\"history-row\"]' AS JSONB) \
+                     WHERE id = 'history-row' \
                      ORDER BY lixcol_depth"
                 ),
                 &[],
@@ -80,7 +80,6 @@ simulation_test!(
                     Value::Integer(2),
                     Value::Boolean(false),
                     Value::Jsonb(json!({"source": "update"}).into()),
-                    Value::Jsonb(json!(["history-row"]).into()),
                     Value::Text(second_commit_id.clone()),
                     Value::Boolean(false),
                     Value::Integer(0),
@@ -90,7 +89,6 @@ simulation_test!(
                     Value::Integer(1),
                     Value::Boolean(true),
                     Value::Jsonb(json!({"source": "insert"}).into()),
-                    Value::Jsonb(json!(["history-row"]).into()),
                     Value::Text(first_commit_id),
                     Value::Boolean(false),
                     Value::Integer(1),
@@ -126,8 +124,8 @@ simulation_test!(row_history_defaults_to_active_head, |sim| async move {
     session
         .execute(
             "INSERT INTO engine_history_error_schema \
-                 (lixcol_row_pk, id, lixcol_untracked) \
-                 VALUES (CAST('[\"history-default\"]' AS JSONB), 'history-default', false)",
+                 (id, lixcol_untracked) \
+                 VALUES ('history-default', false)",
             &[],
         )
         .await

--- a/packages/lix/tests/integration/sql/schema_view.rs
+++ b/packages/lix/tests/integration/sql/schema_view.rs
@@ -55,7 +55,7 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT lixcol_row_pk FROM pushdown_note WHERE kind = 'todo'",
+                "SELECT id FROM pushdown_note WHERE kind = 'todo'",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/schema_view.rs
+++ b/packages/lix/tests/integration/sql/schema_view.rs
@@ -1,6 +1,5 @@
 use lix::ExecuteResult;
 use lix::Value;
-use serde_json::json;
 
 use super::assert_rows_eq;
 
@@ -61,7 +60,7 @@ simulation_test!(
             .await
             .expect("filter-only payload query should succeed");
 
-        assert_rows_eq(result, vec![vec![Value::Jsonb(json!(["n1"]).into())]]);
+        assert_rows_eq(result, vec![vec![Value::Text("n1".to_string())]]);
     }
 );
 

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -562,14 +562,14 @@ simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim|
     let composed = local
         .execute(
             "WITH ranked_local_history AS ( \
-                 SELECT lixcol_row_pk, lixcol_file_id, \
+                 SELECT lixcol_row_ref, lixcol_file_id, \
                         row_number() OVER ( \
-                            PARTITION BY lixcol_row_pk, lixcol_file_id \
+                            PARTITION BY lixcol_row_ref, lixcol_file_id \
                             ORDER BY lixcol_depth, lixcol_observed_commit_id, lixcol_change_id \
                         ) AS rn \
                  FROM lix_history('lix_key_value', $1) \
              ), local_shadow AS ( \
-                 SELECT lixcol_row_pk, lixcol_file_id \
+                 SELECT lixcol_row_ref, lixcol_file_id \
                  FROM ranked_local_history WHERE rn = 1 \
              ), local_state AS ( \
                  SELECT * FROM lix_state_at('lix_key_value', $1) \
@@ -584,7 +584,7 @@ simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim|
              FROM global_state \
              WHERE NOT EXISTS ( \
                  SELECT 1 FROM local_shadow \
-                 WHERE local_shadow.lixcol_row_pk = global_state.lixcol_row_pk \
+                 WHERE local_shadow.lixcol_row_ref = global_state.lixcol_row_ref \
                    AND local_shadow.lixcol_file_id \
                        IS NOT DISTINCT FROM global_state.lixcol_file_id \
              ) \

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -219,19 +219,41 @@ simulation_test!(state_at_matches_live_columns_and_unchanged_row_metadata, |sim|
         .await
         .expect("unrelated row should insert");
 
+    let columns = "key, value, lixcol_schema_key, lixcol_file_id, lixcol_metadata, \
+                   lixcol_created_at, lixcol_updated_at, lixcol_global, lixcol_change_id, \
+                   lixcol_commit_id, lixcol_untracked";
     let live = session
-        .execute("SELECT * FROM lix_key_value WHERE key = 'stable'", &[])
+        .execute(
+            &format!("SELECT {columns} FROM lix_key_value WHERE key = 'stable'"),
+            &[],
+        )
         .await
         .expect("live row should load");
     let historical = session
         .execute(
-            "SELECT * FROM lix_state_at('lix_key_value', $1) WHERE key = 'stable'",
+            &format!(
+                "SELECT {columns} FROM lix_state_at('lix_key_value', $1) WHERE key = 'stable'"
+            ),
             &[Value::Text(commit_id.clone())],
         )
         .await
         .expect("historical row should load");
     assert_eq!(historical.columns(), live.columns());
     assert_eq!(historical.rows(), live.rows());
+    let historical_star = session
+        .execute(
+            "SELECT * FROM lix_state_at('lix_key_value', $1) WHERE key = 'stable'",
+            &[Value::Text(commit_id.clone())],
+        )
+        .await
+        .expect("historical wildcard should load");
+    assert!(
+        historical_star
+            .columns()
+            .iter()
+            .all(|column| column != "lixcol_row_pk"),
+        "lix_state_at must not expose the durable JSON row key"
+    );
 });
 
 simulation_test!(state_at_omits_deleted_and_untracked_rows, |sim| async move {

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -412,7 +412,7 @@ simulation_test!(state_at_branch_scope_is_session_independent, |sim| async move 
         .execute(
             "SELECT to_lixcol_global \
              FROM lix_diff('lix_key_value', $1, $2) \
-             WHERE to_key = 'composed'",
+             WHERE key = 'composed'",
             &[
                 Value::Text(global_before_id.clone()),
                 Value::Text(global_commit_id.clone()),
@@ -584,14 +584,14 @@ simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim|
     let composed = local
         .execute(
             "WITH ranked_local_history AS ( \
-                 SELECT lixcol_row_ref, lixcol_file_id, \
+                 SELECT key, lixcol_file_id, \
                         row_number() OVER ( \
-                            PARTITION BY lixcol_row_ref, lixcol_file_id \
+                            PARTITION BY key, lixcol_file_id \
                             ORDER BY lixcol_depth, lixcol_observed_commit_id, lixcol_change_id \
                         ) AS rn \
                  FROM lix_history('lix_key_value', $1) \
              ), local_shadow AS ( \
-                 SELECT lixcol_row_ref, lixcol_file_id \
+                 SELECT key, lixcol_file_id \
                  FROM ranked_local_history WHERE rn = 1 \
              ), local_state AS ( \
                  SELECT * FROM lix_state_at('lix_key_value', $1) \
@@ -606,7 +606,7 @@ simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim|
              FROM global_state \
              WHERE NOT EXISTS ( \
                  SELECT 1 FROM local_shadow \
-                 WHERE local_shadow.lixcol_row_ref = global_state.lixcol_row_ref \
+                 WHERE local_shadow.key = global_state.key \
                    AND local_shadow.lixcol_file_id \
                        IS NOT DISTINCT FROM global_state.lixcol_file_id \
              ) \
@@ -698,11 +698,11 @@ simulation_test!(state_at_branch_scopes_compose_with_local_shadow_history, |sim|
     assert_ne!(refreshed_head_id, local_commit_id);
     let effective_diff = local
         .execute(
-            "SELECT to_key, diff_type, to_lixcol_global \
+            "SELECT key, diff_type, to_lixcol_global \
              FROM lix_diff('lix_key_value', $1, $2) \
-             WHERE COALESCE(to_key, from_key) IN \
+             WHERE key IN \
                  ('global-only', 'later-global', 'overridden', 'suppressed') \
-             ORDER BY COALESCE(to_key, from_key)",
+             ORDER BY key",
             &[
                 Value::Text(local_commit_id.clone()),
                 Value::Text(refreshed_head_id.clone()),
@@ -930,9 +930,9 @@ simulation_test!(local_collection_replacement_fences_the_global_base, |sim| asyn
     );
     let hidden_base_diff = local
         .execute(
-            "SELECT COALESCE(to_key, from_key) \
+            "SELECT key \
              FROM lix_diff('lix_key_value', $1, $2) \
-             WHERE COALESCE(to_key, from_key) = 'retired-global'",
+             WHERE key = 'retired-global'",
             &[Value::Text(before.clone()), Value::Text(head.clone())],
         )
         .await

--- a/packages/lix/tests/integration/sql/udfs.rs
+++ b/packages/lix/tests/integration/sql/udfs.rs
@@ -169,7 +169,7 @@ simulation_test!(
             .expect("draft should diverge");
         let diff = draft
             .execute(
-                "SELECT lixcol_row_pk FROM lix_diff(\
+                "SELECT key FROM lix_diff(\
                  'lix_key_value', lix_latest_checkpoint_commit_id(), \
                  lix_active_branch_commit_id())",
                 &[],

--- a/packages/lix/tests/integration/sql/untracked_current_state.rs
+++ b/packages/lix/tests/integration/sql/untracked_current_state.rs
@@ -530,7 +530,7 @@ async fn change_count_for_key(
         .execute(
             &format!(
                 "SELECT id FROM lix_change WHERE schema_key = 'lix_key_value' \
-                 AND row_pk ->> 0 = '{key}'"
+                 AND row_ref = lix_row_ref('lix_key_value', '{key}')"
             ),
             &[],
         )

--- a/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
+++ b/packages/lix/tests/integration/support/simulation_test/engine/simulation.rs
@@ -1,11 +1,12 @@
 use lix::storage::Memory;
 use lix::{
-    CreateBranchOptions, CreateBranchReceipt, CreateCheckpointReceipt, ExecuteResult,
+    CreateBranchOptions, CreateBranchReceipt, ExecuteResult,
     MergeBranchOptions, MergeBranchPreview, MergeBranchPreviewOptions, MergeBranchReceipt,
     SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt,
 };
 use lix::{LixError, Value};
 use lix::{engine::Engine, init::InitReceipt, session::SessionContext};
+use lix::session::CreateCheckpointReceipt;
 
 use super::expect_same::SimulationAssertions;
 use super::mode::{SimulationMode, SimulationOptions};

--- a/packages/lix/tests/integration/version_control_model_fuzz.rs
+++ b/packages/lix/tests/integration/version_control_model_fuzz.rs
@@ -708,34 +708,25 @@ async fn assert_working_diff(
         .unwrap_or_else(|error| panic!("{label}: checkpoint ID should be text: {error:?}"));
     let rows = session
         .execute(
-            "SELECT lixcol_row_pk, diff_type \
+            "SELECT key, diff_type \
              FROM lix_diff('lix_key_value', $1, lix_active_branch_commit_id()) \
-             ORDER BY lixcol_row_pk",
+             ORDER BY key",
             &[Value::Text(checkpoint)],
         )
         .await
         .unwrap_or_else(|error| panic!("{label}: working diff read failed: {error:?}"));
     let mut actual = Vec::new();
     for row in rows.rows() {
-        // `row_pk` is the JSON primary-key tuple, `["<key>"]` for
-        // `lix_key_value`.
-        let row_pk = row
-            .get::<JsonValue>("lixcol_row_pk")
-            .unwrap_or_else(|error| panic!("{label}: row_pk should be json: {error:?}"));
-        let Some(key) = row_pk
-            .as_array()
-            .and_then(|components| components.first())
-            .and_then(JsonValue::as_str)
-        else {
-            panic!("{label}: unexpected row_pk shape {row_pk:?}");
-        };
+        let key = row
+            .get::<String>("key")
+            .unwrap_or_else(|error| panic!("{label}: key should be text: {error:?}"));
         if !key.starts_with(prefix) {
             continue;
         }
         let diff_type = row
             .get::<String>("diff_type")
             .unwrap_or_else(|error| panic!("{label}: diff_type should be text: {error:?}"));
-        actual.push((key.to_string(), diff_type));
+        actual.push((key, diff_type));
     }
     actual.sort();
     let expected = expected

--- a/packages/lix/tests/migration_v72_filesystem.rs
+++ b/packages/lix/tests/migration_v72_filesystem.rs
@@ -106,7 +106,7 @@ async fn checkpointed_directories_survive_the_v74_migration() {
 
         // The path-projecting read the product runs on every checkpoint open.
         lix.execute(
-            "SELECT lixcol_row_pk, to_path FROM lix_diff('lix_file', lix_root_commit_id(), $1)",
+            "SELECT row_ref, id, to_path FROM lix_diff('lix_file', lix_root_commit_id(), $1)",
             &[Value::Text(commit_id.clone())],
         )
         .await
@@ -133,11 +133,10 @@ async fn checkpointed_directories_survive_the_v74_migration() {
     let new_file_id = new_file.rows()[0].get::<String>("id").expect("file id");
     let partial = lix
         .execute(
-            "INSERT INTO lix_create_checkpoint (relation, row_pk)
-             SELECT 'lix_file', lixcol_row_pk
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY(
+             SELECT row_ref
              FROM lix_diff('lix_file', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id())
-             WHERE lixcol_row_pk ->> 0 = $1
-             RETURNING commit_id",
+             WHERE id = $1))",
             &[Value::Text(new_file_id)],
         )
         .await


### PR DESCRIPTION
## Summary

- add opaque `RowRef` / `lix_row_ref(...)` identities with typed and composite primary-key support
- expose `row_ref` plus typed primary-key columns from `lix_diff`, with omitted ranges defaulting checkpoint to head
- replace two-column JSON selections with one `row_ref` across checkpoint, revert, and apply
- remove the public typed checkpoint SDK and transport endpoint; full and scoped checkpointing now share `lix_create_checkpoint(...)`
- add engine-owned checkpoint dependency closure and post-closure validation for schemas, file ownership, directory ancestry, foreign keys, unique constraints, and filesystem namespace swaps
- fix sparse-replica selected locator publication and the reported replica revert regression
- migrate docs, tooling, JS protocol v6, tests, examples, and benchmarks without compatibility shims

## Validation

- `cargo nextest run -p lix --no-fail-fast` (3000 passed after latest-main rebase)
- `cargo nextest run -p lix --features all-simulations --no-fail-fast` (3433 passed before latest-main rebase; rebased base suite passed)
- `cargo test -p lix --doc` (10 passed)
- `cargo check --manifest-path tooling/Cargo.toml --all-targets`
- `cargo nextest run -p lix-schema` (50 passed)
- JS SDK typecheck and 71 remote protocol/client/observe tests
- exact sparse replica revert e2e regression

No diff summary or schema visibility surface is introduced.