### PR TITLE
fix(lix): make built-in schemas engine authority

### DIFF
--- a/.changenotes/engine-authoritative-builtin-schemas.md
+++ b/.changenotes/engine-authoritative-builtin-schemas.md
@@ -1,0 +1,12 @@
+---
+type: minor
+---
+
+Made bundled `lix_*` schemas immutable engine authority instead of deriving
+their availability from branch-visible `lix_registered_schema` rows.
+
+Repository format v77 migrates v72-v76 repositories through the existing
+copy-and-activate epoch path. Retained built-in registration rows remain
+introspection and history projections, while custom registered schemas remain
+repository-owned. Sync protocol v2 rejects peers with the older catalog
+semantics.

--- a/packages/lix/server-protocol.openapi.yaml
+++ b/packages/lix/server-protocol.openapi.yaml
@@ -492,7 +492,7 @@ components:
       in: header
       required: true
       description: Exact sync wire-protocol version advertised by the handshake.
-      schema: { type: integer, const: 1 }
+      schema: { type: integer, const: 2 }
     TransactionId:
       name: Lix-Transaction-Id
       in: header
@@ -550,7 +550,7 @@ components:
       required: [protocolVersion, syncProtocolVersion, activeBranchId, activeAccountId, sessionId, capabilities]
       properties:
         protocolVersion: { type: integer, const: 6 }
-        syncProtocolVersion: { type: integer, const: 1 }
+        syncProtocolVersion: { type: integer, const: 2 }
         activeBranchId: { type: string }
         activeAccountId: { type: string }
         sessionId: { type: string }

--- a/packages/lix/src/catalog/context.rs
+++ b/packages/lix/src/catalog/context.rs
@@ -28,12 +28,12 @@ const COMPILED_CATALOG_CACHE_LIMIT: usize = 64;
 
 /// Engine schema visibility boundary.
 ///
