### PR TITLE
fix(lix): decouple sync state from server URL

### DIFF
--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -1708,6 +1708,7 @@ where
             let body = serde_json::to_vec(&json!({
                 "protocolVersion": lix::server_protocol::PROTOCOL_VERSION,
                 "syncProtocolVersion": 999,
+                "lixId": "01920000-0000-7000-8000-000000001234",
                 "sessionId": "incompatible-test-session",
                 "activeBranchId": "01920000-0000-7000-8000-000000001234",
                 "activeAccountId": lix::ANONYMOUS_ACCOUNT_ID,

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -695,7 +695,7 @@ where
     // A fresh repository or one left in the initialization/bootstrap crash
     // window needs one handshake and snapshot before its application session
     // can be bound to the authority's account. Reopens with durable state for
-    // this exact remote remain entirely local.
+    // this repository remain entirely local even when its transport URL changes.
     let (reopened_sync_account_id, mut prepared_sync) = if let Some(server) = server.as_ref() {
         match crate::sync::inspect_sync_bootstrap_with_adapter(
             &admission.adapter,

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -2484,10 +2484,14 @@ where
     let active_branch_id = lease
         .run_cancellable_read(|lix| async move { lix.active_branch_id().await })
         .await?;
+    let lix_id = lease
+        .run_cancellable_read(|lix| async move { Ok(lix.lix_id().to_owned()) })
+        .await?;
     let active_account_id = lease.record.principal.account_id().to_owned();
     Ok(Json(HandshakeResponse {
         protocol_version: PROTOCOL_VERSION,
         sync_protocol_version: crate::sync::SYNC_PROTOCOL_VERSION,
+        lix_id,
         active_branch_id,
         active_account_id,
         session_id: lease.session_id.clone(),
@@ -4402,6 +4406,7 @@ struct HandshakeRequest {
 struct HandshakeResponse {
     protocol_version: u32,
     sync_protocol_version: u32,
+    lix_id: String,
     active_branch_id: String,
     active_account_id: String,
     session_id: String,
@@ -7969,6 +7974,7 @@ mod tests {
             first["syncProtocolVersion"],
             crate::sync::SYNC_PROTOCOL_VERSION
         );
+        assert_eq!(first["lixId"], app.server.inner.engine.lix_id());
         assert_eq!(first["activeAccountId"], lix::ANONYMOUS_ACCOUNT_ID);
         assert!(first["capabilities"].get("requestBlobSplice").is_none());
         assert_eq!(first["capabilities"]["binaryFileUpsert"], true);

--- a/packages/lix/src/sync/bootstrap.rs
+++ b/packages/lix/src/sync/bootstrap.rs
@@ -27,8 +27,8 @@ pub(crate) struct PreparedSyncBootstrap {
 enum BootstrapTier {
     Empty,
     Unbound,
-    Exact { account_id: String },
-    Other,
+    Bound { account_id: String },
+    Ambiguous,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -36,7 +36,7 @@ enum BootstrapInspection {
     Prepare,
     Publishing,
     Ready { account_id: String },
-    BoundToOther,
+    Ambiguous,
 }
 
 pub(crate) async fn inspect_sync_bootstrap<StorageImpl>(
@@ -57,6 +57,7 @@ pub(crate) async fn inspect_sync_bootstrap_with_adapter<StorageImpl>(
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    super::repository::migrate_legacy_sync_replica_state(adapter).await?;
     match inspect_once(&adapter, remote_id).await? {
         BootstrapInspection::Prepare => Ok(SyncBootstrapAdmission::Prepare),
         BootstrapInspection::Ready { account_id } => {
@@ -67,7 +68,7 @@ where
             "sync bootstrap publication is not durable yet",
         )
         .with_details(serde_json::json!({ "retryable": true }))),
-        BootstrapInspection::BoundToOther => Err(bound_to_other_remote_error()),
+        BootstrapInspection::Ambiguous => Err(ambiguous_replica_error()),
     }
 }
 
@@ -86,41 +87,41 @@ where
         .await?;
     let durable_tier = inspect_tier(&durable, remote_id).await?;
     match durable_tier {
-        BootstrapTier::Other => return Ok(BootstrapInspection::BoundToOther),
-        BootstrapTier::Empty | BootstrapTier::Unbound | BootstrapTier::Exact { .. } => {}
+        BootstrapTier::Ambiguous => return Ok(BootstrapInspection::Ambiguous),
+        BootstrapTier::Empty | BootstrapTier::Unbound | BootstrapTier::Bound { .. } => {}
     }
 
     let visible = adapter.begin_read(StorageReadOptions::default()).await?;
     let visible_tier = inspect_tier(&visible, remote_id).await?;
     Ok(match (durable_tier, visible_tier) {
-        (BootstrapTier::Exact { account_id }, BootstrapTier::Exact { account_id: visible })
+        (BootstrapTier::Bound { account_id }, BootstrapTier::Bound { account_id: visible })
             if account_id == visible =>
         {
             BootstrapInspection::Ready { account_id }
         }
         (BootstrapTier::Empty, BootstrapTier::Empty)
         | (BootstrapTier::Unbound, BootstrapTier::Unbound) => BootstrapInspection::Prepare,
-        (_, BootstrapTier::Exact { .. } | BootstrapTier::Other)
+        (_, BootstrapTier::Bound { .. } | BootstrapTier::Ambiguous)
         | (BootstrapTier::Empty, BootstrapTier::Unbound)
         | (BootstrapTier::Unbound, BootstrapTier::Empty) => BootstrapInspection::Publishing,
-        (BootstrapTier::Exact { .. }, _) => BootstrapInspection::Publishing,
-        (BootstrapTier::Other, _) => unreachable!("terminal durable tier returned above"),
+        (BootstrapTier::Bound { .. }, _) => BootstrapInspection::Publishing,
+        (BootstrapTier::Ambiguous, _) => unreachable!("terminal durable tier returned above"),
     })
 }
 
 async fn inspect_tier(
     read: &(impl crate::storage_adapter::StorageAdapterRead + ?Sized),
-    remote_id: &str,
+    _remote_id: &str,
 ) -> Result<BootstrapTier, LixError> {
     match crate::init::repository_protocol_status(read).await? {
         crate::init::RepositoryProtocolStatus::Missing => Ok(BootstrapTier::Empty),
         crate::init::RepositoryProtocolStatus::Current => {
-            Ok(match super::repository::inspect_sync_replica_binding(read, remote_id).await? {
+            Ok(match super::repository::inspect_sync_replica_binding(read).await? {
                 SyncReplicaBinding::Unbound => BootstrapTier::Unbound,
-                SyncReplicaBinding::Exact { account_id } => {
-                    BootstrapTier::Exact { account_id }
+                SyncReplicaBinding::Bound { account_id } => {
+                    BootstrapTier::Bound { account_id }
                 }
-                SyncReplicaBinding::Other => BootstrapTier::Other,
+                SyncReplicaBinding::Ambiguous => BootstrapTier::Ambiguous,
             })
         }
         crate::init::RepositoryProtocolStatus::MigrationRequired { found_version } => {
@@ -140,6 +141,12 @@ pub(crate) async fn prepare_sync_bootstrap(
     let transport = HttpSyncTransport::connect(remote_id, &server.headers).await?;
     let (snapshot, lix_id, default_branch_id) =
         runtime::fetch_repository_snapshot(&transport).await?;
+    if transport.lix_id() != lix_id {
+        return Err(super::sync_repository_id_mismatch(
+            &lix_id,
+            transport.lix_id(),
+        ));
+    }
     Ok(PreparedSyncBootstrap {
         transport,
         snapshot,
@@ -188,7 +195,7 @@ where
                 .await?;
             Ok(prepared.transport)
         }
-        Ok(InitialSyncSnapshotInstall::ExistingExact) => {
+        Ok(InitialSyncSnapshotInstall::ExistingRepository) => {
             let adapter = lix.storage_adapter();
             let _ = inspect_sync_bootstrap_with_adapter(
                 &adapter,
@@ -197,7 +204,7 @@ where
             .await?;
             Err(restart_open_error())
         }
-        Ok(InitialSyncSnapshotInstall::ExistingOther) => Err(bound_to_other_remote_error()),
+        Ok(InitialSyncSnapshotInstall::Ambiguous) => Err(ambiguous_replica_error()),
         Err(error) => Err(
             reconcile_install_error(
                 &lix.storage_adapter(),
@@ -224,7 +231,7 @@ where
         Ok(BootstrapInspection::Ready { .. } | BootstrapInspection::Publishing) => {
             restart_open_error()
         }
-        Ok(BootstrapInspection::BoundToOther) => bound_to_other_remote_error(),
+        Ok(BootstrapInspection::Ambiguous) => ambiguous_replica_error(),
         Ok(BootstrapInspection::Prepare) | Err(_) => error,
     }
 }
@@ -242,10 +249,10 @@ fn restart_open_error() -> LixError {
     .with_details(serde_json::json!({ "retryable": true }))
 }
 
-fn bound_to_other_remote_error() -> LixError {
+fn ambiguous_replica_error() -> LixError {
     LixError::new(
         LixError::CODE_INVALID_PARAM,
-        "an initialized sync replica cannot be rebound to a different remote",
+        "sync replica contains conflicting durable authority receipts",
     )
 }
 
@@ -254,13 +261,48 @@ mod tests {
     use super::*;
     use crate::engine::Engine;
     use crate::storage_adapter::{
-        Memory, MemoryRead, MemoryWrite, StorageError, StorageWriteOptions,
+        Memory, MemoryRead, MemoryWrite, StorageAdapterRead, StorageError,
+        StorageWriteOptions,
     };
 
     #[derive(Clone)]
     struct TieredStorage {
         visible: Memory,
         durable: Memory,
+    }
+
+    #[derive(Clone)]
+    struct DurableMemory {
+        inner: Memory,
+    }
+
+    impl Storage for DurableMemory {
+        type Read<'a> = MemoryRead;
+        type Write<'a> = MemoryWrite;
+
+        async fn acquire_session(
+            &self,
+        ) -> Result<crate::storage::StorageSessionToken, StorageError> {
+            Err(StorageError::Unsupported(
+                crate::storage::Capability::StorageSessions,
+            ))
+        }
+
+        async fn begin_read(
+            &self,
+            mut options: StorageReadOptions,
+        ) -> Result<Self::Read<'_>, StorageError> {
+            options.durability = StorageReadDurability::Visible;
+            self.inner.begin_read(options).await
+        }
+
+        async fn begin_write(
+            &self,
+            mut options: StorageWriteOptions,
+        ) -> Result<Self::Write<'_>, StorageError> {
+            options.await_durable = false;
+            self.inner.begin_write(options).await
+        }
     }
 
     impl Storage for TieredStorage {
@@ -315,21 +357,38 @@ mod tests {
         storage
     }
 
-    async fn store_replica_state(storage: &Memory, remote_id: &str) {
+    async fn store_replica_state(storage: &Memory, _remote_id: &str) {
+        store_replica_state_at_key(storage, b"repository", canonical_replica_state()).await;
+    }
+
+    async fn store_legacy_replica_state(storage: &Memory, remote_id: &str) {
+        store_replica_state_at_key(
+            storage,
+            remote_id.as_bytes(),
+            canonical_replica_state(),
+        )
+        .await;
+    }
+
+    fn canonical_replica_state() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "activeAccountId": crate::ANONYMOUS_ACCOUNT_ID,
+            "cursor": 7,
+            "authoritativeBranches": {},
+            "authorityKnownCommitIds": []
+        }))
+        .expect("replica state should encode")
+    }
+
+    async fn store_replica_state_at_key(storage: &Memory, key: &[u8], value: Vec<u8>) {
         let adapter = StorageAdapter::new(storage.clone());
         let mut writes = adapter.new_write_set();
         writes.put(
             super::super::SYNC_REPLICA_STATE_SPACE,
             crate::storage_adapter::StorageKey(bytes::Bytes::copy_from_slice(
-                remote_id.as_bytes(),
+                key,
             )),
-            serde_json::to_vec(&serde_json::json!({
-                "activeAccountId": crate::ANONYMOUS_ACCOUNT_ID,
-                "cursor": 7,
-                "authoritativeBranches": {},
-                "authorityKnownCommitIds": []
-            }))
-            .expect("replica state should encode"),
+            value,
         );
         adapter
             .commit_write_set(writes, StorageWriteOptions::default())
@@ -337,20 +396,94 @@ mod tests {
             .expect("replica state should commit");
     }
 
-    async fn store_malformed_replica_state(storage: &Memory, remote_id: &str) {
-        let adapter = StorageAdapter::new(storage.clone());
-        let mut writes = adapter.new_write_set();
-        writes.put(
-            super::super::SYNC_REPLICA_STATE_SPACE,
-            crate::storage_adapter::StorageKey(bytes::Bytes::copy_from_slice(
-                remote_id.as_bytes(),
-            )),
+    async fn store_malformed_replica_state(storage: &Memory, _remote_id: &str) {
+        store_replica_state_at_key(
+            storage,
+            b"repository",
             br#"{"activeAccountId":"anonymous"}"#.to_vec(),
-        );
-        adapter
-            .commit_write_set(writes, StorageWriteOptions::default())
+        )
+        .await;
+    }
+
+    async fn replica_state_rows(storage: &Memory) -> Vec<(bytes::Bytes, bytes::Bytes)> {
+        let adapter = StorageAdapter::new(storage.clone());
+        let read = adapter
+            .begin_read(StorageReadOptions::default())
             .await
-            .expect("malformed replica state should commit");
+            .expect("replica-state read should open");
+        let mut cursor = read
+            .begin_scan(
+                super::super::SYNC_REPLICA_STATE_SPACE,
+                crate::storage_adapter::StoragePrefix {
+                    bytes: bytes::Bytes::new(),
+                }
+                .to_range()
+                .expect("replica-state range should build"),
+                crate::storage_adapter::StorageBeginScanOptions {
+                    projection: crate::storage_adapter::StorageCoreProjection::FullValue,
+                    ..crate::storage_adapter::StorageBeginScanOptions::default()
+                },
+            )
+            .await
+            .expect("replica-state scan should begin");
+        let mut rows = Vec::new();
+        while let Some(entries) = cursor
+            .next_chunk()
+            .await
+            .expect("replica-state scan should advance")
+        {
+            for entry in entries {
+                let crate::storage_adapter::StorageProjectedValue::FullValue(value) = entry.value
+                else {
+                    panic!("replica-state scan omitted its value");
+                };
+                rows.push((entry.key.0, value));
+            }
+        }
+        rows
+    }
+
+    #[tokio::test]
+    async fn legacy_url_key_migrates_byte_for_byte_and_accepts_a_new_url() {
+        let storage = DurableMemory {
+            inner: Memory::new(),
+        };
+        Engine::initialize_with_main_branch_id(storage.clone(), None)
+            .await
+            .expect("test storage should initialize");
+        let old_url =
+            "https://old.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001";
+        let raw = format!(
+            r#"{{ "activeAccountId":"{}", "cursor":7, "authoritativeBranches":{{}}, "pendingResets":{{}}, "authorityKnownCommitIds":[] }}"#,
+            crate::ANONYMOUS_ACCOUNT_ID
+        )
+        .into_bytes();
+        store_replica_state_at_key(&storage.inner, old_url.as_bytes(), raw.clone()).await;
+
+        assert_eq!(
+            inspect_sync_bootstrap(
+                &storage,
+                "https://new.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001",
+            )
+            .await
+            .expect("legacy replica should migrate"),
+            SyncBootstrapAdmission::Ready {
+                account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+            }
+        );
+        assert_eq!(
+            replica_state_rows(&storage.inner).await,
+            vec![(bytes::Bytes::from_static(b"repository"), bytes::Bytes::from(raw))],
+            "migration must preserve the durable receipt and remove its URL key",
+        );
+        assert!(matches!(
+            inspect_sync_bootstrap(
+                &storage,
+                "https://third.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001",
+            )
+            .await,
+            Ok(SyncBootstrapAdmission::Ready { .. })
+        ));
     }
 
     #[tokio::test]
@@ -409,15 +542,15 @@ mod tests {
         let visible = initialized_memory().await;
         let durable = initialized_memory().await;
         for storage in [&visible, &durable] {
-            store_replica_state(storage, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001").await;
-            store_replica_state(storage, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000002").await;
+            store_legacy_replica_state(storage, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001").await;
+            store_legacy_replica_state(storage, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000002").await;
         }
         let storage = tiered(visible, durable);
         let error = inspect_sync_bootstrap(&storage, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001")
             .await
             .expect_err("multiple durable remotes must fail closed");
-        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
-        assert!(error.message.contains("different remote"));
+        assert_eq!(error.code, "LIX_ERROR_SYNC_REPLICA_STATE_AMBIGUOUS");
+        assert!(error.message.contains("multiple durable authority receipts"));
     }
 
     #[tokio::test]
@@ -425,7 +558,7 @@ mod tests {
         let visible = initialized_memory().await;
         let durable = initialized_memory().await;
         store_replica_state(&visible, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001").await;
-        store_replica_state(&visible, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000002").await;
+        store_legacy_replica_state(&visible, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000002").await;
         store_replica_state(&durable, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001").await;
         let storage = tiered(visible, durable);
         let adapter = StorageAdapter::new(storage);
@@ -521,7 +654,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ambiguous_install_write_reports_a_different_durable_owner() {
+    async fn ambiguous_install_write_restarts_for_the_same_repository() {
         let visible = initialized_memory().await;
         let durable = initialized_memory().await;
         store_replica_state(&visible, "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000002").await;
@@ -534,7 +667,10 @@ mod tests {
             LixError::new(LixError::CODE_TRANSACTION_CONFLICT, "lost publication race"),
         )
         .await;
-        assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
-        assert!(error.message.contains("different remote"));
+        assert_eq!(error.code, LixError::CODE_STORAGE_READ_EXPIRED);
+        assert_eq!(
+            error.details,
+            Some(serde_json::json!({ "retryable": true }))
+        );
     }
 }

--- a/packages/lix/src/sync/http.rs
+++ b/packages/lix/src/sync/http.rs
@@ -11,7 +11,8 @@ use super::{
     SyncBlobRegistration, SyncHistoryResponse, SyncPushRequest, SyncPushResponse,
     SyncRepositoryPullResponse, SyncSnapshotRowPage, SyncTransport, SyncTransportBounds,
     SyncTransportFuture, SYNC_PROTOCOL_VERSION, SYNC_PROTOCOL_VERSION_HEADER,
-    sync_server_protocol_mismatch, validate_sync_remote_id,
+    sync_server_protocol_mismatch, sync_server_protocol_missing_field,
+    validate_sync_remote_id,
 };
 use crate::LixError;
 
@@ -47,6 +48,7 @@ struct HandshakeResponse {
     protocol_version: u32,
     #[serde(default)]
     sync_protocol_version: Option<u32>,
+    lix_id: Option<String>,
     session_id: String,
     active_account_id: String,
 }
@@ -70,6 +72,7 @@ struct ErrorBody {
 pub(crate) struct HttpSyncTransport<Client> {
     client: Client,
     protocol_url: String,
+    lix_id: String,
     session_id: String,
     active_account_id: String,
 }
@@ -92,10 +95,11 @@ where
             ))
             .await?;
         let handshake: HandshakeResponse = decode_response(response, "open sync session")?;
-        validate_handshake(&handshake)?;
+        let lix_id = validate_handshake(&handshake)?.to_owned();
         Ok(Self {
             client,
             protocol_url,
+            lix_id,
             session_id: handshake.session_id,
             active_account_id: handshake.active_account_id,
         })
@@ -104,6 +108,10 @@ where
     pub(super) fn is_reserved_header(name: &str) -> bool {
         name.eq_ignore_ascii_case(SESSION_HEADER)
             || name.eq_ignore_ascii_case(SYNC_PROTOCOL_VERSION_HEADER)
+    }
+
+    pub(super) fn lix_id(&self) -> &str {
+        &self.lix_id
     }
 
     fn request(&self, method: Method, path: &str, operation: &'static str) -> RawHttpRequest {
@@ -127,7 +135,7 @@ where
     }
 }
 
-fn validate_handshake(handshake: &HandshakeResponse) -> Result<(), LixError> {
+fn validate_handshake(handshake: &HandshakeResponse) -> Result<&str, LixError> {
     if handshake.protocol_version != crate::SERVER_PROTOCOL_VERSION {
         return Err(LixError::new(
             "LIX_SERVER_PROTOCOL_ERROR",
@@ -142,6 +150,16 @@ fn validate_handshake(handshake: &HandshakeResponse) -> Result<(), LixError> {
             handshake.sync_protocol_version,
         ));
     }
+    let lix_id = handshake
+        .lix_id
+        .as_deref()
+        .ok_or_else(|| sync_server_protocol_missing_field("lixId"))?;
+    crate::row_pk::RowPk::uuid_from_canonical(lix_id).map_err(|_| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "sync handshake returned an invalid lixId",
+        )
+    })?;
     if handshake.session_id.is_empty() || handshake.session_id.len() > 4096 {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -154,7 +172,7 @@ fn validate_handshake(handshake: &HandshakeResponse) -> Result<(), LixError> {
             "sync handshake returned an invalid active account identity",
         )
     })?;
-    Ok(())
+    Ok(lix_id)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -533,6 +551,7 @@ mod tests {
         let error = validate_handshake(&HandshakeResponse {
             protocol_version: crate::SERVER_PROTOCOL_VERSION + 1,
             sync_protocol_version: Some(crate::sync::SYNC_PROTOCOL_VERSION),
+            lix_id: Some("01936f4e-7b6c-7c3d-8f9a-123456789abc".to_owned()),
             session_id: "session-1".to_owned(),
             active_account_id: "01920000-0000-7000-8000-000000000602".to_owned(),
         })
@@ -553,6 +572,7 @@ mod tests {
                     body: serde_json::to_vec(&serde_json::json!({
                         "protocolVersion": crate::SERVER_PROTOCOL_VERSION,
                         "syncProtocolVersion": 999,
+                        "lixId": "01936f4e-7b6c-7c3d-8f9a-123456789abc",
                         "sessionId": "session-from-incompatible-server",
                         "activeBranchId": "01920000-0000-7000-8000-000000001234",
                         "activeAccountId": crate::SYSTEM_ACCOUNT_ID,
@@ -561,6 +581,43 @@ mod tests {
                 })
             })
         }
+    }
+
+    #[derive(Debug)]
+    struct MatchingClient;
+
+    impl RawHttpClient for MatchingClient {
+        fn send(&self, _request: RawHttpRequest) -> SyncTransportFuture<'_, RawHttpResponse> {
+            Box::pin(async {
+                Ok(RawHttpResponse {
+                    status: 200,
+                    status_text: "OK".to_owned(),
+                    body: serde_json::to_vec(&serde_json::json!({
+                        "protocolVersion": crate::SERVER_PROTOCOL_VERSION,
+                        "syncProtocolVersion": crate::sync::SYNC_PROTOCOL_VERSION,
+                        "lixId": "01936f4e-7b6c-7c3d-8f9a-123456789abc",
+                        "sessionId": "session-from-server",
+                        "activeBranchId": "01920000-0000-7000-8000-000000001234",
+                        "activeAccountId": crate::SYSTEM_ACCOUNT_ID,
+                    }))
+                    .expect("encode handshake"),
+                })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn sync_transport_retains_the_authority_lix_id() {
+        let transport = HttpSyncTransport::connect_with(
+            MatchingClient,
+            "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-123456789abc",
+        )
+        .await
+        .expect("matching handshake should connect");
+        assert_eq!(
+            transport.lix_id(),
+            "01936f4e-7b6c-7c3d-8f9a-123456789abc"
+        );
     }
 
     #[derive(Debug)]
@@ -574,6 +631,29 @@ mod tests {
                     status_text: "OK".to_owned(),
                     body: serde_json::to_vec(&serde_json::json!({
                         "protocolVersion": crate::SERVER_PROTOCOL_VERSION,
+                        "lixId": "01936f4e-7b6c-7c3d-8f9a-123456789abc",
+                        "sessionId": "session-from-legacy-server",
+                        "activeBranchId": "01920000-0000-7000-8000-000000001234",
+                        "activeAccountId": crate::SYSTEM_ACCOUNT_ID,
+                    }))
+                    .expect("encode legacy handshake"),
+                })
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct MissingIdentityClient;
+
+    impl RawHttpClient for MissingIdentityClient {
+        fn send(&self, _request: RawHttpRequest) -> SyncTransportFuture<'_, RawHttpResponse> {
+            Box::pin(async {
+                Ok(RawHttpResponse {
+                    status: 200,
+                    status_text: "OK".to_owned(),
+                    body: serde_json::to_vec(&serde_json::json!({
+                        "protocolVersion": crate::SERVER_PROTOCOL_VERSION,
+                        "syncProtocolVersion": crate::sync::SYNC_PROTOCOL_VERSION,
                         "sessionId": "session-from-legacy-server",
                         "activeBranchId": "01920000-0000-7000-8000-000000001234",
                         "activeAccountId": crate::SYSTEM_ACCOUNT_ID,
@@ -617,6 +697,21 @@ mod tests {
                 "clientSyncProtocolVersion": crate::sync::SYNC_PROTOCOL_VERSION,
                 "serverSyncProtocolVersion": null,
             }))
+        );
+    }
+
+    #[tokio::test]
+    async fn sync_handshake_rejects_a_missing_repository_identity_as_terminal() {
+        let error = HttpSyncTransport::connect_with(
+            MissingIdentityClient,
+            "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-123456789abc",
+        )
+        .await
+        .expect_err("a legacy server must fail before transfer");
+        assert_eq!(error.code, crate::sync::SYNC_PROTOCOL_MISMATCH_CODE);
+        assert_eq!(
+            error.details,
+            Some(serde_json::json!({ "missingField": "lixId" }))
         );
     }
 

--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -75,6 +75,8 @@ pub(crate) const SYNC_LONG_POLL_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const SYNC_PROTOCOL_VERSION: u32 = 1;
 pub(crate) const SYNC_PROTOCOL_VERSION_HEADER: &str = "lix-sync-protocol-version";
 pub(crate) const SYNC_PROTOCOL_MISMATCH_CODE: &str = "LIX_SYNC_PROTOCOL_MISMATCH";
+pub(crate) const SYNC_REPOSITORY_ID_MISMATCH_CODE: &str =
+    "LIX_SYNC_REPOSITORY_ID_MISMATCH";
 pub(crate) const SYNC_IMMUTABLE_OBJECT_MISMATCH_CODE: &str =
     "LIX_SYNC_IMMUTABLE_OBJECT_MISMATCH";
 const MAX_SYNC_REMOTE_ID_BYTES: usize = 4 * 1024;
@@ -92,6 +94,25 @@ pub(crate) fn sync_server_protocol_mismatch(server_version: Option<u32>) -> LixE
     .with_details(serde_json::json!({
         "clientSyncProtocolVersion": SYNC_PROTOCOL_VERSION,
         "serverSyncProtocolVersion": server_version,
+    }))
+}
+
+pub(crate) fn sync_server_protocol_missing_field(field: &str) -> LixError {
+    LixError::new(
+        SYNC_PROTOCOL_MISMATCH_CODE,
+        format!("incompatible sync protocol: server handshake omitted required {field}"),
+    )
+    .with_details(serde_json::json!({ "missingField": field }))
+}
+
+pub(crate) fn sync_repository_id_mismatch(local: &str, authority: &str) -> LixError {
+    LixError::new(
+        SYNC_REPOSITORY_ID_MISMATCH_CODE,
+        "sync authority lixId does not match the local repository",
+    )
+    .with_details(serde_json::json!({
+        "localLixId": local,
+        "authorityLixId": authority,
     }))
 }
 

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -30,7 +30,7 @@ use crate::hot_state::{
 };
 use crate::row_pk::RowPk;
 use crate::storage_adapter::{
-    Storage, StorageAdapterRead, StorageBeginScanOptions, StorageCoreProjection,
+    Storage, StorageAdapter, StorageAdapterRead, StorageBeginScanOptions, StorageCoreProjection,
     StorageGetManyRequest, StorageGetOptions, StorageKey, StoragePrecondition, StoragePrefix,
     StorageProjectedValue, StorageReadOptions, StorageSpace, StorageSpaceId, StorageWriteOptions,
     StorageWriteSet, ValueSemantics, exact_get_many,
@@ -406,6 +406,8 @@ pub(crate) const SYNC_REPLICA_STATE_SPACE: StorageSpace = StorageSpace::declare(
 );
 
 const SEQUENCE_KEY: &[u8] = b"repository";
+const REPLICA_STATE_KEY: &[u8] = b"repository";
+const AMBIGUOUS_REPLICA_STATE_CODE: &str = "LIX_ERROR_SYNC_REPLICA_STATE_AMBIGUOUS";
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RepositoryEventRecord {
@@ -461,15 +463,15 @@ const MAX_SUPERSEDED_RESET_HEADS: usize = 16;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) enum SyncReplicaBinding {
     Unbound,
-    Exact { account_id: String },
-    Other,
+    Bound { account_id: String },
+    Ambiguous,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum InitialSyncSnapshotInstall {
     Installed,
-    ExistingExact,
-    ExistingOther,
+    ExistingRepository,
+    Ambiguous,
 }
 
 /// The authority's complete coordinate for one known branch.
@@ -530,22 +532,19 @@ impl AuthoritativeBranchCoordinate {
 }
 
 struct ReplicaStatePublication<'a> {
-    remote_id: &'a str,
     expected_cursor: u64,
     expected_state_raw: &'a Bytes,
     state: &'a SyncReplicaState,
 }
 
-fn replica_state_key(remote_id: &str) -> StorageKey {
-    StorageKey(Bytes::copy_from_slice(remote_id.as_bytes()))
+fn replica_state_key() -> StorageKey {
+    StorageKey(Bytes::from_static(REPLICA_STATE_KEY))
 }
 
 async fn load_replica_state(
     read: &(impl StorageAdapterRead + ?Sized),
-    remote_id: &str,
 ) -> Result<(Option<SyncReplicaState>, Option<Bytes>), LixError> {
-    super::validate_sync_remote_id(remote_id)?;
-    let key = replica_state_key(remote_id);
+    let key = replica_state_key();
     let values = exact_get_many(
         read,
         &[StorageGetManyRequest {
@@ -584,9 +583,8 @@ async fn load_replica_state(
 
 pub(crate) async fn load_sync_replica_account(
     read: &(impl StorageAdapterRead + ?Sized),
-    remote_id: &str,
 ) -> Result<Option<String>, LixError> {
-    Ok(load_replica_state(read, remote_id)
+    Ok(load_replica_state(read)
         .await?
         .0
         .map(|state| state.active_account_id))
@@ -594,9 +592,8 @@ pub(crate) async fn load_sync_replica_account(
 
 pub(super) async fn inspect_sync_replica_binding(
     read: &(impl StorageAdapterRead + ?Sized),
-    remote_id: &str,
 ) -> Result<SyncReplicaBinding, LixError> {
-    let exact = load_replica_state(read, remote_id).await?.0;
+    let exact = load_replica_state(read).await?.0;
     let range = StoragePrefix {
         bytes: Bytes::new(),
     }
@@ -614,12 +611,117 @@ pub(super) async fn inspect_sync_replica_binding(
     let keys = cursor.next_page(2).await?;
     match (exact, keys.len()) {
         (None, 0) => Ok(SyncReplicaBinding::Unbound),
-        (None, _) => Ok(SyncReplicaBinding::Other),
-        (Some(state), 1) => Ok(SyncReplicaBinding::Exact {
+        (None, _) => Ok(SyncReplicaBinding::Ambiguous),
+        (Some(state), 1) => Ok(SyncReplicaBinding::Bound {
             account_id: state.active_account_id,
         }),
-        (Some(_), _) => Ok(SyncReplicaBinding::Other),
+        (Some(_), _) => Ok(SyncReplicaBinding::Ambiguous),
     }
+}
+
+/// Moves the one legacy URL-keyed sync receipt to the repository-scoped key.
+///
+/// The raw bytes are preserved so repository admission cannot alter cursor or
+/// outbox acknowledgement state. Lix supports exactly one sync authority per
+/// local store, so more than one receipt is ambiguous and must fail closed.
+pub(crate) async fn migrate_legacy_sync_replica_state<StorageImpl>(
+    adapter: &StorageAdapter<StorageImpl>,
+) -> Result<(), LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let read = adapter.begin_read(StorageReadOptions::default()).await?;
+    let range = StoragePrefix {
+        bytes: Bytes::new(),
+    }
+    .to_range()?;
+    let mut cursor = read
+        .begin_scan(
+            SYNC_REPLICA_STATE_SPACE,
+            range,
+            StorageBeginScanOptions {
+                projection: StorageCoreProjection::FullValue,
+                ..StorageBeginScanOptions::default()
+            },
+        )
+        .await?;
+    let (entries, _) = cursor.next_page(2).await?.into_parts();
+    if entries.is_empty() {
+        return Ok(());
+    }
+    if entries.len() != 1 {
+        return Err(ambiguous_replica_state_error());
+    }
+    let entry = entries.into_iter().next().expect("one replica-state row");
+    drop(cursor);
+    if entry.key == replica_state_key() {
+        return Ok(());
+    }
+    let StorageProjectedValue::FullValue(raw) = entry.value else {
+        return Err(LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            "legacy sync replica-state scan omitted its value",
+        ));
+    };
+    serde_json::from_slice::<SyncReplicaState>(&raw).map_err(|error| {
+        LixError::new(
+            LixError::CODE_INTERNAL_ERROR,
+            format!("decode sync replica state: {error}"),
+        )
+    })?;
+
+    let canonical_key = replica_state_key();
+    let mut writes = adapter.new_write_set();
+    writes.put(
+        SYNC_REPLICA_STATE_SPACE,
+        canonical_key.clone(),
+        raw.to_vec(),
+    );
+    writes.delete(SYNC_REPLICA_STATE_SPACE, entry.key.clone());
+    drop(read);
+    let commit = adapter
+        .commit_write_set(
+            writes,
+            StorageWriteOptions {
+                preconditions: vec![
+                    StoragePrecondition::KeyAbsent {
+                        space: SYNC_REPLICA_STATE_SPACE,
+                        key: canonical_key,
+                    },
+                    StoragePrecondition::KeyValueEquals {
+                        space: SYNC_REPLICA_STATE_SPACE,
+                        key: entry.key,
+                        expected: raw,
+                    },
+                ],
+                await_durable: true,
+                ..StorageWriteOptions::default()
+            },
+        )
+        .await;
+    match commit {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            let error = LixError::from(error);
+            if error.code != LixError::CODE_TRANSACTION_CONFLICT
+                && error.code != LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+            {
+                return Err(error);
+            }
+            let read = adapter.begin_read(StorageReadOptions::default()).await?;
+            match inspect_sync_replica_binding(&read).await? {
+                SyncReplicaBinding::Bound { .. } => Ok(()),
+                SyncReplicaBinding::Unbound | SyncReplicaBinding::Ambiguous => Err(error),
+            }
+        }
+    }
+}
+
+fn ambiguous_replica_state_error() -> LixError {
+    LixError::new(
+        AMBIGUOUS_REPLICA_STATE_CODE,
+        "sync replica contains multiple durable authority receipts",
+    )
 }
 
 pub(crate) async fn has_any_sync_replica_state(
@@ -794,11 +896,10 @@ pub(crate) async fn load_pending_sync_export_commit_ids(
 fn stage_replica_state(
     writes: &mut StorageWriteSet,
     preconditions: &mut Vec<StoragePrecondition>,
-    remote_id: &str,
     state: &SyncReplicaState,
     previous: Option<Bytes>,
 ) -> Result<(), LixError> {
-    let key = replica_state_key(remote_id);
+    let key = replica_state_key();
     writes.put(
         SYNC_REPLICA_STATE_SPACE,
         key.clone(),
@@ -835,7 +936,7 @@ pub(crate) async fn stage_sync_restore_intents(
     if restore_targets.is_empty() {
         return Ok(());
     }
-    let (state, previous) = load_replica_state(read, remote_id).await?;
+    let (state, previous) = load_replica_state(read).await?;
     let Some(mut state) = state else {
         return Err(LixError::new(
             LixError::CODE_INTERNAL_ERROR,
@@ -893,7 +994,7 @@ pub(crate) async fn stage_sync_restore_intents(
         }
     }
     if changed {
-        stage_replica_state(writes, preconditions, remote_id, &state, previous)?;
+        stage_replica_state(writes, preconditions, &state, previous)?;
     }
     Ok(())
 }
@@ -2100,11 +2201,11 @@ where
 {
     pub(crate) async fn load_sync_repository_cursor(
         &self,
-        remote_id: &str,
+        _remote_id: &str,
     ) -> Result<Option<u64>, LixError> {
         let adapter = self.storage_adapter();
         let read = adapter.begin_read(StorageReadOptions::default()).await?;
-        Ok(load_replica_state(&read, remote_id)
+        Ok(load_replica_state(&read)
             .await?
             .0
             .map(|state| state.cursor))
@@ -2112,12 +2213,12 @@ where
 
     pub(crate) async fn validate_sync_repository_account(
         &self,
-        remote_id: &str,
+        _remote_id: &str,
         active_account_id: &str,
     ) -> Result<(), LixError> {
         let adapter = self.storage_adapter();
         let read = adapter.begin_read(StorageReadOptions::default()).await?;
-        let expected = load_sync_replica_account(&read, remote_id).await?;
+        let expected = load_sync_replica_account(&read).await?;
         if expected
             .as_deref()
             .is_some_and(|expected| expected != active_account_id)
@@ -2149,7 +2250,7 @@ where
         let mut remaining_reconciliations = None;
         loop {
             let read = adapter.begin_read(StorageReadOptions::default()).await?;
-            let Some(state) = load_replica_state(&read, remote_id).await?.0 else {
+            let Some(state) = load_replica_state(&read).await?.0 else {
                 return Ok(None);
             };
             let local_controls = BranchHeadControlContext::new()
@@ -2530,13 +2631,13 @@ where
 
     async fn mark_pending_reset_heads(
         &self,
-        remote_id: &str,
+        _remote_id: &str,
         prepared: &BTreeMap<String, (PendingSyncReset, String)>,
     ) -> Result<bool, LixError> {
         let _collaboration_guard = self.lock_collaboration_writes().await;
         let adapter = self.storage_adapter();
         let read = adapter.begin_read(StorageReadOptions::default()).await?;
-        let (Some(mut state), previous) = load_replica_state(&read, remote_id).await? else {
+        let (Some(mut state), previous) = load_replica_state(&read).await? else {
             return Ok(false);
         };
         let mut changed = false;
@@ -2563,7 +2664,7 @@ where
         }
         let mut writes = adapter.new_write_set();
         let mut preconditions = Vec::new();
-        stage_replica_state(&mut writes, &mut preconditions, remote_id, &state, previous)?;
+        stage_replica_state(&mut writes, &mut preconditions, &state, previous)?;
         drop(read);
         adapter
             .commit_write_set(
@@ -2580,7 +2681,7 @@ where
 
     pub(crate) async fn apply_sync_repository_pull(
         &self,
-        remote_id: &str,
+        _remote_id: &str,
         response: &SyncRepositoryPullResponse,
     ) -> Result<(), LixError> {
         match response {
@@ -2592,7 +2693,7 @@ where
                 let (mut state, expected_state_raw) = {
                     let adapter = self.storage_adapter();
                     let read = adapter.begin_read(StorageReadOptions::default()).await?;
-                    let (state, raw) = load_replica_state(&read, remote_id).await?;
+                    let (state, raw) = load_replica_state(&read).await?;
                     let state = state.ok_or_else(|| {
                             LixError::new(
                                 LixError::CODE_INVALID_PARAM,
@@ -2867,7 +2968,6 @@ where
                         SyncImportPurpose::ReplicaDelta,
                         None,
                         Some(ReplicaStatePublication {
-                            remote_id,
                             expected_cursor,
                             expected_state_raw: &expected_state_raw,
                             state: &state,
@@ -2910,7 +3010,6 @@ where
                         SyncImportPurpose::ReplicaDelta,
                         None,
                         Some(ReplicaStatePublication {
-                            remote_id,
                             expected_cursor,
                             expected_state_raw: &expected_state_raw,
                             state: &state,
@@ -3028,10 +3127,10 @@ where
         let _collaboration_guard = self.lock_collaboration_writes().await;
         let adapter = self.storage_adapter();
         let read = adapter.begin_read(StorageReadOptions::default()).await?;
-        let (_, previous) = load_replica_state(&read, remote_id).await?;
+        let (_, previous) = load_replica_state(&read).await?;
         let mut writes = adapter.new_write_set();
         let mut preconditions = Vec::new();
-        stage_replica_state(&mut writes, &mut preconditions, remote_id, &state, previous)?;
+        stage_replica_state(&mut writes, &mut preconditions, &state, previous)?;
         drop(read);
         adapter
             .commit_write_set(
@@ -3130,13 +3229,13 @@ where
         }
         let adapter = self.storage_adapter();
         let read = adapter.begin_read(StorageReadOptions::default()).await?;
-        match inspect_sync_replica_binding(&read, remote_id).await? {
+        match inspect_sync_replica_binding(&read).await? {
             SyncReplicaBinding::Unbound => {}
-            SyncReplicaBinding::Exact { .. } => {
-                return Ok(InitialSyncSnapshotInstall::ExistingExact);
+            SyncReplicaBinding::Bound { .. } => {
+                return Ok(InitialSyncSnapshotInstall::ExistingRepository);
             }
-            SyncReplicaBinding::Other => {
-                return Ok(InitialSyncSnapshotInstall::ExistingOther);
+            SyncReplicaBinding::Ambiguous => {
+                return Ok(InitialSyncSnapshotInstall::Ambiguous);
             }
         }
         let branch_ids = branches
@@ -3725,7 +3824,6 @@ where
         stage_replica_state(
             &mut writes,
             &mut preconditions,
-            remote_id,
             &SyncReplicaState {
                 active_account_id: active_account_id.to_owned(),
                 cursor,
@@ -5395,8 +5493,7 @@ where
                     "sync replica publication must advance its event cursor",
                 ));
             }
-            let (_stored_state, previous) =
-                load_replica_state(&read, publication.remote_id).await?;
+            let (_stored_state, previous) = load_replica_state(&read).await?;
             if previous.as_ref() != Some(publication.expected_state_raw) {
                 return Err(LixError::new(
                     LixError::CODE_TRANSACTION_CONFLICT,
@@ -5406,7 +5503,6 @@ where
             stage_replica_state(
                 &mut writes,
                 &mut preconditions,
-                publication.remote_id,
                 publication.state,
                 previous,
             )?;
@@ -6667,7 +6763,7 @@ mod tests {
             .await
             .expect("published branch should load")
             .expect("published branch should exist");
-        let stored_state = load_replica_state(&read, TEST_REMOTE)
+        let stored_state = load_replica_state(&read)
             .await
             .expect("published receipt should load")
             .0
@@ -7679,7 +7775,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_initial_snapshots_cannot_publish_two_remote_bindings() {
+    async fn concurrent_initial_snapshots_publish_one_repository_binding() {
         let authority = open_lix().await.expect("authority should open");
         let snapshot = authority
             .pull_sync_repository(None, 1)
@@ -7734,12 +7830,12 @@ mod tests {
                 .filter(|result| matches!(result, Ok(InitialSyncSnapshotInstall::Installed)))
                 .count(),
             1,
-            "exactly one remote may claim an unbound replica"
+            "exactly one bootstrap may claim an unbound replica"
         );
         let loser = results
             .iter()
             .find_map(|result| result.as_ref().err())
-            .expect("the competing remote should lose atomically");
+            .expect("the competing bootstrap should lose atomically");
         assert_eq!(loser.code, LixError::CODE_TRANSACTION_CONFLICT);
 
         let serialized_loser = if matches!(
@@ -7770,10 +7866,10 @@ mod tests {
                 )
                 .await
         }
-        .expect("the coherent binding scan should classify a later alias");
+        .expect("the coherent binding scan should recognize the same repository");
         assert_eq!(
             serialized_loser,
-            InitialSyncSnapshotInstall::ExistingOther
+            InitialSyncSnapshotInstall::ExistingRepository
         );
 
         let adapter = first.storage_adapter();
@@ -9323,7 +9419,7 @@ mod tests {
                 .begin_read(StorageReadOptions::default())
                 .await
                 .expect("acknowledgement state read should open");
-            let acknowledged = load_replica_state(&read, TEST_REMOTE)
+            let acknowledged = load_replica_state(&read)
                 .await
                 .expect("acknowledgement state should load")
                 .0
@@ -10612,7 +10708,7 @@ mod tests {
             .begin_read(StorageReadOptions::default())
             .await
             .expect("replica state read should open");
-        let (_, expected_state_raw) = load_replica_state(&read, TEST_REMOTE)
+        let (_, expected_state_raw) = load_replica_state(&read)
             .await
             .expect("replica state should load");
         let expected_state_raw = expected_state_raw.expect("replica state should have bytes");
@@ -10639,7 +10735,6 @@ mod tests {
                 SyncImportPurpose::ReplicaDelta,
                 None,
                 Some(ReplicaStatePublication {
-                    remote_id: TEST_REMOTE,
                     expected_cursor: 7,
                     expected_state_raw: &expected_state_raw,
                     state: &folded,
@@ -10654,7 +10749,7 @@ mod tests {
             .await
             .expect("replica state read should reopen");
         assert_eq!(
-            load_replica_state(&read, TEST_REMOTE)
+            load_replica_state(&read)
                 .await
                 .expect("replica state should load")
                 .0,
@@ -11015,7 +11110,7 @@ mod tests {
             .await
             .expect("replica state read should open");
         assert_eq!(
-            load_sync_replica_account(&read, TEST_REMOTE)
+            load_sync_replica_account(&read)
                 .await
                 .expect("replica account should decode")
                 .as_deref(),

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -304,6 +304,9 @@ where
 {
     let remote_id = server.url.clone();
     let headers = server.headers.clone();
+    if let Some(transport) = initial_transport.as_ref() {
+        validate_connected_authority(lix, &remote_id, transport).await?;
+    }
     lix.set_sync_replica_remote_id(&remote_id)?;
     lix.set_sync_role(crate::sync::SyncRole::Replica)?;
 
@@ -369,12 +372,12 @@ where
             };
             match connected {
                 Ok(connected) => {
-                    if let Err(error) = lix
-                        .validate_sync_repository_account(&remote_id, connected.active_account_id())
-                        .await
+                    if let Err(error) =
+                        validate_connected_authority(&lix, &remote_id, &connected).await
                     {
-                        tracing::error!(error = ?error, "sync authority account changed");
-                        lix.fail_observers_for_sync(error);
+                        tracing::error!(error = ?error, "sync authority identity changed");
+                        lix.fail_observers_for_sync(error.clone());
+                        terminal_error = Some(error);
                         break;
                     }
                     transport = Some(connected);
@@ -499,6 +502,26 @@ where
     drop(demand_rx);
     let close_result = lix.close().await;
     result.and(close_result)
+}
+
+async fn validate_connected_authority<StorageImpl>(
+    lix: &Lix<StorageImpl>,
+    remote_id: &str,
+    transport: &HttpSyncTransport,
+) -> Result<(), LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    validate_authority_lix_id(lix.lix_id(), transport.lix_id())?;
+    lix.validate_sync_repository_account(remote_id, transport.active_account_id())
+        .await
+}
+
+fn validate_authority_lix_id(local: &str, authority: &str) -> Result<(), LixError> {
+    if local == authority {
+        return Ok(());
+    }
+    Err(super::sync_repository_id_mismatch(local, authority))
 }
 
 async fn drain_sync_outbox<StorageImpl>(
@@ -856,6 +879,7 @@ fn is_terminal_sync_error(error: &LixError) -> bool {
             | SYNC_SNAPSHOT_TOO_LARGE_CODE
             | SYNC_DEMAND_STALLED_CODE
             | super::SYNC_PROTOCOL_MISMATCH_CODE
+            | super::SYNC_REPOSITORY_ID_MISMATCH_CODE
             | super::SYNC_IMMUTABLE_OBJECT_MISMATCH_CODE
     )
 }
@@ -1568,6 +1592,21 @@ mod tests {
     use crate::engine::Engine;
     use crate::storage::Memory;
     use crate::{Value, open_lix};
+
+    #[test]
+    fn authority_lix_id_must_match_before_sync_iteration() {
+        validate_authority_lix_id("local", "local").expect("same lixId should pass");
+        let error = validate_authority_lix_id("local", "other")
+            .expect_err("different lixId must stop before sync iteration");
+        assert_eq!(error.code, super::super::SYNC_REPOSITORY_ID_MISMATCH_CODE);
+        assert_eq!(
+            error.details,
+            Some(serde_json::json!({
+                "localLixId": "local",
+                "authorityLixId": "other",
+            }))
+        );
+    }
 
     #[derive(Debug)]
     struct HistoryTransport {


### PR DESCRIPTION
## Summary

- store sync replica state under one repository-level key instead of the transport URL
- migrate the single legacy URL-keyed receipt atomically and byte-for-byte on open
- include the authority `lixId` in the handshake and reject a mismatch before any sync iteration or push
- keep the existing sync protocol and OPFS versions unchanged

## Why

The remote URL is transport configuration, not repository identity. Changing a deployment URL must not make an initialized local replica look like a different repository. The repository `lixId` is the identity check we control end to end.

## Migration behavior

- zero existing receipts: normal bootstrap
- one legacy URL-keyed receipt: move it to the singleton key without rewriting its value
- singleton receipt already present: normal open
- multiple conflicting receipts: fail closed with a typed ambiguity error

## Verification

- `cargo test -p lix --features all-simulations` (3427 passed, 26 ignored)
- focused legacy migration, URL-alias concurrency, handshake, runtime mismatch, and server protocol tests
- `cargo fmt --check`
- `git diff --check`