### PR TITLE
ci: reduce runner spend and duplicate release runs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
+    - blacksmith-16vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404-arm
     - blacksmith-12vcpu-macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   changelog:
     name: Changelog
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -50,11 +50,11 @@ jobs:
       matrix:
         include:
           - name: Linux x64
-            runner: blacksmith-32vcpu-ubuntu-2404
+            runner: ubuntu-24.04
           - name: macOS arm64
-            runner: blacksmith-12vcpu-macos-15
+            runner: macos-15
           - name: Windows x64
-            runner: blacksmith-16vcpu-windows-2025
+            runner: windows-2025
 
     steps:
       - name: Checkout repository
@@ -68,7 +68,7 @@ jobs:
   cargo:
     name: Cargo ${{ matrix.name }}
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,18 +76,22 @@ jobs:
           - name: Clippy
             task: clippy
             workspace: .
+            runner: blacksmith-32vcpu-ubuntu-2404
           - name: Test
             task: test
             workspace: .
             junit: target/nextest/ci/junit.xml
+            runner: blacksmith-32vcpu-ubuntu-2404
           - name: Tooling Test
             task: tooling
             workspace: tooling
             junit: tooling/target/nextest/ci/junit.xml
+            runner: blacksmith-16vcpu-ubuntu-2404
           - name: E2E Test
             task: e2e
             workspace: tooling
             junit: tooling/target/nextest/ci-e2e/junit.xml
+            runner: blacksmith-16vcpu-ubuntu-2404
 
     steps:
       - name: Checkout repository
@@ -290,15 +294,17 @@ jobs:
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: Native
             runtime: native
+            runner: blacksmith-16vcpu-ubuntu-2404
           - name: Browser
             runtime: browser
+            runner: blacksmith-32vcpu-ubuntu-2404
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -59,8 +59,70 @@ jobs:
         if: steps.prepare.outputs.has_release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_SHA: ${{ steps.release_pr.outputs.pull-request-head-sha }}
           TARGET_BRANCH: release/v${{ steps.prepare.outputs.version }}
-        run: gh workflow run ci.yml --ref "$TARGET_BRANCH"
+        run: |
+          set -euo pipefail
+
+          # Creating or updating the release PR can already trigger ordinary
+          # pull_request CI. Reuse that run when GitHub accepted it instead of
+          # paying for a second full workflow_dispatch run for the same SHA.
+          # GITHUB_TOKEN-authored PR events can be approval-blocked, so retain
+          # workflow_dispatch as a fail-open fallback.
+          if [ -n "$RELEASE_SHA" ]; then
+            for attempt in 1 2 3 4 5 6; do
+              if ! runs="$(gh run list \
+                --workflow ci.yml \
+                --event pull_request \
+                --commit "$RELEASE_SHA" \
+                --limit 100 \
+                --json status,conclusion,url)"; then
+                echo "Could not inspect pull request CI; dispatching the fallback run."
+                break
+              fi
+
+              if jq -e 'def blocked:
+                  . == "action_required" or . == "cancelled" or
+                  . == "skipped" or . == "stale";
+                any(.[];
+                .status == "queued" or
+                .status == "in_progress" or
+                (.status == "completed" and
+                  (.conclusion | blocked | not)))' \
+                <<< "$runs" >/dev/null; then
+                echo "Reusing pull request CI for $RELEASE_SHA."
+                jq -r 'def blocked:
+                    . == "action_required" or . == "cancelled" or
+                    . == "skipped" or . == "stale";
+                  .[] | select(
+                  .status == "queued" or
+                  .status == "in_progress" or
+                  (.status == "completed" and
+                    (.conclusion | blocked | not))) |
+                  .url' <<< "$runs"
+                exit 0
+              fi
+
+              if jq -e 'def blocked:
+                  . == "action_required" or . == "cancelled" or
+                  . == "skipped" or . == "stale";
+                any(.[];
+                .status == "completed" and
+                (.conclusion | blocked))' \
+                <<< "$runs" >/dev/null; then
+                echo "Pull request CI cannot provide a reusable check; dispatching the fallback run."
+                break
+              fi
+
+              if [ "$attempt" -lt 6 ]; then
+                sleep 5
+              fi
+            done
+          else
+            echo "The release PR action did not return a head SHA; dispatching the fallback run."
+          fi
+
+          gh workflow run ci.yml --ref "$TARGET_BRANCH"
 
       - name: Close superseded release PRs
         if: steps.prepare.outputs.has_release == 'true'

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -9,6 +9,10 @@ const workflow = readFileSync(
 	resolve(repositoryRoot, ".github/workflows/ci.yml"),
 	"utf8",
 );