-/// Dynamic SQL planning receives a schema snapshot from live state. System
-/// schemas are also seeded as ordinary `lix_registered_schema` rows for
-/// validation and introspection, while fixed-surface reads may use their
-/// compile-time definitions without loading those rows. The context also owns
-/// engine-wide caches of compiled snapshots, keyed by either fact content or
-/// the atomic storage revision captured when a transaction opens.
+/// Dynamic SQL planning receives an effective schema snapshot composed from
+/// immutable engine built-ins plus custom schemas in live state. Historical
+/// repositories can retain built-in `lix_registered_schema` rows for
+/// introspection, but those mirrors never participate in schema authority. The
+/// context also owns engine-wide caches keyed by effective fact content or the
+/// atomic storage revision captured when a transaction opens.
 pub(crate) struct CatalogContext {
     compiled_catalogs: Mutex<HashMap<CatalogFingerprint, Arc<CatalogSnapshot>>>,
     transaction_opening_catalogs:
@@ -216,9 +216,18 @@ impl CatalogContext {
         let facts = self
             .schema_facts_for_domain(hot_state, &Domain::schema_catalog(branch_id, true))
             .await?;
-        let mut schemas = BTreeMap::<String, JsonValue>::new();
+        let mut schemas = crate::schema::seed_schema_definitions()
+            .into_iter()
+            .map(|schema| {
+                let key = crate::schema::schema_key_from_definition(schema)?;
+                Ok((key.schema_key, schema.clone()))
+            })
+            .collect::<Result<BTreeMap<String, JsonValue>, LixError>>()?;
         for fact in facts {
             let schema_key = fact.catalog_key().schema_key.clone();
+            if crate::schema::seed_schema_definition(&schema_key).is_some() {
+                continue;
+            }
             if schemas
                 .insert(schema_key.clone(), fact.schema().clone())
                 .is_some()
@@ -751,7 +760,12 @@ mod tests {
             .await
             .expect("schema visibility should load");
 
-        assert!(schemas.is_empty());
+        assert!(schemas.iter().all(|schema| {
+            schema.get("key").and_then(JsonValue::as_str) != Some("global_only_schema")
+        }));
+        assert!(schemas.iter().any(|schema| {
+            schema.get("key").and_then(JsonValue::as_str) == Some("lix_file_descriptor")
+        }));
     }
 
     #[tokio::test]
@@ -779,7 +793,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn visible_schemas_are_empty_when_no_schema_rows_are_visible() {
+    async fn visible_schemas_still_include_engine_builtins_when_no_rows_are_visible() {
         let context = CatalogContext::new();
 
         let schemas = context
@@ -790,7 +804,10 @@ mod tests {
             .await
             .expect("schema visibility should load");
 
-        assert!(schemas.is_empty());
+        assert_eq!(schemas.len(), crate::schema::seed_schema_definitions().len());
+        assert!(schemas.iter().any(|schema| {
+            schema.get("key").and_then(JsonValue::as_str) == Some("lix_file_descriptor")
+        }));
     }
 
     struct RowsHotStateReader {

--- a/packages/lix/src/catalog/snapshot.rs
+++ b/packages/lix/src/catalog/snapshot.rs
@@ -63,10 +63,10 @@ impl CatalogSnapshot {
 
     /// Compiled catalog for schemas shipped with the engine.
     ///
-    /// Repository bootstrap must encode its first rows before a persisted
-    /// catalog exists. Keeping this immutable catalog in the binary gives
-    /// those rows the same schema fingerprint and native value layout used
-    /// after catalog hydration.
+    /// These schemas are engine authority, not repository authority. Every
+    /// transaction catalog starts with this immutable base; persisted
+    /// `lix_registered_schema` rows for the same keys are only discoverability
+    /// projections retained in repository history.
     pub(crate) fn builtin() -> &'static Self {
         static BUILTIN: OnceLock<CatalogSnapshot> = OnceLock::new();
         BUILTIN.get_or_init(|| {
@@ -80,14 +80,22 @@ impl CatalogSnapshot {
     }
 
     pub(crate) fn from_schema_facts(facts: &[SchemaCatalogFact]) -> Result<Self, LixError> {
-        let entries = facts
-            .iter()
-            .map(|fact| CatalogEntry {
-                identity: fact.identity.clone(),
-                key: fact.catalog_key.clone(),
-                schema: fact.schema.clone(),
-            })
-            .collect::<Vec<_>>();
+        let mut entries = Self::builtin().entries.clone();
+        entries.extend(facts.iter().filter_map(|fact| {
+            // Repository history can retain the old bootstrap projections, but
+            // it can no longer make an engine schema appear, disappear, or
+            // change definition. Runtime registration already reserves every
+            // `lix_*` key; filtering all known built-ins here also lets the
+            // migration chain read historical definitions while an older
+            // schema amendment is still being upgraded.
+            crate::schema::seed_schema_definition(&fact.catalog_key.schema_key).is_none().then(
+                || CatalogEntry {
+                    identity: fact.identity.clone(),
+                    key: fact.catalog_key.clone(),
+                    schema: fact.schema.clone(),
+                },
+            )
+        }));
         Self::from_entries(entries)
     }
 
@@ -348,14 +356,23 @@ pub(crate) fn fingerprint_schema_facts(
     facts: &[SchemaCatalogFact],
 ) -> Result<CatalogFingerprint, LixError> {
     let mut hasher = blake3::Hasher::new();
-    let mut facts = facts.iter().collect::<Vec<_>>();
-    facts.sort_by(|left, right| left.identity.cmp(&right.identity));
-    for fact in facts {
+    let mut effective_facts = CatalogSnapshot::builtin()
+        .entries
+        .iter()
+        .map(|entry| (&entry.identity, &entry.key.schema_key, &entry.schema))
+        .chain(facts.iter().filter_map(|fact| {
+            crate::schema::seed_schema_definition(&fact.catalog_key.schema_key)
+                .is_none()
+                .then_some((&fact.identity, &fact.catalog_key.schema_key, &fact.schema))
+        }))
+        .collect::<Vec<_>>();
+    effective_facts.sort_by(|left, right| left.0.cmp(right.0));
+    for (identity, schema_key, schema) in effective_facts {
         hash_catalog_fact(
             &mut hasher,
-            &fact.identity,
-            &fact.catalog_key.schema_key,
-            &fact.schema,
+            identity,
+            schema_key,
+            schema,
         )?;
     }
     Ok(CatalogFingerprint(hasher.finalize().to_hex().to_string()))
@@ -2405,6 +2422,49 @@ mod tests {
     }
 
     #[test]
+    fn transaction_catalog_always_contains_engine_builtin_schemas() {
+        let catalog = CatalogSnapshot::from_schema_facts(&[])
+            .expect("an empty repository catalog should still bind engine schemas");
+
+        for schema in crate::schema::seed_schema_definitions() {
+            let key = crate::schema::schema_key_from_definition(schema)
+                .expect("embedded schema should have a key");
+            assert!(catalog.contains(&key.schema_key), "{}", key.schema_key);
+        }
+    }
+
+    #[test]
+    fn persisted_builtin_projection_cannot_override_engine_authority() {
+        let mut stored = crate::schema::seed_schema_definition("lix_file_descriptor")
+            .expect("file descriptor schema should be embedded")
+            .clone();
+        stored["description"] = json!("repository-controlled definition");
+        let custom = SchemaCatalogFact::new(
+            Domain::schema_catalog("main", false),
+            SchemaKey::new("acme_note"),
+            schema_json("acme_note"),
+        );
+        let catalog_without_projection = CatalogSnapshot::from_schema_facts(&[custom.clone()])
+            .expect("custom catalog should bind");
+        let catalog = CatalogSnapshot::from_schema_facts(&[
+            SchemaCatalogFact::new(
+                Domain::schema_catalog("main", false),
+                SchemaKey::new("lix_file_descriptor"),
+                stored,
+            ),
+            custom,
+        ])
+        .expect("persisted built-in projections should be ignored as catalog authority");
+
+        assert_eq!(
+            catalog.schema("lix_file_descriptor"),
+            crate::schema::seed_schema_definition("lix_file_descriptor")
+        );
+        assert!(catalog.contains("acme_note"));
+        assert_eq!(catalog.fingerprint(), catalog_without_projection.fingerprint());
+    }
+
+    #[test]
     fn insert_schema_for_domain_is_atomic_when_binding_fails() {
         let mut catalog = CatalogSnapshot::from_schema_facts(&[SchemaCatalogFact::new(
             Domain::schema_catalog("main", false),
@@ -2533,7 +2593,17 @@ mod tests {
         ])
         .expect("catalog should bind");
 
-        assert_eq!(catalog.schema_jsons(), vec![alpha, zeta]);
+        let mut expected = crate::schema::seed_schema_definitions()
+            .into_iter()
+            .cloned()
+            .chain([alpha, zeta])
+            .collect::<Vec<_>>();
+        expected.sort_by_key(|schema| {
+            crate::schema::schema_key_from_definition(schema)
+                .expect("test schema should have a key")
+                .schema_key
+        });
+        assert_eq!(catalog.schema_jsons(), expected);
     }
 
     #[test]

--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -107,9 +107,15 @@ pub(crate) const REPOSITORY_PROTOCOL_KEY: &[u8] = b"current";
 /// `v76` moves repository data behind Lix-owned copy-and-activate storage
 /// epochs. Logical data is unchanged; the new envelope makes migration,
 /// validation, rollback, and stale-writer fencing engine policy.
-pub(crate) const CURRENT_FORMAT_VERSION: u32 = 76;
+///
+/// `v77` makes bundled `lix_*` schemas immutable engine authority. Persisted
+/// bootstrap registration rows remain history/introspection projections, but
+/// branch, checkpoint, and sync visibility can no longer remove or redefine a
+/// schema required to interpret engine rows.
+pub(crate) const CURRENT_FORMAT_VERSION: u32 = 77;
 const REPOSITORY_PROTOCOL_PREFIX: &[u8] = b"tracked-default-branch.v";
-pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v76";
+pub(crate) const REPOSITORY_PROTOCOL_VALUE: &[u8] = b"tracked-default-branch.v77";
+pub(crate) const REPOSITORY_PROTOCOL_V76: &[u8] = b"tracked-default-branch.v76";
 pub(crate) const REPOSITORY_PROTOCOL_V75: &[u8] = b"tracked-default-branch.v75";
 pub(crate) const REPOSITORY_PROTOCOL_V72_ROW_PK_BOOTSTRAP: &[u8] =
     b"tracked-default-branch.v72-row-pk-bootstrap";
@@ -1380,7 +1386,7 @@ mod tests {
     fn repository_protocol_parser_distinguishes_versions() {
         assert_eq!(
             parse_repository_protocol(b"tracked-default-branch.v76"),
-            RepositoryProtocolStatus::Current
+            RepositoryProtocolStatus::MigrationRequired { found_version: 76 }
         );
         assert_eq!(
             parse_repository_protocol(b"tracked-default-branch.v75"),
@@ -1412,7 +1418,11 @@ mod tests {
         );
         assert_eq!(
             parse_repository_protocol(b"tracked-default-branch.v77"),
-            RepositoryProtocolStatus::TooNew { found_version: 77 }
+            RepositoryProtocolStatus::Current
+        );
+        assert_eq!(
+            parse_repository_protocol(b"tracked-default-branch.v78"),
+            RepositoryProtocolStatus::TooNew { found_version: 78 }
         );
         assert_eq!(
             parse_repository_protocol(b"not-a-lix-format"),

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -160,10 +160,12 @@ pub(crate) async fn migrate_lix_with_adapter<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    let read = adapter
-        .begin_read(ReadOptions::default())
-        .await
-        .map_err(storage_error)?;
+    let read = SharedStorageAdapterRead::new(
+        adapter
+            .begin_read(ReadOptions::default())
+            .await
+            .map_err(storage_error)?,
+    );
     let protocol_status = crate::init::repository_protocol_status(&read).await?;
     // The v75 chain traverses commit records with the v5-arity decoder before
     // rewriting them to v6. Repositories below v72 still carry older record
@@ -181,7 +183,7 @@ where
     }
     let from_version = match protocol_status {
         RepositoryProtocolStatus::MigrationRequired {
-            found_version: found_version @ (72 | 73 | 74 | 75),
+            found_version: found_version @ (72 | 73 | 74 | 75 | 76),
         } => found_version,
         RepositoryProtocolStatus::Current => {
             return Ok(MigrationReport {
@@ -207,7 +209,7 @@ where
             ));
         }
     };
-    drop(read);
+    read.finish().map_err(storage_error)?;
     // Every step from here on loads commit records through the current
     // v6 decoder, so the v5 records are rewritten first, under whichever
     // marker the repository currently carries.
@@ -225,25 +227,47 @@ where
     let commit_members_rewritten = if from_version <= 74 {
         migrate_v74_complete_snapshot_commits(&adapter, &storage, options).await?
     } else {
+        0
+    };
+    if from_version == 75 {
         let read = adapter
             .begin_read(ReadOptions::default())
             .await
             .map_err(storage_error)?;
-        let expected_revision =
-            crate::storage_adapter::load_repository_mutation_revision(&read)
-                .await
-                .map_err(storage_error)?;
+        let expected_revision = crate::storage_adapter::load_repository_mutation_revision(&read)
+            .await
+            .map_err(storage_error)?;
         drop(read);
         crate::migration::publish::publish(
             &adapter,
             expected_revision,
             crate::init::REPOSITORY_PROTOCOL_V75,
-            crate::init::REPOSITORY_PROTOCOL_VALUE,
+            crate::init::REPOSITORY_PROTOCOL_V76,
             crate::migration::publish::PublicationPlan::bounded(0, 0),
         )
         .await?;
-        0
-    };
+    }
+    // v77 deliberately does not rewrite or validate historical built-in
+    // registration rows. Those rows describe the engine version that authored
+    // each commit; the current engine's immutable catalog is authoritative.
+    // Custom schemas are still loaded from the repository and validated when
+    // the migrated engine opens it.
+    let read = adapter
+        .begin_read(ReadOptions::default())
+        .await
+        .map_err(storage_error)?;
+    let expected_revision = crate::storage_adapter::load_repository_mutation_revision(&read)
+        .await
+        .map_err(storage_error)?;
+    drop(read);
+    crate::migration::publish::publish(
+        &adapter,
+        expected_revision,
+        crate::init::REPOSITORY_PROTOCOL_V76,
+        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        crate::migration::publish::PublicationPlan::bounded(0, 0),
+    )
+    .await?;
     Ok(MigrationReport {
         from_version,
         to_version: CURRENT_FORMAT_VERSION,
@@ -546,7 +570,7 @@ where
         adapter,
         expected_revision,
         source_protocol,
-        crate::init::REPOSITORY_PROTOCOL_VALUE,
+        crate::init::REPOSITORY_PROTOCOL_V76,
         publication,
     )
     .await?;
@@ -1668,6 +1692,56 @@ mod tests {
                 to_version: CURRENT_FORMAT_VERSION,
             }
         );
+    }
+
+    #[tokio::test]
+    async fn v76_repository_advances_through_the_builtin_catalog_hard_cut() {
+        let storage = Memory::new();
+        let adapter = crate::storage_adapter::StorageAdapter::new(storage.clone());
+        crate::engine::Engine::initialize_with_adapter(adapter.clone(), None)
+            .await
+            .expect("repository should initialize");
+        let mut marker = adapter.new_write_set();
+        marker.put(
+            REPOSITORY_PROTOCOL_SPACE,
+            REPOSITORY_PROTOCOL_KEY,
+            crate::init::REPOSITORY_PROTOCOL_V76,
+        );
+        adapter
+            .commit_write_set(marker, WriteOptions::default())
+            .await
+            .expect("v76 marker should stage");
+
+        let report = migrate_lix_with_adapter(
+            storage.clone(),
+            adapter.clone(),
+            MigrationOptions::default(),
+        )
+        .await
+        .expect("v76 repository should migrate to engine-authoritative built-ins");
+
+        assert_eq!(report.from_version, 76);
+        assert_eq!(report.to_version, CURRENT_FORMAT_VERSION);
+        assert_eq!(
+            inspect_lix_with_adapter(&adapter).await.unwrap(),
+            MigrationStatus::Current {
+                version: CURRENT_FORMAT_VERSION,
+            }
+        );
+        let engine = crate::engine::Engine::new_with_adapter(
+            adapter,
+            crate::engine::EngineOptions::new(),
+        )
+        .await
+        .expect("migrated repository should open");
+        let session = engine.open_session().await.expect("session should open");
+        session
+            .execute(
+                "INSERT INTO lix_file (path, content) VALUES ('/after-v77.txt', CAST('ok' AS BYTEA))",
+                &[],
+            )
+            .await
+            .expect("migrated repository should accept file descriptor writes");
     }
 
     #[tokio::test]

--- a/packages/lix/src/migration/epoch.rs
+++ b/packages/lix/src/migration/epoch.rs
@@ -3005,7 +3005,7 @@ mod tests {
             admitted.report.migration,
             Some(OpenMigrationReport {
                 from_format: 75,
-                to_format: 76,
+                to_format: crate::init::CURRENT_FORMAT_VERSION,
             })
         );
     }

--- a/packages/lix/src/migration/registry.rs
+++ b/packages/lix/src/migration/registry.rs
@@ -25,6 +25,10 @@ const MIGRATIONS: &[Migration] = &[
         from_version: 75,
         to_version: 76,
     },
+    Migration {
+        from_version: 76,
+        to_version: 77,
+    },
 ];
 
 pub(crate) fn registered_migrations() -> &'static [Migration] {
@@ -88,7 +92,14 @@ mod tests {
                 to_version: 76,
             })
         );
-        assert_eq!(registered_migrations().len(), 4);
+        assert_eq!(
+            migration_from(76),
+            Some(&Migration {
+                from_version: 76,
+                to_version: 77,
+            })
+        );
+        assert_eq!(registered_migrations().len(), 5);
         assert!(has_complete_migration_path(
             72,
             crate::init::CURRENT_FORMAT_VERSION

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -2387,14 +2387,7 @@ fn required_session_id(headers: &HeaderMap) -> Result<String, ApiError> {
 fn require_sync_protocol_version(headers: &HeaderMap) -> Result<(), ApiError> {
     let mut values = headers.get_all(SYNC_PROTOCOL_VERSION_HEADER).iter();
     let Some(first) = values.next() else {
-        // Protocol v1 predates the request header. Treat omission as v1 so a
-        // v1 server can be deployed before browser/client updates. A future
-        // server version will reject this implicit v1 before transfer.
-        return if crate::sync::SYNC_PROTOCOL_VERSION == 1 {
-            Ok(())
-        } else {
-            Err(crate::sync::sync_client_protocol_mismatch(Some(1)).into())
-        };
+        return Err(crate::sync::sync_client_protocol_mismatch(None).into());
     };
     let version = first
         .to_str()
@@ -8026,11 +8019,15 @@ mod tests {
                 Request::builder()
                     .uri("/lix/v1/sync/pull")
                     .body(Body::empty())
-                    .expect("legacy v1 sync request"),
+                    .expect("headerless sync request"),
             )
             .await
-            .expect("legacy v1 sync response");
-        assert_ne!(missing.status(), StatusCode::CONFLICT);
+            .expect("headerless sync response");
+        assert_eq!(missing.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            error_code(missing).await,
+            crate::sync::SYNC_PROTOCOL_MISMATCH_CODE
+        );
     }
 
     #[test]

--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -72,7 +72,10 @@ pub(crate) const MAX_SYNC_HISTORY_PAGE_SIZE: usize = 100;
 pub(crate) const MAX_SYNC_BLOB_BATCH_ITEMS: usize = 16;
 pub(crate) const MAX_SYNC_REQUEST_ITEMS: usize = 512;
 pub(crate) const SYNC_LONG_POLL_TIMEOUT: Duration = Duration::from_secs(30);
-pub(crate) const SYNC_PROTOCOL_VERSION: u32 = 1;
+// v2 fences the v77 engine-authoritative built-in schema semantics. Repository
+// format markers are local storage metadata and do not cross the sync wire, so
+// the sync handshake must reject v76 peers explicitly.
+pub(crate) const SYNC_PROTOCOL_VERSION: u32 = 2;
 pub(crate) const SYNC_PROTOCOL_VERSION_HEADER: &str = "lix-sync-protocol-version";
 pub(crate) const SYNC_PROTOCOL_MISMATCH_CODE: &str = "LIX_SYNC_PROTOCOL_MISMATCH";
 pub(crate) const SYNC_REPOSITORY_ID_MISMATCH_CODE: &str =

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -494,6 +494,78 @@ async fn deterministic_replica_scenarios(sim: Simulation) {
         .expect("reconciled offline chains should survive restart");
 }
 
+async fn checkpoint_reconciliation_keeps_builtin_file_schemas(_sim: Simulation) {
+    let authority = fresh_authority().await;
+    let mut left = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+    let mut right = Replica::bootstrap(AuthorityTransport::connected(authority.clone())).await;
+
+    left.lix
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/shared.md', CAST('base' AS BYTEA))",
+            &[],
+        )
+        .await
+        .expect("left file creation should use the engine catalog");
+    left.pump().await.expect("left file should publish");
+    right.pump().await.expect("right should receive the file");
+
+    left.lix
+        .create_checkpoint()
+        .await
+        .expect("left checkpoint should commit");
+    left.pump().await.expect("checkpoint should publish");
+    right.pump().await.expect("right should receive the checkpoint");
+
+    right.lix
+        .execute(
+            "UPDATE lix_file SET content = CAST('after-checkpoint' AS BYTEA) WHERE path = '/shared.md'",
+            &[],
+        )
+        .await
+        .expect("post-checkpoint file edit should commit");
+    right.pump().await.expect("post-checkpoint edit should publish");
+    left.pump().await.expect("left should receive the remote edit");
+
+    left.lix
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/left.md', CAST('left' AS BYTEA))",
+            &[],
+        )
+        .await
+        .expect("left divergent file should commit");
+    right.lix
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/right.csv', CAST('right' AS BYTEA))",
+            &[],
+        )
+        .await
+        .expect("right divergent file should commit");
+
+    let (left_push, right_push) = tokio::join!(left.pump(), right.pump());
+    left_push.expect("left concurrent push should reconcile");
+    right_push.expect("right concurrent push should reconcile");
+    converge(&authority, &mut [&mut left, &mut right])
+        .await
+        .expect("checkpointed divergent file commits should converge");
+    left.restart().await;
+    right.restart().await;
+    converge(&authority, &mut [&mut left, &mut right])
+        .await
+        .expect("converged file schemas should survive restart");
+
+    for repository in [&authority, &left.lix, &right.lix] {
+        let files = repository
+            .execute("SELECT path FROM lix_file ORDER BY path", &[])
+            .await
+            .expect("all file descriptors should remain readable")
+            .rows()
+            .iter()
+            .map(|row| row.get::<String>("path").expect("file path"))
+            .collect::<Vec<_>>();
+        assert_eq!(files, vec!["/left.md", "/right.csv", "/shared.md"]);
+    }
+}
+
 async fn lazy_history_and_binary_cas_scenarios(sim: Simulation) {
     let authority = authority_for_simulation(&sim).await;
     write_key_value(&authority, "history-0", "0").await;
@@ -1783,7 +1855,7 @@ async fn pre_v75_partial_checkpoint_repository_is_rejected(_sim: Simulation) {
 	.await
 	.expect_err("the complete-snapshot hard cut must reject a pre-v72 repository");
 	assert_eq!(error.code, "LIX_ERROR_MIGRATION_FAILED");
-	assert!(error.message.contains("predates the v76 complete-snapshot"));
+	assert!(error.message.contains("predates the v77 complete-snapshot"));
 	let _ = crate::tracked_state::take_diff_commits_test_probe(
 		&checkpoint_commit_id,
 		&head_commit_id,
@@ -1833,6 +1905,10 @@ async fn deterministic_sync_command_traces(_sim: Simulation) {
 sync_simulation_test!(
     deterministic_replica_scenarios,
     deterministic_replica_scenarios
+);
+sync_simulation_test!(
+    checkpoint_reconciliation_keeps_builtin_file_schemas,
+    checkpoint_reconciliation_keeps_builtin_file_schemas
 );
 sync_simulation_test!(
     lazy_history_and_binary_cas_scenarios,

--- a/packages/lix/src/transaction/normalization.rs
+++ b/packages/lix/src/transaction/normalization.rs
@@ -672,6 +672,12 @@ pub(crate) fn remember_pending_registered_schema(
     let (key, schema) = schema_from_registered_snapshot(snapshot)?;
     reject_reserved_schema_namespace_unless_exact_builtin(&key, &schema)?;
     validate_lix_schema_definition(&schema)?;
+    // Exact built-in registration rows are durable introspection projections,
+    // not schema authority. The immutable engine catalog already contains the
+    // plan and must not acquire a second branch-scoped identity for it.
+    if crate::schema::seed_schema_definition(&key.schema_key).is_some() {
+        return Ok(());
+    }
     schema_catalog.insert_schema_for_domain(domain, key, schema)?;
     Ok(())
 }
@@ -692,10 +698,10 @@ pub(crate) fn reject_reserved_schema_namespace(key: &SchemaKey) -> Result<(), Li
     ))
 }
 
-/// The offline repository migration persists an engine-owned schema through
-/// the ordinary schema-amendment transaction path. Permit only the exact
-/// bundled definition; arbitrary runtime schemas remain excluded from the
-/// reserved namespace.
+/// Historical migration and initialization paths persist engine-owned schemas
+/// as introspection projections. Permit only the exact bundled definition;
+/// arbitrary runtime schemas remain excluded from the reserved namespace and
+/// the projection is ignored when composing the effective catalog.
 pub(crate) fn reject_reserved_schema_namespace_unless_exact_builtin(
     key: &SchemaKey,
     schema: &JsonValue,

--- a/packages/lix/tests/migration_v68.rs
+++ b/packages/lix/tests/migration_v68.rs
@@ -27,7 +27,7 @@ async fn snapshot_open_rejects_v68_at_the_intentional_hard_cut() {
             "unexpected rejection: {error:?}"
         );
         assert!(
-            error.message.contains("v76"),
+            error.message.contains("v77"),
             "unexpected rejection: {error:?}"
         );
         let Err(retry) = open_lix()
@@ -48,5 +48,5 @@ async fn automatic_open_rejects_v68_before_reading_commit_authority() {
     };
     assert_eq!(error.code, "LIX_ERROR_MIGRATION_FAILED");
     assert!(error.message.contains("v68"));
-    assert!(error.message.contains("v76"));
+    assert!(error.message.contains("v77"));
 }

--- a/packages/lix/tests/migration_v72.rs
+++ b/packages/lix/tests/migration_v72.rs
@@ -39,7 +39,7 @@ async fn fresh_open_reports_initialization_without_migration() {
         .await
         .expect("fresh repository should initialize and open");
 
-    assert_eq!(lix.open_report().format, 76);
+    assert_eq!(lix.open_report().format, 77);
     assert!(lix.open_report().initialized);
     assert_eq!(lix.open_report().migration, None);
     assert_eq!(
@@ -71,14 +71,14 @@ async fn migrates_profile_uri_and_persists_updates_across_cold_reopen() {
         .from_snapshot(Cursor::new(V72_ACCOUNT_SNAPSHOT))
         .await
         .expect("opening a v72 repository should migrate it automatically");
-    assert_eq!(lix.open_report().format, 76);
+    assert_eq!(lix.open_report().format, 77);
     assert!(!lix.open_report().initialized);
     let migration = lix
         .open_report()
         .migration
         .expect("the open report should record the automatic migration");
     assert_eq!(migration.from_format, 72);
-    assert_eq!(migration.to_format, 76);
+    assert_eq!(migration.to_format, 77);
 
     let events = progress.events();
     assert_eq!(
@@ -93,7 +93,7 @@ async fn migrates_profile_uri_and_persists_updates_across_cold_reopen() {
         "automatic migration progress should be deterministic and ordered",
     );
     assert_eq!(events[1].from_format, Some(72));
-    assert_eq!(events[1].to_format, 76);
+    assert_eq!(events[1].to_format, 77);
     assert_eq!(events[1].completed, Some(0));
     assert_eq!(events[1].total, None);
     assert!(
@@ -138,7 +138,7 @@ async fn migrates_profile_uri_and_persists_updates_across_cold_reopen() {
         .from_snapshot(Cursor::new(migrated))
         .await
         .expect("migrated repository should cold-open");
-    assert_eq!(lix.open_report().format, 76);
+    assert_eq!(lix.open_report().format, 77);
     assert_eq!(lix.open_report().migration, None);
     assert!(!lix.open_report().initialized);
     let result = lix

--- a/packages/lix/tests/migration_v72_filesystem.rs
+++ b/packages/lix/tests/migration_v72_filesystem.rs
@@ -59,7 +59,7 @@ async fn checkpointed_directories_survive_the_v74_migration() {
         .migration
         .expect("the open report should record the automatic migration");
     assert_eq!(migration.from_format, 72);
-    assert_eq!(migration.to_format, 76);
+    assert_eq!(migration.to_format, 77);
 
     let checkpoints = lix
         .execute(

--- a/packages/lix/tests/migration_v75.rs
+++ b/packages/lix/tests/migration_v75.rs
@@ -118,14 +118,14 @@ async fn released_v75_repository_auto_upgrades_with_semantics_intact() {
         .await
         .expect("released v75 repository should auto-upgrade");
 
-    assert_eq!(lix.open_report().format, 76);
+    assert_eq!(lix.open_report().format, 77);
     assert!(!lix.open_report().initialized);
     let migration = lix
         .open_report()
         .migration
         .expect("v75 open should report its automatic upgrade");
     assert_eq!(migration.from_format, 75);
-    assert_eq!(migration.to_format, 76);
+    assert_eq!(migration.to_format, 77);
 
     let main_branch_id = lix
         .active_branch_id()
@@ -175,7 +175,7 @@ async fn released_v75_repository_auto_upgrades_with_semantics_intact() {
         .from_snapshot(Cursor::new(migrated))
         .await
         .expect("migrated repository should cold-open");
-    assert_eq!(reopened.open_report().format, 76);
+    assert_eq!(reopened.open_report().format, 77);
     assert!(!reopened.open_report().initialized);
     assert_eq!(reopened.open_report().migration, None);
 


### PR DESCRIPTION
## Summary

- make the effective catalog immutable engine built-ins plus repository custom schemas
- treat persisted built-in schema rows as inert historical projections
- add the explicit repository format v76 to v77 migration edge
- bump sync protocol to v2 so pre-cut peers cannot mix catalog semantics
- cover checkpoint, CAS reconciliation, concurrent writes, migration retry, and warm reopen

## Why

A transaction could derive its catalog solely from branch-visible `lix_registered_schema` rows. Checkpoint/sync/ref reconciliation could therefore make an engine schema such as `lix_file_descriptor` disappear from that transaction. The engine now owns built-in schema identity unconditionally.

## Verification

- `cargo nextest run -p lix` (3012 passed)
- `cargo nextest run -p lix --features all-simulations --no-fail-fast` (3448 passed, 28 skipped)
- `cargo test -p lix --doc` (10 passed)
- `cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings`
- frozen v72/v75 migration and restart fixtures

Lixray integration: opral/lixray#306.