+const releasePrWorkflow = readFileSync(
+	resolve(repositoryRoot, ".github/workflows/release-pr.yml"),
+	"utf8",
+);
 
 test("superseded CI runs are cancelled per pull request or branch", () => {
 	assert.match(
@@ -19,21 +23,62 @@ test("superseded CI runs are cancelled per pull request or branch", () => {
 });
 
 test("Rust test scopes run independently with workspace-specific caches", () => {
-	for (const [name, task, workspace] of [
-		["Test", "test", "."],
-		["Tooling Test", "tooling", "tooling"],
-		["E2E Test", "e2e", "tooling"],
+	for (const [name, task, workspace, runner] of [
+		["Clippy", "clippy", ".", "blacksmith-32vcpu-ubuntu-2404"],
+		["Test", "test", ".", "blacksmith-32vcpu-ubuntu-2404"],
+		["Tooling Test", "tooling", "tooling", "blacksmith-16vcpu-ubuntu-2404"],
+		["E2E Test", "e2e", "tooling", "blacksmith-16vcpu-ubuntu-2404"],
 	]) {
 		assert.match(
 			workflow,
 			new RegExp(
-				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}`,
+				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}[\\s\\S]*?runner: ${runner}`,
 			),
 		);
 	}
 	assert.match(workflow, /workspaces: \$\{\{ matrix\.workspace \}\}/);
 	assert.match(workflow, /name: rust-nextest-junit-\$\{\{ matrix\.task \}\}/);
 	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
+	assert.match(workflow, /name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/);
+});
+
+test("short support jobs use free standard runners for the public repository", () => {
+	assert.match(workflow, /name: Changelog[\s\S]*?runs-on: ubuntu-24\.04/);
+	for (const [name, runner] of [
+		["Linux x64", "ubuntu-24.04"],
+		["macOS arm64", "macos-15"],
+		["Windows x64", "windows-2025"],
+	]) {
+		assert.match(
+			workflow,
+			new RegExp(`- name: ${name}\\n\\s+runner: ${runner.replaceAll(".", "\\.")}`),
+		);
+	}
+});
+
+test("JS SDK native CI is right-sized without changing browser architecture coverage", () => {
+	assert.match(
+		workflow,
+		/- name: Native\n\s+runtime: native\n\s+runner: blacksmith-16vcpu-ubuntu-2404/,
+	);
+	assert.match(
+		workflow,
+		/- name: Browser\n\s+runtime: browser\n\s+runner: blacksmith-32vcpu-ubuntu-2404/,
+	);
+	assert.match(workflow, /name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/);
+});
+
+test("release PR automation reuses same-SHA pull request CI with a dispatch fallback", () => {
+	assert.match(
+		releasePrWorkflow,
+		/RELEASE_SHA: \$\{\{ steps\.release_pr\.outputs\.pull-request-head-sha \}\}/,
+	);
+	assert.match(releasePrWorkflow, /--event pull_request/);
+	assert.match(releasePrWorkflow, /--commit "\$RELEASE_SHA"/);
+	for (const conclusion of ["action_required", "cancelled", "skipped", "stale"]) {
+		assert.match(releasePrWorkflow, new RegExp(`\\. == "${conclusion}"`));
+	}
+	assert.match(releasePrWorkflow, /gh workflow run ci\.yml --ref "\$TARGET_BRANCH"/);
 });
 
 test("nextest compiles test targets without building unused examples", () => {


### PR DESCRIPTION
## Summary

- move Changelog and the Linux/macOS/Windows Cargo configuration checks to standard GitHub-hosted runners, which are free for this public repository
- right-size Cargo Tooling Test, Cargo E2E Test, and JS SDK Native Test from 32-vCPU to 16-vCPU Blacksmith runners
- reuse an existing same-SHA pull-request CI run for generated release PRs instead of immediately dispatching a duplicate full run
- retain an exact-SHA, fail-open release fallback when pull-request CI is absent, blocked, cancelled, or cannot be queried
- add workflow invariants and the 16-vCPU runner label to the Actions linter configuration

## Expected impact

The runner changes target roughly 20–30% of the paid compute cost of an ordinary successful CI run at list rates while retaining 32-vCPU runners for Clippy, the main Cargo test suite, and browser tests. The release change addresses the larger multiplicative waste found in the audit: 88 of 92 sampled dispatch runs had a pull-request CI run for the same commit SHA.

This deliberately does not remove main-branch CI, change `fail-fast`, add broad path filters, move compilation-heavy jobs to ARM, or add a weekly observation workflow.

## Safety

- runner architecture coverage is preserved: Linux and Windows remain x64; `macos-15` is a standard ARM64 runner
- release reuse requires the exact release PR head SHA
- completed test failures are reused rather than hidden by an automatic second run
- approval-blocked/cancelled/skipped/stale runs and query failures dispatch the existing workflow as a fallback

## Validation

- first PR CI run: all 10 jobs passed in 6m12s, with the unchanged 32-vCPU Cargo Test setting the wall time
- downsized jobs: Tooling 2m33s, JS Native 2m49s, E2E 5m41s; all completed before the critical path
- free standard-runner jobs: Changelog 7s, macOS ARM64 20s, Linux x64 22s, Windows x64 58s
- `node --test scripts/ci-workflow.test.mjs scripts/release.test.mjs`
- `node scripts/validate-changes.mjs`
- `node scripts/validate-server-protocol-docs.mjs`
- `node scripts/validate-publish-surface.mjs`
- `actionlint -config-file .github/actionlint.yaml` (v1.7.12)
- exercised the exact `gh run list --workflow ci.yml --event pull_request --commit <sha>` lookup against a recent repository CI SHA
- `git diff --check`
