### PR TITLE
Add a deployable Lix reference server

### DIFF
--- a/.changenotes/add-reference-server.md
+++ b/.changenotes/add-reference-server.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Added a deployable reference server for the Lix Server Protocol.
+
+Hosts can run the provided S3-backed container, embed the Rust protocol handler, or provide an independent compatible implementation.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+**/.env
+**/.env.*
+**/*.key
+**/*.p12
+**/*.pfx
+**/*.pem
+**/node_modules
+**/target
+**/.turbo
+**/.wrangler
+**/.dev.vars
+packages/js-sdk/npm
+packages/js-sdk/lix-js-sdk-*

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -102,6 +102,7 @@ jobs:
           else
             tag="$(node scripts/release-tag.mjs | tail -n 1)"
           fi
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
           if [ -z "$tag" ] || [ "$tag" = "No release tag needed for this commit." ]; then
             echo "has_release=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -117,8 +118,72 @@ jobs:
             echo "has_release=true"
             echo "tag=$tag"
             echo "version=${tag#v}"
-            echo "release_sha=$release_sha"
           } >> "$GITHUB_OUTPUT"
+
+  publish-lix-server:
+    name: Publish Lix reference server
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    needs: release-version
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-version.outputs.release_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Select server image tags
+        id: image-tags
+        env:
+          RELEASE_SHA: ${{ needs.release-version.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.release-version.outputs.tag }}
+          HAS_RELEASE: ${{ needs.release-version.outputs.has_release }}
+        run: |
+          {
+            echo 'tags<<EOF'
+            echo "ghcr.io/opral/lix-server:sha-$RELEASE_SHA"
+            if [ "${{ github.event_name }}" = push ]; then
+              echo 'ghcr.io/opral/lix-server:main'
+            fi
+            if [ "$HAS_RELEASE" = true ]; then
+              echo "ghcr.io/opral/lix-server:$RELEASE_TAG"
+            fi
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and publish immutable server image
+        id: publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/server/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image-tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.revision=${{ needs.release-version.outputs.release_sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.release-version.outputs.has_release == 'true' && needs.release-version.outputs.version || needs.release-version.outputs.release_sha }}
+          cache-from: type=gha,scope=lix-server-release
+          cache-to: type=gha,mode=max,scope=lix-server-release
+
+      - name: Verify the reference image is publicly pullable
+        run: |
+          docker logout ghcr.io
+          docker manifest inspect \
+            "ghcr.io/opral/lix-server@${{ steps.publish.outputs.digest }}"
 
   build-js-sdk-native-packages:
     name: Build @lix-js/sdk native package (${{ matrix.suffix }})
@@ -619,6 +684,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-version
+      - publish-lix-server
       - create-github-release
       - build-js-sdk-native-packages
       - build-js-sdk
@@ -631,6 +697,7 @@ jobs:
       - name: Fail if any publish job failed
         run: |
           echo "release-version: ${{ needs.release-version.result }}"
+          echo "publish-lix-server: ${{ needs.publish-lix-server.result }}"
           echo "create-github-release: ${{ needs.create-github-release.result }}"
           echo "build-js-sdk-native-packages: ${{ needs.build-js-sdk-native-packages.result }}"
           echo "build-js-sdk: ${{ needs.build-js-sdk.result }}"
@@ -639,6 +706,9 @@ jobs:
           echo "publish-js-sdk: ${{ needs.publish-js-sdk.result }}"
 
           if [ "${{ needs.release-version.result }}" != "success" ]; then
+            exit 1
+          fi
+          if [ "${{ needs.publish-lix-server.result }}" != "success" ]; then
             exit 1
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +453,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -648,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +966,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +984,25 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -916,6 +1056,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1094,6 +1244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1330,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1839,8 +2008,18 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1880,6 +2059,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duration-str"
@@ -2077,6 +2262,22 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2299,6 +2500,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,10 +2633,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2428,9 +2663,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2748,6 +2985,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2983,7 +3264,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "paste",
- "reqwest",
+ "reqwest 0.12.28",
  "ruzstd",
  "serde",
  "serde_json",
@@ -3023,6 +3304,38 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "lix-server"
+version = "0.14.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "blake3",
+ "bytes",
+ "flate2",
+ "fs2",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "lix",
+ "lix-storage-slatedb",
+ "object_store 0.14.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3197,10 +3510,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -3225,6 +3554,12 @@ checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -3559,17 +3894,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
+ "base64",
  "bytes",
  "chrono",
+ "crc-fast",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-util",
  "http",
+ "http-body-util",
  "humantime",
+ "hyper",
  "itertools 0.15.0",
+ "md-5",
  "nix",
  "parking_lot",
  "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest 0.13.1",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3593,6 +3942,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,6 +3958,48 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.1",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "flate2",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
 ]
 
 [[package]]
@@ -3620,6 +4017,7 @@ dependencies = [
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3923,6 +4321,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pulley-interpreter"
 version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3943,6 +4364,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -3971,6 +4402,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4198,6 +4630,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4281,12 +4753,25 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4300,11 +4785,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4338,6 +4851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4348,6 +4870,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -4424,6 +4969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4480,7 +5036,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4629,6 +5185,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "sqlparser"
@@ -5027,6 +5589,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5035,12 +5598,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5157,9 +5725,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ulid"
@@ -5417,6 +5985,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.247.0",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5775,6 +6356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5974,6 +6564,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6006,6 +6605,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6052,6 +6666,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6064,6 +6684,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6073,6 +6699,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6100,6 +6732,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6109,6 +6747,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6124,6 +6768,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6133,6 +6783,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "3"
 members = [
+  "packages/server",
   "packages/collaboration-test-support",
   "packages/js-sdk",
   "packages/lix",

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -69,9 +69,27 @@ locally. See [Collaboration and Sync](./collaboration-and-sync.md).
 ## Host it yourself
 
 Companies that must keep repositories on their own infrastructure can run their
-own host. The `lix` crate contains the server implementation, so a host does not
-implement the protocol. It provides HTTP and authentication and forwards
-requests.
+own host. There are three interoperable approaches:
+
+1. Deploy the ready-made [Lix reference server](../packages/server/README.md)
+   behind your authentication gateway.
+2. Embed the `lix` crate's protocol handler in a custom Rust host.
+3. Implement the documented Lix Server Protocol independently in another
+   language or architecture.
+
+The reference server is a supported example, not the protocol authority. Every
+compatible implementation exposes the same wire contract to clients.
+
+### Deploy the reference server
+
+The reference server uses SlateDB and S3-compatible object storage and is
+published as `ghcr.io/opral/lix-server`. It provides runtime pooling, caching,
+stream leases, timeouts, and graceful recovery. Authentication, authorization,
+and resource-existence policy remain the responsibility of a trusted gateway.
+See its [README](../packages/server/README.md) for configuration and security
+requirements.
+
+### Embed the Rust handler
 
 Enable the feature:
 

--- a/docs/server-protocol.md
+++ b/docs/server-protocol.md
@@ -21,8 +21,10 @@ client works against it unchanged. Point a client at a different server and
 nothing in the client changes but the connection URL. The OpenAPI document plus
 the normative behavior below is the complete per-Lix contract.
 
-The `lix` crate contains the reference implementation, so a server provides HTTP
-and authentication and forwards requests to it. See [Hosting](./hosting.md).
+The `lix` crate contains a reusable Rust handler and this repository ships a
+[reference server](../packages/server/README.md). A host can run or customize
+that server, embed the Rust handler, or independently implement the same wire
+contract in another language. See [Hosting](./hosting.md).
 
 ## Surface
 
@@ -135,6 +137,8 @@ The machine-readable surface is
 
 Behavior that OpenAPI cannot express — session pinning, transaction ownership,
 idempotency replay, observation ordering, and terminal storage semantics — is
-normative in the reference implementation and its tests.
+specified by the behavioral requirements in this documentation. The Rust
+implementation and its tests demonstrate those requirements; they do not make
+the implementation itself part of the protocol.
 
 To run a server, see [Hosting](./hosting.md).

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "lix-server"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+description = "Reference host for the Lix Server Protocol."
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+anyhow = "1.0.100"
+axum = "0.8.9"
+blake3 = "1.8.2"
+fs2 = "0.4.3"
+futures-util = "0.3.31"
+http = "1.4.0"
+http-body = "1.0.1"
+lix_sdk = { package = "lix", path = "../lix", default-features = false, features = ["default_wasm_runtime", "server-protocol"] }
+lix_slatedb_storage = { package = "lix-storage-slatedb", path = "../storage-slatedb" }
+object_store = { version = "0.14.0", default-features = false, features = ["aws"] }
+opentelemetry = "0.32"
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["gzip-http", "http-proto", "reqwest-client", "reqwest-rustls-webpki-roots", "trace"] }
+opentelemetry_sdk = { version = "0.32", features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.48.0", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tower-http = { version = "0.6.8", features = ["compression-gzip", "compression-zstd", "decompression-gzip"] }
+tracing = "0.1.44"
+tracing-opentelemetry = "0.33"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
+uuid = "1.19.0"
+
+[dev-dependencies]
+async-trait = "0.1.89"
+bytes = "1.10.1"
+flate2 = "1.1.8"
+futures-util = "0.3.31"
+http-body-util = "0.1.3"
+tower = { version = "0.5.2", features = ["util"] }
+
+[lints]
+workspace = true

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1.93-bookworm AS builder
+WORKDIR /app
+
+# The build context is the Lix repository root. The reference server links the
+# exact protocol and SlateDB implementation from the same revision.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --locked --package lix-server \
+    && cp /app/target/release/lix-server /usr/local/bin/lix-server
+
+FROM debian:bookworm-slim AS runtime
+LABEL org.opencontainers.image.title="Lix reference server" \
+      org.opencontainers.image.description="Reference implementation of the Lix Server Protocol" \
+      org.opencontainers.image.source="https://github.com/opral/lix"
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 10001 lix-server \
+    && mkdir -p /var/cache/lix-server \
+    && chown lix-server:lix-server /var/cache/lix-server
+
+COPY --from=builder /usr/local/bin/lix-server /usr/local/bin/lix-server
+
+USER lix-server
+EXPOSE 8080
+CMD ["/usr/local/bin/lix-server"]

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,90 @@
+# Lix reference server
+
+This package is a deployable **reference implementation** of a host for the
+[Lix Server Protocol](../../docs/server-protocol.md). It is one example of how
+to operate Lix over HTTP; it is not the protocol itself and it is not required
+in order to build a Lix server. Any service in any language can be a Lix server
+by implementing the documented protocol contract.
+
+The reference server combines the canonical Rust protocol handler with a
+multi-Lix runtime pool, SlateDB, and S3-compatible object storage. It is useful
+as a ready-made internal data plane or as source code for a custom host.
+
+## Trust boundary
+
+The binary deliberately does not implement product authentication,
+authorization, tenancy, billing, or repository discovery. Put it behind a
+trusted gateway that owns those policies. A valid Lix UUID is opened on demand,
+so the gateway must reject targets the caller is not allowed to access.
+
+`LIX_SERVER_INTERNAL_TOKEN` is required at startup. Protocol requests must carry
+`Authorization: Bearer <token>`. After authenticating the end user, the trusted
+gateway may also set:
+
+- `x-lix-account-id`: the verified Lix account ID;
+- `x-lix-idempotency-scope`: a stable identity-provider scope, defaulting to
+  the account ID when omitted.
+
+These headers are implementation-specific and are removed before canonical
+protocol dispatch. They are rejected when internal authentication is disabled;
+unprotected local deployments always use the anonymous protocol principal.
+Clients must never be allowed to set or forward them directly.
+
+`GET /healthz` and the internal bearer token are operational features of this
+binary, not Lix Server Protocol endpoints. All protocol operations live below
+`/lix/v1/{lix_id}`.
+
+## Run
+
+The server requires an S3-compatible object store:
+
+```sh
+S3_ENDPOINT=https://s3.example.com \
+S3_BUCKET=lix \
+S3_ACCESS_KEY_ID=... \
+S3_SECRET_ACCESS_KEY=... \
+LIX_SERVER_INTERNAL_TOKEN=... \
+cargo run --release --package lix-server
+```
+
+The container is published as `ghcr.io/opral/lix-server`. Deployments should
+pin its immutable digest rather than a moving tag. GitHub creates the package
+as private on its first publication; an organization administrator must make
+`lix-server` public once. The release workflow verifies anonymous digest pulls
+and will remain red until that one-time setting is complete.
+
+### Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BIND_ADDR` | `0.0.0.0:$PORT` | Listen address |
+| `PORT` | `8080` | Port used when `BIND_ADDR` is absent |
+| `LIX_SERVER_INTERNAL_TOKEN` | required | Protect protocol routes and enable trusted identity headers |
+| `LIX_SERVER_MAX_OPEN_LIXS` | `32` | Maximum retained Lix runtimes |
+| `LIX_SERVER_PROTOCOL_TIMEOUT_SECS` | `60` | Admission and request deadline |
+| `LIX_SERVER_RECOVERY_CLOSE_TIMEOUT_SECS` | `30` | Runtime recovery close deadline |
+| `S3_ENDPOINT` | required | S3-compatible endpoint |
+| `S3_BUCKET` | required | Object-store bucket |
+| `S3_ACCESS_KEY_ID` | required | Object-store access key |
+| `S3_SECRET_ACCESS_KEY` | required | Object-store secret key |
+| `S3_REGION` | `auto` | Object-store region |
+| `S3_PREFIX` | empty | Explicit object key prefix |
+| `S3_ALLOW_HTTP` | `false` | Allow an insecure object-store endpoint |
+| `SLATEDB_CACHE_DIR` | `/tmp/lix-server-slatedb-cache` | Local cache root |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Optional OTLP/HTTP trace endpoint |
+
+`S3_PREFIX` is part of the persistent object layout. Set it explicitly and do
+not change it for an existing deployment. Cache settings affect only local,
+rebuildable data.
+
+## Build the image
+
+Use the repository root as the Docker build context:
+
+```sh
+docker build -f packages/server/Dockerfile -t lix-server .
+```
+
+LixRay-specific public routing, Supabase policy, demo identities, MCP routes,
+and product analytics remain in LixRay's gateway. They are intentionally not
+part of this reference implementation.

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -1,0 +1,402 @@
+use anyhow::{Context, Result, bail};
+use std::env;
+use std::path::PathBuf;
+use std::time::Duration;
+
+const DEFAULT_CACHE_DIR: &str = "/tmp/lix-server-slatedb-cache";
+const DEFAULT_DISK_CACHE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const DEFAULT_BLOCK_CACHE_BYTES: u64 = 128 * 1024 * 1024;
+const DEFAULT_METADATA_CACHE_BYTES: u64 = 32 * 1024 * 1024;
+// Each retained Lix owns an independent SlateDB runtime and in-memory cache
+// allocation.
+// Keep a useful single-operator working set warm. Cache byte budgets are split
+// across this cap, so raising it does not raise the configured aggregate block,
+// metadata, or disk-cache budgets. Larger deployments can still override it.
+const DEFAULT_MAX_OPEN_LIXS: u64 = 32;
+const DEFAULT_PROTOCOL_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_RECOVERY_CLOSE_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub bind_addr: String,
+    pub internal_token: Option<String>,
+    pub max_open_lixes: usize,
+    pub protocol_timeout: Duration,
+    pub recovery_close_timeout: Duration,
+    pub(crate) storage: S3StorageConfig,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct S3StorageConfig {
+    pub(crate) endpoint: String,
+    pub(crate) bucket: String,
+    pub(crate) access_key_id: String,
+    pub(crate) secret_access_key: String,
+    pub(crate) region: String,
+    pub(crate) prefix: String,
+    pub(crate) allow_http: bool,
+    pub(crate) cache: SlateDBCacheConfig,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SlateDBCacheConfig {
+    pub(crate) root_folder: PathBuf,
+    pub(crate) max_disk_cache_bytes: usize,
+    pub(crate) block_cache_bytes: u64,
+    pub(crate) metadata_cache_bytes: u64,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self> {
+        let bind_addr = env::var("BIND_ADDR").unwrap_or_else(|_| {
+            let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+            format!("0.0.0.0:{port}")
+        });
+        let internal_token = Some(required_env("LIX_SERVER_INTERNAL_TOKEN")?);
+        let max_open_lixes = usize::try_from(positive_u64_env(
+            "LIX_SERVER_MAX_OPEN_LIXS",
+            DEFAULT_MAX_OPEN_LIXS,
+        )?)
+        .context("LIX_SERVER_MAX_OPEN_LIXS does not fit this platform")?;
+        let protocol_timeout = Duration::from_secs(positive_u64_env(
+            "LIX_SERVER_PROTOCOL_TIMEOUT_SECS",
+            DEFAULT_PROTOCOL_TIMEOUT_SECS,
+        )?);
+        let recovery_close_timeout = Duration::from_secs(positive_u64_env(
+            "LIX_SERVER_RECOVERY_CLOSE_TIMEOUT_SECS",
+            DEFAULT_RECOVERY_CLOSE_TIMEOUT_SECS,
+        )?);
+
+        let storage = S3StorageConfig {
+            endpoint: required_env("S3_ENDPOINT")?,
+            bucket: required_env("S3_BUCKET")?,
+            access_key_id: required_env("S3_ACCESS_KEY_ID")?,
+            secret_access_key: required_env("S3_SECRET_ACCESS_KEY")?,
+            region: env::var("S3_REGION").unwrap_or_else(|_| "auto".to_string()),
+            prefix: storage_prefix()?,
+            allow_http: boolean_env("S3_ALLOW_HTTP", false)?,
+            cache: SlateDBCacheConfig::from_env()?,
+        };
+
+        Ok(Self {
+            bind_addr,
+            internal_token,
+            max_open_lixes,
+            protocol_timeout,
+            recovery_close_timeout,
+            storage,
+        })
+    }
+}
+
+fn storage_prefix() -> Result<String> {
+    let value = optional_nonempty_env("S3_PREFIX")?.unwrap_or_default();
+    let normalized = value.trim_matches('/');
+    if normalized.is_empty() {
+        return Ok(String::new());
+    }
+    if normalized.split('/').any(|segment| {
+        segment.is_empty()
+            || segment == "."
+            || segment == ".."
+            || !segment
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+    }) {
+        bail!(
+            "S3_PREFIX must contain slash-separated alphanumeric, hyphen, or underscore segments"
+        );
+    }
+    Ok(normalized.to_string())
+}
+
+fn boolean_env(name: &str, default: bool) -> Result<bool> {
+    match env::var(name) {
+        Ok(value) if value == "true" => Ok(true),
+        Ok(value) if value == "false" => Ok(false),
+        Ok(_) => bail!("{name} must be `true` or `false`"),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(error).with_context(|| format!("read {name}")),
+    }
+}
+
+impl SlateDBCacheConfig {
+    fn from_env() -> Result<Self> {
+        let root_folder =
+            env::var("SLATEDB_CACHE_DIR").unwrap_or_else(|_| DEFAULT_CACHE_DIR.to_string());
+        if root_folder.trim().is_empty() {
+            bail!("SLATEDB_CACHE_DIR must not be empty");
+        }
+        let disk_cache_bytes =
+            positive_u64_env("SLATEDB_CACHE_MAX_BYTES", DEFAULT_DISK_CACHE_BYTES)?;
+        let max_disk_cache_bytes = usize::try_from(disk_cache_bytes)
+            .context("SLATEDB_CACHE_MAX_BYTES does not fit this platform")?;
+
+        Ok(Self {
+            root_folder: PathBuf::from(root_folder),
+            max_disk_cache_bytes,
+            block_cache_bytes: positive_u64_env(
+                "SLATEDB_BLOCK_CACHE_BYTES",
+                DEFAULT_BLOCK_CACHE_BYTES,
+            )?,
+            metadata_cache_bytes: positive_u64_env(
+                "SLATEDB_METADATA_CACHE_BYTES",
+                DEFAULT_METADATA_CACHE_BYTES,
+            )?,
+        })
+    }
+}
+
+fn positive_u64_env(name: &str, default: u64) -> Result<u64> {
+    let value = match env::var(name) {
+        Ok(value) => value
+            .parse::<u64>()
+            .with_context(|| format!("{name} must be a positive integer"))?,
+        Err(env::VarError::NotPresent) => default,
+        Err(error) => return Err(error).with_context(|| format!("read {name}")),
+    };
+    if value == 0 {
+        bail!("{name} must be greater than zero");
+    }
+    Ok(value)
+}
+
+fn required_env(name: &str) -> Result<String> {
+    let value = env::var(name).with_context(|| format!("{name} is required"))?;
+    if value.is_empty() {
+        bail!("{name} is required");
+    }
+    Ok(value)
+}
+
+fn optional_nonempty_env(name: &str) -> Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) if value.is_empty() => bail!("{name} must not be empty when set"),
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {name}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn set_env(name: &str, value: &str) {
+        // SAFETY: every environment-mutating test in this module holds env_lock.
+        unsafe { env::set_var(name, value) };
+    }
+
+    fn remove_env(name: &str) {
+        // SAFETY: every environment-mutating test in this module holds env_lock.
+        unsafe { env::remove_var(name) };
+    }
+
+    #[test]
+    fn from_env_configures_s3_without_a_lix_path() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        clear_server_env();
+        set_s3_env();
+
+        let config = Config::from_env().unwrap();
+
+        assert_eq!(config.max_open_lixes, 32);
+        assert_eq!(config.bind_addr, "0.0.0.0:8080");
+        assert_eq!(config.internal_token.as_deref(), Some("test-token"));
+        assert_eq!(config.storage.endpoint, "https://s3.example");
+        assert_eq!(config.storage.bucket, "lix");
+        assert_eq!(config.storage.region, "auto");
+        assert_eq!(config.storage.prefix, "");
+        assert!(!config.storage.allow_http);
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_uses_platform_port_and_internal_token() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_s3_env();
+        set_env("PORT", "4567");
+        set_env("LIX_SERVER_INTERNAL_TOKEN", "test-token");
+
+        let config = Config::from_env().unwrap();
+
+        assert_eq!(config.bind_addr, "0.0.0.0:4567");
+        assert_eq!(config.internal_token.as_deref(), Some("test-token"));
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_rejects_empty_internal_token() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_env("LIX_SERVER_INTERNAL_TOKEN", "");
+
+        let error = Config::from_env().unwrap_err();
+
+        assert!(format!("{error:#}").contains("LIX_SERVER_INTERNAL_TOKEN is required"));
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_requires_internal_token() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+
+        let error = Config::from_env().unwrap_err();
+
+        assert!(format!("{error:#}").contains("LIX_SERVER_INTERNAL_TOKEN is required"));
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_configures_lix_capacity() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_s3_env();
+        set_env("LIX_SERVER_MAX_OPEN_LIXS", "7");
+
+        let config = Config::from_env().unwrap();
+
+        assert_eq!(config.max_open_lixes, 7);
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_configures_recovery_close_timeout() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_s3_env();
+        set_env("LIX_SERVER_RECOVERY_CLOSE_TIMEOUT_SECS", "17");
+
+        let config = Config::from_env().unwrap();
+
+        assert_eq!(config.recovery_close_timeout, Duration::from_secs(17));
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_rejects_zero_recovery_close_timeout() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_env("LIX_SERVER_INTERNAL_TOKEN", "test-token");
+        set_env("LIX_SERVER_RECOVERY_CLOSE_TIMEOUT_SECS", "0");
+
+        let error = Config::from_env().unwrap_err();
+
+        assert!(
+            format!("{error:#}")
+                .contains("LIX_SERVER_RECOVERY_CLOSE_TIMEOUT_SECS must be greater than zero")
+        );
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_rejects_zero_lix_capacity() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_env("LIX_SERVER_INTERNAL_TOKEN", "test-token");
+        set_env("LIX_SERVER_MAX_OPEN_LIXS", "0");
+
+        let error = Config::from_env().unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("LIX_SERVER_MAX_OPEN_LIXS must be greater than zero")
+        );
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_configures_bounded_s3_cache_and_prefix() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_s3_env();
+        set_env("S3_PREFIX", "/preview/pr_123/");
+        set_env("S3_ALLOW_HTTP", "true");
+        set_env("SLATEDB_CACHE_DIR", "/tmp/test-cache");
+        set_env("SLATEDB_CACHE_MAX_BYTES", "1024");
+        set_env("SLATEDB_BLOCK_CACHE_BYTES", "256");
+        set_env("SLATEDB_METADATA_CACHE_BYTES", "64");
+
+        let config = Config::from_env().unwrap();
+
+        assert_eq!(config.storage.prefix, "preview/pr_123");
+        assert!(config.storage.allow_http);
+        assert_eq!(
+            config.storage.cache,
+            SlateDBCacheConfig {
+                root_folder: PathBuf::from("/tmp/test-cache"),
+                max_disk_cache_bytes: 1024,
+                block_cache_bytes: 256,
+                metadata_cache_bytes: 64,
+            }
+        );
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_rejects_zero_cache_sizes() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_s3_env();
+        set_env("SLATEDB_CACHE_MAX_BYTES", "0");
+
+        let error = Config::from_env().unwrap_err();
+
+        assert!(format!("{error:#}").contains("SLATEDB_CACHE_MAX_BYTES must be greater than zero"));
+        clear_server_env();
+    }
+
+    #[test]
+    fn from_env_rejects_unsafe_s3_prefix() {
+        let _guard = env_lock().lock().unwrap();
+        clear_server_env();
+        set_s3_env();
+        set_env("S3_PREFIX", "preview/../production");
+
+        let error = Config::from_env().unwrap_err();
+
+        assert!(format!("{error:#}").contains("S3_PREFIX"));
+        clear_server_env();
+    }
+
+    fn set_s3_env() {
+        set_env("LIX_SERVER_INTERNAL_TOKEN", "test-token");
+        set_env("S3_ENDPOINT", "https://s3.example");
+        set_env("S3_BUCKET", "lix");
+        set_env("S3_ACCESS_KEY_ID", "access-key");
+        set_env("S3_SECRET_ACCESS_KEY", "secret-key");
+    }
+
+    fn clear_server_env() {
+        for name in [
+            "BIND_ADDR",
+            "PORT",
+            "LIX_SERVER_INTERNAL_TOKEN",
+            "LIX_SERVER_MAX_OPEN_LIXS",
+            "LIX_SERVER_PROTOCOL_TIMEOUT_SECS",
+            "LIX_SERVER_RECOVERY_CLOSE_TIMEOUT_SECS",
+            "S3_ENDPOINT",
+            "S3_BUCKET",
+            "S3_ACCESS_KEY_ID",
+            "S3_SECRET_ACCESS_KEY",
+            "S3_REGION",
+            "S3_PREFIX",
+            "S3_ALLOW_HTTP",
+            "SLATEDB_CACHE_DIR",
+            "SLATEDB_CACHE_MAX_BYTES",
+            "SLATEDB_BLOCK_CACHE_BYTES",
+            "SLATEDB_METADATA_CACHE_BYTES",
+        ] {
+            remove_env(name);
+        }
+    }
+}

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -1,0 +1,11 @@
+#![recursion_limit = "256"]
+
+mod config;
+mod routes;
+mod store;
+#[doc(hidden)]
+pub mod telemetry;
+
+pub use config::Config;
+pub use routes::router;
+pub use store::LixRuntimeManager;

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -1,0 +1,82 @@
+use anyhow::Context;
+use lix_server::{Config, LixRuntimeManager, router, telemetry};
+use tokio::net::TcpListener;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let telemetry = telemetry::init();
+
+    let config = Config::from_env()?;
+    let listener = TcpListener::bind(&config.bind_addr)
+        .await
+        .with_context(|| format!("bind {}", config.bind_addr))?;
+    let manager = LixRuntimeManager::new(&config, telemetry.lix_sink)?;
+    let internal_token = config.internal_token.clone();
+    let shutdown_manager = manager.clone();
+    let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
+    let shutdown_task = tokio::spawn(async move {
+        if shutdown_receiver.await.is_ok() {
+            shutdown_manager.shutdown().await
+        } else {
+            Ok(())
+        }
+    });
+    tracing::info!(
+        addr = %config.bind_addr,
+        max_open_lixes = config.max_open_lixes,
+        internal_auth = internal_token.is_some(),
+        "lix lix service ready"
+    );
+    let result = axum::serve(
+        listener,
+        router(
+            manager,
+            internal_token,
+            config.protocol_timeout,
+            telemetry.in_flight_sql,
+        ),
+    )
+    .with_graceful_shutdown(async move {
+        shutdown_signal().await;
+        if shutdown_sender.send(()).is_err() {
+            tracing::error!("Lix protocol shutdown task stopped before the shutdown signal");
+        }
+    })
+    .await
+    .context("serve HTTP");
+    let shutdown_result = shutdown_task
+        .await
+        .context("join Lix protocol shutdown task")
+        .and_then(|result| result.context("close Lix protocols during shutdown"));
+    match tokio::task::spawn_blocking(move || telemetry.trace_provider.shutdown()).await {
+        Ok(Err(error)) => tracing::warn!(%error, "failed to flush traces during shutdown"),
+        Err(error) => tracing::warn!(%error, "failed to join trace shutdown task"),
+        Ok(Ok(())) => {}
+    }
+    result?;
+    shutdown_result
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("install Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+}

--- a/packages/server/src/routes.rs
+++ b/packages/server/src/routes.rs
@@ -1,0 +1,1794 @@
+use crate::LixRuntimeManager;
+use crate::store::{LixRuntimeError, LixService};
+use crate::telemetry::InFlightSqlRegistry;
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, Request, StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::{any, get},
+};
+use lix_sdk::server_protocol::{self, ServerProtocolContext, ServerProtocolPrincipal};
+use serde::Serialize;
+use serde_json::json;
+use std::{
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    task::{Context, Poll},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+use tower_http::{
+    compression::{
+        CompressionLayer, CompressionLevel,
+        predicate::{DefaultPredicate, NotForContentType, Predicate as _, SizeAbove},
+    },
+    decompression::RequestDecompressionLayer,
+};
+use tracing::Instrument as _;
+
+const TRUSTED_ACCOUNT_ID_HEADER: &str = "x-lix-account-id";
+const TRUSTED_IDEMPOTENCY_SCOPE_HEADER: &str = "x-lix-idempotency-scope";
+const MAX_TRUSTED_PRINCIPAL_BYTES: usize = 255;
+const MIN_COMPRESSION_BODY_BYTES: u16 = 32 * 1024;
+
+#[derive(Debug)]
+struct TrustedRequestPrincipal {
+    account_id: String,
+    idempotency_scope: String,
+}
+
+#[derive(Clone)]
+struct AppState {
+    manager: Arc<LixRuntimeManager>,
+    internal_token: Option<Arc<str>>,
+    protocol_timeout: Duration,
+    request_id_key: [u8; 32],
+    request_sequence: Arc<AtomicU64>,
+    in_flight_sql: InFlightSqlRegistry,
+}
+
+struct TracedBody {
+    inner: Body,
+    span: tracing::Span,
+}
+
+/// Keeps the Lix's one shared Engine alive until a storage-backed stream ends.
+/// Dropping the request-scoped service lease as soon as headers are returned
+/// would let LRU eviction open a second Engine while an SSE observation or
+/// snapshot download from the first Engine is still active. Buffered protocol
+/// bodies do not need this lease and must not delay terminal-runtime recovery.
+struct LixLeaseBody {
+    inner: Body,
+    lix: Option<Arc<LixService>>,
+}
+
+enum CancellationRecoveryMode {
+    WaitForTerminalStorage(server_protocol::DurableTerminalStorageSignal),
+    RecoverOnDrop,
+    Disarmed,
+}
+
+/// Recovers the exact runtime if an HTTP future is cancelled after it has
+/// started protocol work. Terminal storage results are reported from both
+/// durable work and cancellable reads; cancellation itself remains nonterminal.
+struct CancellationRecovery {
+    mode: CancellationRecoveryMode,
+    manager: Arc<LixRuntimeManager>,
+    lix_id: String,
+    service: Arc<LixService>,
+}
+
+impl CancellationRecovery {
+    fn new(
+        signal: server_protocol::DurableTerminalStorageSignal,
+        manager: Arc<LixRuntimeManager>,
+        lix_id: String,
+        service: Arc<LixService>,
+    ) -> Self {
+        Self {
+            mode: CancellationRecoveryMode::WaitForTerminalStorage(signal),
+            manager,
+            lix_id,
+            service,
+        }
+    }
+
+    fn recover_on_drop(&mut self) {
+        self.mode = CancellationRecoveryMode::RecoverOnDrop;
+    }
+
+    fn disarm(&mut self) {
+        self.mode = CancellationRecoveryMode::Disarmed;
+    }
+}
+
+impl Drop for CancellationRecovery {
+    fn drop(&mut self) {
+        let mode = std::mem::replace(&mut self.mode, CancellationRecoveryMode::Disarmed);
+        let manager = Arc::clone(&self.manager);
+        let lix_id = self.lix_id.clone();
+        let service = Arc::clone(&self.service);
+        match mode {
+            CancellationRecoveryMode::WaitForTerminalStorage(signal) => {
+                tokio::spawn(async move {
+                    if signal.wait_for_terminal_storage().await {
+                        tracing::warn!(
+                            lix_id = lix_id.as_str(),
+                            "cancelled protocol request hit a terminal storage error; recovering runtime"
+                        );
+                        manager.recover(&lix_id, &service).await;
+                    }
+                });
+            }
+            CancellationRecoveryMode::RecoverOnDrop => {
+                tokio::spawn(async move {
+                    manager.recover(&lix_id, &service).await;
+                });
+            }
+            CancellationRecoveryMode::Disarmed => {}
+        }
+    }
+}
+
+impl http_body::Body for TracedBody {
+    type Data = <Body as http_body::Body>::Data;
+    type Error = <Body as http_body::Body>::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let span = self.span.clone();
+        let _entered = span.enter();
+        Pin::new(&mut self.inner).poll_frame(context)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl http_body::Body for LixLeaseBody {
+    type Data = <Body as http_body::Body>::Data;
+    type Error = <Body as http_body::Body>::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let frame = Pin::new(&mut self.inner).poll_frame(context);
+        if matches!(&frame, Poll::Ready(None)) {
+            // A completed stream no longer needs to prevent LRU eviction or
+            // terminal-runtime cleanup, even when its response object remains
+            // retained by an in-process caller.
+            self.lix.take();
+        }
+        frame
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+pub fn router(
+    manager: Arc<LixRuntimeManager>,
+    internal_token: Option<String>,
+    protocol_timeout: Duration,
+    in_flight_sql: InFlightSqlRegistry,
+) -> Router {
+    let request_id_key = protocol_request_id_key(internal_token.as_deref());
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/lix/v1/{lix_id}", any(lix_protocol_root))
+        .route("/lix/v1/{lix_id}/", any(lix_protocol_root))
+        .route("/lix/v1/{lix_id}/{*protocol_path}", any(lix_protocol))
+        .with_state(AppState {
+            manager,
+            internal_token: internal_token.map(Arc::from),
+            protocol_timeout,
+            request_id_key,
+            request_sequence: Arc::new(AtomicU64::new(0)),
+            in_flight_sql,
+        })
+        .layer(
+            CompressionLayer::new()
+                .gzip(true)
+                .zstd(true)
+                .quality(CompressionLevel::Precise(2))
+                .compress_when(
+                    DefaultPredicate::new()
+                        .and(SizeAbove::new(MIN_COMPRESSION_BODY_BYTES))
+                        .and(NotForContentType::const_new(
+                            server_protocol::SNAPSHOT_MEDIA_TYPE,
+                        )),
+                ),
+        )
+        // The canonical protocol applies its body limit while consuming the
+        // expanded stream, so decompression must happen before dispatch.
+        .layer(RequestDecompressionLayer::new().gzip(true))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HealthResponse {
+    ok: bool,
+    service: &'static str,
+    storage_backend: &'static str,
+    storage_layout: &'static str,
+}
+
+async fn healthz(State(state): State<AppState>) -> Json<HealthResponse> {
+    // The storage identity belongs to the runtime manager. Do not accept it
+    // from a request or a benchmark invocation: reports must describe the
+    // backend the server actually opened.
+    Json(HealthResponse {
+        ok: true,
+        service: "lix-server",
+        storage_backend: state.manager.storage_backend(),
+        storage_layout: state.manager.storage_layout(),
+    })
+}
+
+async fn lix_protocol(
+    State(state): State<AppState>,
+    Path((lix_id, protocol_path)): Path<(String, String)>,
+    request: Request<Body>,
+) -> Response {
+    lix_protocol_route(state, lix_id, protocol_path, request).await
+}
+
+async fn lix_protocol_root(
+    State(state): State<AppState>,
+    Path(lix_id): Path<String>,
+    request: Request<Body>,
+) -> Response {
+    lix_protocol_route(state, lix_id, String::new(), request).await
+}
+
+async fn lix_protocol_route(
+    state: AppState,
+    lix_id: String,
+    protocol_path: String,
+    request: Request<Body>,
+) -> Response {
+    let request_id = protocol_request_id(&state, &lix_id, &protocol_path);
+    let span = tracing::info_span!(
+        "lix.protocol.request",
+        "otel.name" = "Lix protocol request",
+        "otel.kind" = "server",
+        "http.request.method" = %request.method(),
+        "http.route" = "/lix/v1/{lix_id}/{*protocol_path}",
+        "lix.lix.id" = %lix_id,
+        "lix.protocol.path" = %protocol_path,
+        "lix.request.id" = %request_id,
+        "lix.request.phase" = tracing::field::Empty,
+        "lix.sql.active.count" = tracing::field::Empty,
+        "lix.sql.active.operations" = tracing::field::Empty,
+        "lix.sql.active.execution_kinds" = tracing::field::Empty,
+        "lix.sql.active.fingerprints" = tracing::field::Empty,
+        "http.response.status_code" = tracing::field::Empty,
+        "lix.error.code" = tracing::field::Empty,
+        "otel.status_code" = tracing::field::Empty,
+    );
+    let response = lix_protocol_inner(state, lix_id, protocol_path, request_id, request)
+        .instrument(span.clone())
+        .await;
+    if response.status() != StatusCode::GATEWAY_TIMEOUT {
+        span.record("lix.request.phase", "completed");
+    }
+    span.record("http.response.status_code", response.status().as_u16());
+    if response.status().is_server_error() {
+        span.record("otel.status_code", "ERROR");
+    }
+    let (parts, body) = response.into_parts();
+    Response::from_parts(parts, Body::new(TracedBody { inner: body, span }))
+}
+
+async fn lix_protocol_inner(
+    state: AppState,
+    lix_id: String,
+    protocol_path: String,
+    request_id: String,
+    mut request: Request<Body>,
+) -> Response {
+    tracing::info!(
+        request_id,
+        lix_id,
+        protocol_path,
+        method = %request.method(),
+        "protocol request started"
+    );
+    if !authorized(request.headers(), state.internal_token.as_deref()) {
+        let mut response = protocol_error(
+            StatusCode::UNAUTHORIZED,
+            "LIX_ERROR_UNAUTHENTICATED",
+            "Invalid internal service token.",
+            None,
+            None,
+        );
+        response
+            .headers_mut()
+            .insert(header::WWW_AUTHENTICATE, HeaderValue::from_static("Bearer"));
+        return response;
+    }
+    let canonical_lix_id = uuid::Uuid::parse_str(&lix_id)
+        .ok()
+        .map(|id| id.hyphenated().to_string());
+    if canonical_lix_id.as_deref() != Some(lix_id.as_str()) {
+        return protocol_error(
+            StatusCode::NOT_FOUND,
+            "LIX_NOT_FOUND",
+            "Lix not found.",
+            None,
+            None,
+        );
+    }
+    // The bearer token authenticates the outer host route. It is not
+    // part of the canonical Lix Server Protocol request.
+    request.headers_mut().remove(header::AUTHORIZATION);
+
+    let trusted_principal =
+        match take_trusted_principal(&mut request, state.internal_token.is_some()) {
+            Ok(principal) => principal,
+            Err(message) => {
+                return protocol_error(
+                    StatusCode::BAD_REQUEST,
+                    "LIX_INVALID_ARGUMENT",
+                    message,
+                    None,
+                    None,
+                );
+            }
+        };
+    let principal = trusted_principal.map_or(ServerProtocolPrincipal::Anonymous, |principal| {
+        ServerProtocolPrincipal::Authenticated {
+            account_id: principal.account_id,
+            idempotency_scope: principal.idempotency_scope,
+        }
+    });
+    let protocol_started_at = Instant::now();
+    let runtime =
+        match tokio::time::timeout(state.protocol_timeout, state.manager.get(&lix_id)).await {
+            Ok(Ok(runtime)) => runtime,
+            Ok(Err(error)) => return lix_error(error),
+            Err(_elapsed) => {
+                tracing::warn!(
+                    lix_id,
+                    timeout_secs = state.protocol_timeout.as_secs(),
+                    "lix runtime admission exceeded its deadline"
+                );
+                return lix_error(LixRuntimeError::AtCapacity {
+                    max: state.manager.max_open_lixes(),
+                });
+            }
+        };
+
+    let (notifier, signal) = server_protocol::durable_terminal_storage_signal();
+    let context = ServerProtocolContext {
+        principal,
+        durable_terminal_storage_notifier: Some(notifier),
+    };
+    let mut cancellation_recovery = CancellationRecovery::new(
+        signal,
+        Arc::clone(&state.manager),
+        lix_id.clone(),
+        Arc::clone(&runtime),
+    );
+
+    // Acquisition above and this protocol call are both bounded. The
+    // object-store client has its own request budget, but a wedged connection
+    // (e.g. after a host sleep) can still hang past it — without these bounds
+    // requests never answer and a runtime can remain wedged for later calls.
+    let handler_future = runtime.handle_protocol(request, context);
+    let response = match tokio::time::timeout(state.protocol_timeout, handler_future).await {
+        Ok(response) => response,
+        Err(_elapsed) => {
+            let activities = state.in_flight_sql.current();
+            let phase = if activities.is_empty() {
+                "protocol_handler"
+            } else {
+                "sql_execution"
+            };
+            let operations =
+                sql_activity_values(&activities, |activity| activity.operation.as_deref());
+            let execution_kinds =
+                sql_activity_values(&activities, |activity| activity.execution_kind.as_deref());
+            let fingerprints =
+                sql_activity_values(&activities, |activity| activity.fingerprint.as_deref());
+            let span = tracing::Span::current();
+            span.record("lix.request.phase", phase);
+            span.record("lix.sql.active.count", activities.len() as u64);
+            span.record("lix.sql.active.operations", operations.as_str());
+            span.record("lix.sql.active.execution_kinds", execution_kinds.as_str());
+            span.record("lix.sql.active.fingerprints", fingerprints.as_str());
+            tracing::warn!(
+                lix_id,
+                request_id,
+                phase,
+                active_sql_count = activities.len(),
+                active_sql_operations = operations,
+                active_sql_execution_kinds = execution_kinds,
+                active_sql_fingerprints = fingerprints,
+                timeout_secs = state.protocol_timeout.as_secs(),
+                "protocol request exceeded its deadline; recovering runtime"
+            );
+            cancellation_recovery.recover_on_drop();
+            state.manager.recover(&lix_id, &runtime).await;
+            cancellation_recovery.disarm();
+            return protocol_timeout_response();
+        }
+    };
+    record_sql_failures(
+        &state.in_flight_sql,
+        response.status(),
+        &request_id,
+        &lix_id,
+        &protocol_path,
+    );
+    if server_protocol::is_terminal_storage_response(&response) {
+        tracing::warn!(
+            lix_id = lix_id.as_str(),
+            "protocol request hit a terminal storage error; recovering runtime"
+        );
+        // The failed operation is deliberately not replayed: SlateDB reports
+        // a terminal storage failure, but a mutation's outcome can still be
+        // unknown to the caller. The protocol response marks that explicitly.
+        cancellation_recovery.recover_on_drop();
+        state.manager.recover(&lix_id, &runtime).await;
+    }
+    if let Some(terminal_signal) = server_protocol::terminal_storage_stream_signal(&response) {
+        let manager = Arc::clone(&state.manager);
+        let recovery_runtime = Arc::clone(&runtime);
+        let recovery_lix_id = lix_id.clone();
+        // Streaming responses can hit storage after sending their HTTP status.
+        // Keep the terminal signal in-process rather than parsing body bytes,
+        // and do not retain this runtime after a normal stream end.
+        tokio::spawn(async move {
+            if terminal_signal.wait_for_terminal_storage().await {
+                tracing::warn!(
+                    lix_id = recovery_lix_id.as_str(),
+                    "protocol stream hit a terminal storage error; recovering runtime"
+                );
+                manager.recover(&recovery_lix_id, &recovery_runtime).await;
+            }
+        });
+    }
+    cancellation_recovery.disarm();
+    let protocol_duration_ms = protocol_started_at.elapsed().as_secs_f64() * 1_000.0;
+    let holds_lix_lease = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|content_type| content_type.split(';').next())
+        .is_some_and(|media_type| {
+            let media_type = media_type.trim();
+            media_type.eq_ignore_ascii_case("text/event-stream")
+                || media_type.eq_ignore_ascii_case(server_protocol::SNAPSHOT_MEDIA_TYPE)
+        });
+    let (mut parts, body) = response.into_parts();
+    if let Ok(server_timing) = HeaderValue::from_str(&format!(
+        "lix-server-protocol;dur={protocol_duration_ms:.3}"
+    )) {
+        parts.headers.insert(
+            header::HeaderName::from_static("server-timing"),
+            server_timing,
+        );
+    }
+    let body = Body::new(body);
+    if holds_lix_lease {
+        Response::from_parts(
+            parts,
+            Body::new(LixLeaseBody {
+                inner: body,
+                lix: Some(runtime),
+            }),
+        )
+    } else {
+        Response::from_parts(parts, body)
+    }
+}
+
+fn record_sql_failures(
+    registry: &InFlightSqlRegistry,
+    response_status: StatusCode,
+    request_id: &str,
+    lix_id: &str,
+    protocol_path: &str,
+) {
+    let failures = registry.take_errors();
+    if failures.is_empty() {
+        return;
+    }
+
+    let error_codes = sql_activity_values(&failures, |activity| activity.error_code.as_deref());
+    let span = tracing::Span::current();
+    span.record("lix.error.code", error_codes.as_str());
+    span.record("otel.status_code", "ERROR");
+
+    for failure in failures {
+        tracing::warn!(
+            request_id,
+            lix_id,
+            protocol_path,
+            "http.response.status_code" = response_status.as_u16(),
+            "lix.error.code" = failure.error_code.as_deref().unwrap_or("unavailable"),
+            "lix.sql.fingerprint" = failure.fingerprint.as_deref().unwrap_or("unavailable"),
+            "db.operation.name" = failure.operation.as_deref().unwrap_or("unavailable"),
+            "lix.execution.kind" = failure.execution_kind.as_deref().unwrap_or("unavailable"),
+            "lix.batch.index" = ?failure.batch_index,
+            "Lix SQL protocol request failed"
+        );
+    }
+}
+
+fn protocol_request_id_key(internal_token: Option<&str>) -> [u8; 32] {
+    blake3::derive_key(
+        "lix server protocol request identity v1",
+        internal_token.unwrap_or("local-development").as_bytes(),
+    )
+}
+
+fn protocol_request_id(state: &AppState, lix_id: &str, protocol_path: &str) -> String {
+    let sequence = state.request_sequence.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut hasher = blake3::Hasher::new_keyed(&state.request_id_key);
+    hasher.update(b"lix-server.protocol.request.v1\0");
+    hasher.update(&timestamp.to_le_bytes());
+    hasher.update(&sequence.to_le_bytes());
+    hasher.update(lix_id.as_bytes());
+    hasher.update(protocol_path.as_bytes());
+    hasher.finalize().to_hex().as_str()[..24].to_string()
+}
+
+fn sql_activity_values<'a>(
+    activities: &'a [crate::telemetry::InFlightSqlActivity],
+    value: impl Fn(&'a crate::telemetry::InFlightSqlActivity) -> Option<&'a str>,
+) -> String {
+    let mut values = Vec::new();
+    for activity in activities {
+        let Some(value) = value(activity) else {
+            continue;
+        };
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
+    if values.is_empty() {
+        "unavailable".to_string()
+    } else {
+        values.join(",")
+    }
+}
+
+fn take_trusted_principal(
+    request: &mut Request<Body>,
+    trusted_headers_enabled: bool,
+) -> Result<Option<TrustedRequestPrincipal>, &'static str> {
+    let account_id = take_trusted_header(request, TRUSTED_ACCOUNT_ID_HEADER)?;
+    let idempotency_scope = take_trusted_header(request, TRUSTED_IDEMPOTENCY_SCOPE_HEADER)?;
+    if !trusted_headers_enabled && (account_id.is_some() || idempotency_scope.is_some()) {
+        return Err("Trusted principal headers require LIX_SERVER_INTERNAL_TOKEN.");
+    }
+    let Some(account_id) = account_id else {
+        if idempotency_scope.is_some() {
+            return Err("x-lix-idempotency-scope requires x-lix-account-id.");
+        }
+        return Ok(None);
+    };
+    let idempotency_scope = idempotency_scope.unwrap_or_else(|| account_id.clone());
+    Ok(Some(TrustedRequestPrincipal {
+        account_id,
+        idempotency_scope,
+    }))
+}
+
+fn take_trusted_header(
+    request: &mut Request<Body>,
+    name: &'static str,
+) -> Result<Option<String>, &'static str> {
+    let value = {
+        let mut values = request.headers().get_all(name).iter();
+        let value = values.next().cloned();
+        if values.next().is_some() {
+            return Err("Trusted principal headers must be sent at most once.");
+        }
+        value
+    };
+    request.headers_mut().remove(name);
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| "Trusted principal headers must contain visible ASCII characters.")?;
+    if value.is_empty()
+        || value.len() > MAX_TRUSTED_PRINCIPAL_BYTES
+        || !value.bytes().all(|byte| (0x21..=0x7e).contains(&byte))
+    {
+        return Err("Trusted principal headers must contain 1 to 255 visible ASCII characters.");
+    }
+    Ok(Some(value.to_string()))
+}
+
+fn protocol_timeout_response() -> Response {
+    // Lix deliberately lets durable protocol work outlive the cancelled HTTP
+    // future. This outer layer cannot distinguish an idempotent SQL write
+    // from a read-shaped operation that persists runtime state, so it must
+    // preserve an unknown outcome rather than infer replay safety from a URL
+    // or header alone.
+    protocol_error(
+        StatusCode::GATEWAY_TIMEOUT,
+        "LIX_ERROR_LIX_TIMEOUT",
+        "The lix request timed out before its outcome was known.",
+        Some("Do not automatically retry this request; a mutation may still complete.".to_string()),
+        Some(json!({
+        "operation": "lix_request",
+        "retryable": false,
+        "outcome": "unknown",
+        })),
+    )
+}
+
+fn authorized(headers: &HeaderMap, internal_token: Option<&str>) -> bool {
+    let Some(internal_token) = internal_token else {
+        return true;
+    };
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|value| value == internal_token)
+}
+
+fn lix_error(error: LixRuntimeError) -> Response {
+    match error {
+        LixRuntimeError::InvalidId => protocol_error(
+            StatusCode::BAD_REQUEST,
+            "LIX_INVALID_ARGUMENT",
+            "Invalid lix ID.",
+            None,
+            Some(json!({
+                "operation": "lix_open",
+                "retryable": false,
+            })),
+        ),
+        LixRuntimeError::AtCapacity { max } => protocol_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "LIX_ERROR_LIX_CAPACITY",
+            "The lix service is at capacity.",
+            Some("Retry after an active lix closes.".to_string()),
+            Some(json!({
+                "maxOpenLixes": max,
+                "operation": "lix_open",
+                "retryable": true,
+            })),
+        )
+        .with_retry_after(),
+        LixRuntimeError::Migrating {
+            from_version,
+            to_version,
+        } => protocol_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "LIX_ERROR_LIX_MIGRATING",
+            "The lix repository is being migrated.",
+            Some("Retry after the migration completes.".to_string()),
+            Some(json!({
+                "fromVersion": from_version,
+                "toVersion": to_version,
+                "operation": "lix_open",
+                "retryable": true,
+            })),
+        )
+        .with_retry_after(),
+        LixRuntimeError::MigrationFailed {
+            from_version,
+            to_version,
+        } => protocol_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "LIX_ERROR_LIX_MIGRATION_FAILED",
+            "The lix repository migration failed.",
+            Some("Contact the service operator to recover the repository.".to_string()),
+            Some(json!({
+                "fromVersion": from_version,
+                "toVersion": to_version,
+                "operation": "lix_open",
+                "retryable": false,
+            })),
+        ),
+        LixRuntimeError::UpgradeFailed => protocol_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "LIX_ERROR_LIX_MIGRATION_FAILED",
+            "The lix repository upgrade failed.",
+            Some("Contact the service operator to recover the repository.".to_string()),
+            Some(json!({
+                "operation": "lix_open",
+                "retryable": false,
+            })),
+        ),
+        LixRuntimeError::Recovering => protocol_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "LIX_ERROR_LIX_RECOVERING",
+            "The lix is recovering.",
+            Some("Retry the request.".to_string()),
+            Some(json!({
+                "operation": "lix_open",
+                "retryable": true,
+            })),
+        )
+        .with_retry_after(),
+        LixRuntimeError::ShuttingDown => protocol_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "LIX_ERROR_LIX_SHUTTING_DOWN",
+            "The lix server is shutting down.",
+            Some("Retry the request on a healthy server.".to_string()),
+            Some(json!({
+                "operation": "lix_open",
+                "retryable": true,
+            })),
+        )
+        .with_retry_after(),
+        LixRuntimeError::Cleanup(error) => {
+            tracing::error!(error = %error, "lix cache cleanup could not complete");
+            protocol_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "LIX_ERROR_LIX_CACHE_CLEANUP",
+                "The lix service cache needs operator repair.",
+                Some(
+                    "Contact the service operator to repair the cache and restart the server."
+                        .to_string(),
+                ),
+                Some(json!({
+                    "operation": "lix_open",
+                    "retryable": false,
+                })),
+            )
+        }
+        LixRuntimeError::Open(error) if is_unsupported_storage_format(&error) => {
+            tracing::warn!(
+                error = %error,
+                error_code = "LIX_ERROR_STORAGE_FORMAT_UNSUPPORTED",
+                "lix uses an unsupported storage format"
+            );
+            protocol_error(
+                StatusCode::CONFLICT,
+                "LIX_ERROR_STORAGE_FORMAT_UNSUPPORTED",
+                "This lix uses an unsupported storage format.",
+                Some("Create a new lix.".to_string()),
+                Some(json!({
+                    "operation": "lix_open",
+                    "retryable": false,
+                })),
+            )
+        }
+        LixRuntimeError::Open(error) => {
+            tracing::error!(error = %error, "failed to open lix runtime");
+            protocol_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                lix_sdk::LixError::CODE_INTERNAL_ERROR,
+                "Unable to open lix.",
+                None,
+                Some(json!({
+                    "operation": "lix_open",
+                    "retryable": false,
+                })),
+            )
+        }
+    }
+}
+
+fn is_unsupported_storage_format(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<lix_sdk::LixError>()
+            .is_some_and(|error| {
+                error.code == "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT"
+                    || (error.code == lix_sdk::LixError::CODE_INTERNAL_ERROR
+                        && error
+                            .message
+                            .contains("tracked_state commit_root has an unsupported format"))
+            })
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorEnvelope {
+    error: ErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    code: String,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<serde_json::Value>,
+}
+
+fn protocol_error(
+    status: StatusCode,
+    code: impl Into<String>,
+    message: impl Into<String>,
+    hint: Option<String>,
+    details: Option<serde_json::Value>,
+) -> Response {
+    let code = code.into();
+    tracing::Span::current().record("lix.error.code", code.as_str());
+    (
+        status,
+        Json(ErrorEnvelope {
+            error: ErrorBody {
+                code,
+                message: message.into(),
+                hint,
+                details,
+            },
+        }),
+    )
+        .into_response()
+}
+
+trait RetryAfterResponse {
+    fn with_retry_after(self) -> Self;
+}
+
+impl RetryAfterResponse for Response {
+    fn with_retry_after(mut self) -> Self {
+        self.headers_mut()
+            .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use flate2::{Compression, write::GzEncoder};
+    use http_body_util::BodyExt;
+    use lix_sdk::{Value as LixValue, WireValue};
+    use serde_json::{Value as JsonValue, json};
+    use std::{
+        io::Write as _,
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+    use tower::ServiceExt as _;
+
+    const TEST_PROTOCOL_TIMEOUT: Duration = Duration::from_secs(60);
+    const TEST_INTERNAL_TOKEN: &str = "test-internal-token";
+    const LIX_A: &str = "11111111-1111-4111-8111-111111111111";
+    const LIX_B: &str = "22222222-2222-4222-8222-222222222222";
+    const LIX_MARKDOWN: &str = "33333333-3333-4333-8333-333333333333";
+    static TEST_IDEMPOTENCY_KEY_SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+
+    fn test_router() -> Router {
+        let manager = LixRuntimeManager::new_in_memory(4);
+        router(
+            manager,
+            None,
+            TEST_PROTOCOL_TIMEOUT,
+            InFlightSqlRegistry::default(),
+        )
+    }
+
+    fn trusted_test_router() -> Router {
+        let manager = LixRuntimeManager::new_in_memory(4);
+        router(
+            manager,
+            Some(TEST_INTERNAL_TOKEN.to_string()),
+            TEST_PROTOCOL_TIMEOUT,
+            InFlightSqlRegistry::default(),
+        )
+    }
+
+    async fn json_body(response: Response) -> JsonValue {
+        serde_json::from_slice(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("response body")
+                .to_bytes(),
+        )
+        .expect("response JSON")
+    }
+
+    #[tokio::test]
+    async fn exposes_only_the_lix_addressed_protocol() {
+        let app = test_router();
+        let unscoped = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/")
+                    .body(Body::empty())
+                    .expect("unscoped request"),
+            )
+            .await
+            .expect("unscoped response");
+        assert_eq!(unscoped.status(), StatusCode::NOT_FOUND);
+
+        let legacy = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lixes/11111111-1111-4111-8111-111111111111/lix/v1/")
+                    .body(Body::empty())
+                    .expect("legacy request"),
+            )
+            .await
+            .expect("legacy response");
+        assert_eq!(legacy.status(), StatusCode::NOT_FOUND);
+
+        let handshake = app
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(handshake.status(), StatusCode::OK);
+        assert!(
+            handshake
+                .headers()
+                .get("server-timing")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("lix-server-protocol;dur=")),
+            "Lix protocol responses expose the canonical Server-Timing metric"
+        );
+        let handshake = json_body(handshake).await;
+        assert_eq!(
+            handshake["protocolVersion"],
+            json!(server_protocol::PROTOCOL_VERSION)
+        );
+        assert_eq!(
+            handshake["activeAccountId"],
+            json!(lix_sdk::ANONYMOUS_ACCOUNT_ID)
+        );
+        assert!(handshake["sessionId"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn snapshot_is_an_authenticated_canonical_protocol_stream() {
+        const ACCOUNT_ID: &str = "01920000-0000-7000-8000-000000000601";
+        let response = trusted_test_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/snapshot")
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {TEST_INTERNAL_TOKEN}"),
+                    )
+                    .header(TRUSTED_ACCOUNT_ID_HEADER, ACCOUNT_ID)
+                    .header(header::ACCEPT_ENCODING, "gzip")
+                    .body(Body::empty())
+                    .expect("snapshot request"),
+            )
+            .await
+            .expect("snapshot response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&HeaderValue::from_static(
+                server_protocol::SNAPSHOT_MEDIA_TYPE
+            ))
+        );
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL),
+            Some(&HeaderValue::from_static("no-store, no-transform"))
+        );
+        assert!(response.headers().get(header::CONTENT_ENCODING).is_none());
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("snapshot body")
+            .to_bytes();
+        assert!(bytes.starts_with(b"LIXSNAP"));
+    }
+
+    #[tokio::test]
+    async fn malformed_protocol_ids_do_not_open_storage() {
+        let manager = LixRuntimeManager::new_in_memory(1);
+        let app = router(
+            Arc::clone(&manager),
+            None,
+            TEST_PROTOCOL_TIMEOUT,
+            InFlightSqlRegistry::default(),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/not-a-uuid/snapshot")
+                    .body(Body::empty())
+                    .expect("malformed target request"),
+            )
+            .await
+            .expect("malformed target response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(manager.cached_lix_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn trusted_account_is_provisioned_bound_and_attributed_end_to_end() {
+        const ACCOUNT_ID: &str = "01920000-0000-7000-8000-000000000601";
+        const OTHER_ACCOUNT_ID: &str = "01920000-0000-7000-8000-000000000602";
+        let app = trusted_test_router();
+        let handshake = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/22222222-2222-4222-8222-222222222222/")
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {TEST_INTERNAL_TOKEN}"),
+                    )
+                    .header(TRUSTED_ACCOUNT_ID_HEADER, ACCOUNT_ID)
+                    .body(Body::empty())
+                    .expect("trusted handshake request"),
+            )
+            .await
+            .expect("trusted handshake response");
+        assert_eq!(handshake.status(), StatusCode::OK);
+        let handshake = json_body(handshake).await;
+        assert_eq!(handshake["activeAccountId"], ACCOUNT_ID);
+        let session_id = handshake["sessionId"].as_str().expect("session id");
+
+        let insert = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/22222222-2222-4222-8222-222222222222/execute")
+                    .header(server_protocol::SESSION_ID_HEADER, session_id)
+                    .header(server_protocol::IDEMPOTENCY_KEY_HEADER, "account-e2e-insert")
+                    .header(header::AUTHORIZATION, format!("Bearer {TEST_INTERNAL_TOKEN}"))
+                    .header(TRUSTED_ACCOUNT_ID_HEADER, ACCOUNT_ID)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"sql":"INSERT INTO lix_key_value (key, value) VALUES ('account-e2e', $1)","params":[{"kind":"jsonb","value":true}]}"#,
+                    ))
+                    .expect("attributed insert request"),
+            )
+            .await
+            .expect("attributed insert response");
+        assert_eq!(
+            insert.status(),
+            StatusCode::OK,
+            "{:?}",
+            json_body(insert).await
+        );
+
+        let attribution = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/22222222-2222-4222-8222-222222222222/execute")
+                    .header(server_protocol::SESSION_ID_HEADER, session_id)
+                    .header(header::AUTHORIZATION, format!("Bearer {TEST_INTERNAL_TOKEN}"))
+                    .header(TRUSTED_ACCOUNT_ID_HEADER, ACCOUNT_ID)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"sql":"SELECT account_id FROM lix_change WHERE schema_key = 'lix_key_value' ORDER BY created_at DESC LIMIT 1"}"#,
+                    ))
+                    .expect("attribution query request"),
+            )
+            .await
+            .expect("attribution query response");
+        assert_eq!(attribution.status(), StatusCode::OK);
+        assert_eq!(
+            json_body(attribution).await["rows"][0][0]["value"],
+            ACCOUNT_ID
+        );
+
+        let cross_account = app
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/22222222-2222-4222-8222-222222222222/")
+                    .header(server_protocol::SESSION_ID_HEADER, session_id)
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {TEST_INTERNAL_TOKEN}"),
+                    )
+                    .header(TRUSTED_ACCOUNT_ID_HEADER, OTHER_ACCOUNT_ID)
+                    .body(Body::empty())
+                    .expect("cross-account resume request"),
+            )
+            .await
+            .expect("cross-account resume response");
+        assert_eq!(cross_account.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            json_body(cross_account).await["error"]["code"],
+            "LIX_ERROR_PROTOCOL_ACCOUNT_MISMATCH"
+        );
+    }
+
+    #[tokio::test]
+    async fn decompresses_gzip_before_canonical_protocol_dispatch() {
+        let app = test_router();
+        let handshake = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/33333333-3333-4333-8333-333333333333/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        let session_id = json_body(handshake).await["sessionId"]
+            .as_str()
+            .expect("session id")
+            .to_owned();
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder
+            .write_all(br#"{"sql":"SELECT 1 AS value","params":[]}"#)
+            .expect("compress execute request");
+        let body = encoder.finish().expect("finish gzip request");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/33333333-3333-4333-8333-333333333333/execute")
+                    .header(server_protocol::SESSION_ID_HEADER, session_id)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header(header::CONTENT_ENCODING, "gzip")
+                    .body(Body::from(body))
+                    .expect("compressed execute request"),
+            )
+            .await
+            .expect("compressed execute response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(json_body(response).await["rows"][0][0]["value"], 1);
+    }
+
+    #[tokio::test]
+    async fn health_does_not_open_a_lix_or_require_authentication() {
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .expect("health request"),
+            )
+            .await
+            .expect("health response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            json_body(response).await,
+            json!({
+                "ok": true,
+                "service": "lix-server",
+                "storageBackend": "slatedb",
+                "storageLayout": "lix-slatedb-lz4-v1",
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_token_protects_lix_routes() {
+        let manager = LixRuntimeManager::new_in_memory(4);
+        let app = router(
+            manager,
+            Some("secret".to_string()),
+            TEST_PROTOCOL_TIMEOUT,
+            InFlightSqlRegistry::default(),
+        );
+
+        let unauthorized = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("unauthorized request"),
+            )
+            .await
+            .expect("unauthorized response");
+        assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            json_body(unauthorized).await["error"],
+            json!({
+                "code": "LIX_ERROR_UNAUTHENTICATED",
+                "message": "Invalid internal service token.",
+            })
+        );
+
+        let authorized = app
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .header(header::AUTHORIZATION, "Bearer secret")
+                    .body(Body::empty())
+                    .expect("authorized request"),
+            )
+            .await
+            .expect("authorized response");
+        assert_eq!(authorized.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn isolates_lix_data() {
+        let app = test_router();
+        let lix_a_session = open_protocol_session(app.clone(), LIX_A).await;
+        let insert = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/execute")
+                    .header(
+                        server_protocol::SESSION_ID_HEADER,
+                        &lix_a_session,
+                    )
+                    .header(server_protocol::IDEMPOTENCY_KEY_HEADER, "isolate-lix-a")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"sql":"INSERT INTO lix_file (path, content) VALUES ('/only-a.txt', CAST('A' AS BYTEA))"}"#,
+                    ))
+                    .expect("insert request"),
+            )
+            .await
+            .expect("insert response");
+        assert_eq!(
+            insert.status(),
+            StatusCode::OK,
+            "{:?}",
+            json_body(insert).await
+        );
+
+        for (lix_id, expected) in [(LIX_A, 1), (LIX_B, 0)] {
+            let session_id = if lix_id == LIX_A {
+                lix_a_session.clone()
+            } else {
+                open_protocol_session(app.clone(), lix_id).await
+            };
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!(
+                            "/lix/v1/{lix_id}/execute"
+                        ))
+                        .header(server_protocol::SESSION_ID_HEADER, session_id)
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            r#"{"sql":"SELECT COUNT(*) AS count FROM lix_file WHERE path = '/only-a.txt'"}"#,
+                        ))
+                        .expect("count request"),
+                )
+                .await
+                .expect("count response");
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(json_body(response).await["rows"][0][0]["value"], expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn strict_remote_sessions_merge_disjoint_markdown_blob_edits() {
+        let archive_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(
+                "../vendor/lix/packages/js-sdk/dist/bundled-plugins/plugin_markdown_incremental_v2.lixplugin",
+            );
+        let Ok(markdown_plugin) = std::fs::read(&archive_path) else {
+            // The root pnpm install supplies bundled plugins. Keep standalone
+            // Rust development usable before that generated artifact exists.
+            eprintln!(
+                "skipping native Markdown protocol test; build {} first",
+                archive_path.display()
+            );
+            return;
+        };
+
+        let app = test_router();
+        let lix_id = LIX_MARKDOWN;
+        let installer = open_protocol_session(app.clone(), lix_id).await;
+        expect_protocol_ok(
+            protocol_execute(
+                app.clone(),
+                lix_id,
+                &installer,
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                vec![
+                    wire_value(LixValue::Text(
+                        "/.lix/plugins/plugin_markdown_incremental_v2.lixplugin".to_string(),
+                    )),
+                    wire_value(LixValue::Blob(markdown_plugin.into())),
+                ],
+            )
+            .await,
+        )
+        .await;
+
+        let session_a = open_protocol_session(app.clone(), lix_id).await;
+        let session_b = open_protocol_session(app.clone(), lix_id).await;
+        let path = "/shared.md";
+        let seed = b"# Shared\n\nLeft: 0\n\nRight: 0\n".to_vec();
+        expect_protocol_ok(
+            protocol_execute(
+                app.clone(),
+                lix_id,
+                &session_a,
+                "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+                vec![
+                    wire_value(LixValue::Text(path.to_string())),
+                    wire_value(LixValue::Blob(seed.clone().into())),
+                ],
+            )
+            .await,
+        )
+        .await;
+
+        for session_id in [&session_a, &session_b] {
+            let delivered = expect_protocol_ok(
+                protocol_execute(
+                    app.clone(),
+                    lix_id,
+                    session_id,
+                    "SELECT content FROM lix_file WHERE path = $1",
+                    vec![wire_value(LixValue::Text(path.to_string()))],
+                )
+                .await,
+            )
+            .await;
+            assert_eq!(wire_blob(&delivered), seed);
+        }
+
+        let write_a = protocol_execute(
+            app.clone(),
+            lix_id,
+            &session_a,
+            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            vec![
+                wire_value(LixValue::Blob(
+                    b"# Shared\n\nLeft: A\n\nRight: 0\n".to_vec().into(),
+                )),
+                wire_value(LixValue::Text(path.to_string())),
+            ],
+        );
+        let write_b = protocol_execute(
+            app.clone(),
+            lix_id,
+            &session_b,
+            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            vec![
+                wire_value(LixValue::Blob(
+                    b"# Shared\n\nLeft: 0\n\nRight: B\n".to_vec().into(),
+                )),
+                wire_value(LixValue::Text(path.to_string())),
+            ],
+        );
+        let (write_a, write_b) = tokio::join!(write_a, write_b);
+        expect_protocol_ok(write_a).await;
+        expect_protocol_ok(write_b).await;
+
+        let merged = expect_protocol_ok(
+            protocol_execute(
+                app.clone(),
+                lix_id,
+                &session_a,
+                "SELECT content FROM lix_file WHERE path = $1",
+                vec![wire_value(LixValue::Text(path.to_string()))],
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(
+            String::from_utf8(wire_blob(&merged)).expect("merged Markdown should be UTF-8"),
+            "# Shared\n\nLeft: A\n\nRight: B\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_lix_ids_are_not_found_before_storage_open() {
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/contains%20space/")
+                    .body(Body::empty())
+                    .expect("unsafe request"),
+            )
+            .await
+            .expect("unsafe response");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(json_body(response).await["error"]["code"], "LIX_NOT_FOUND");
+    }
+
+    #[tokio::test]
+    async fn unsupported_storage_format_is_a_terminal_structured_error() {
+        let response = lix_error(LixRuntimeError::Open(anyhow::Error::new(
+            lix_sdk::LixError::new(
+                "LIX_ERROR_UNSUPPORTED_STORAGE_FORMAT",
+                "repository uses an unsupported storage protocol; recreate the repository",
+            ),
+        )));
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
+        assert_eq!(
+            json_body(response).await["error"],
+            json!({
+                "code": "LIX_ERROR_STORAGE_FORMAT_UNSUPPORTED",
+                "message": "This lix uses an unsupported storage format.",
+                "hint": "Create a new lix.",
+                "details": {
+                    "operation": "lix_open",
+                    "retryable": false,
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn migrating_lix_is_a_retryable_structured_state() {
+        let response = lix_error(LixRuntimeError::Migrating {
+            from_version: 68,
+            to_version: 71,
+        });
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[header::RETRY_AFTER], "1");
+        assert_eq!(
+            json_body(response).await["error"],
+            json!({
+                "code": "LIX_ERROR_LIX_MIGRATING",
+                "message": "The lix repository is being migrated.",
+                "hint": "Retry after the migration completes.",
+                "details": {
+                    "fromVersion": 68,
+                    "toVersion": 71,
+                    "operation": "lix_open",
+                    "retryable": true,
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_lix_migration_is_a_terminal_structured_error() {
+        let response = lix_error(LixRuntimeError::MigrationFailed {
+            from_version: 68,
+            to_version: 71,
+        });
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!response.headers().contains_key(header::RETRY_AFTER));
+        assert_eq!(
+            json_body(response).await["error"],
+            json!({
+                "code": "LIX_ERROR_LIX_MIGRATION_FAILED",
+                "message": "The lix repository migration failed.",
+                "hint": "Contact the service operator to recover the repository.",
+                "details": {
+                    "fromVersion": 68,
+                    "toVersion": 71,
+                    "operation": "lix_open",
+                    "retryable": false,
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_progress_upgrade_failure_is_a_terminal_structured_error() {
+        let response = lix_error(LixRuntimeError::UpgradeFailed);
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(!response.headers().contains_key(header::RETRY_AFTER));
+        assert_eq!(
+            json_body(response).await["error"],
+            json!({
+                "code": "LIX_ERROR_LIX_MIGRATION_FAILED",
+                "message": "The lix repository upgrade failed.",
+                "hint": "Contact the service operator to recover the repository.",
+                "details": {
+                    "operation": "lix_open",
+                    "retryable": false,
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn unexpected_lix_open_errors_are_redacted() {
+        let response = lix_error(LixRuntimeError::Open(anyhow::anyhow!(
+            "secret object-store failure"
+        )));
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            json_body(response).await["error"],
+            json!({
+                "code": "LIX_INTERNAL_ERROR",
+                "message": "Unable to open lix.",
+                "details": {
+                    "operation": "lix_open",
+                    "retryable": false,
+                },
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_cleanup_errors_require_operator_repair_and_are_redacted() {
+        let response = lix_error(LixRuntimeError::Cleanup(Arc::from(
+            "delete /cache/tenant-a/secret-object failed",
+        )));
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(!response.headers().contains_key(header::RETRY_AFTER));
+        let body = json_body(response).await;
+        assert_eq!(
+            body["error"],
+            json!({
+                "code": "LIX_ERROR_LIX_CACHE_CLEANUP",
+                "message": "The lix service cache needs operator repair.",
+                "hint": "Contact the service operator to repair the cache and restart the server.",
+                "details": {
+                    "operation": "lix_open",
+                    "retryable": false,
+                },
+            })
+        );
+        assert!(!body.to_string().contains("tenant-a"));
+    }
+
+    #[tokio::test]
+    async fn timed_out_protocol_requests_are_not_advertised_as_retryable() {
+        let response = protocol_timeout_response();
+
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
+        let error = json_body(response).await["error"].clone();
+        assert_eq!(error["code"], "LIX_ERROR_LIX_TIMEOUT");
+        assert_eq!(error["details"]["operation"], "lix_request");
+        assert_eq!(error["details"]["retryable"], false);
+        assert_eq!(error["details"]["outcome"], "unknown");
+    }
+
+    #[test]
+    fn trusted_principal_is_removed_from_headers_before_protocol_dispatch() {
+        let mut request = Request::builder()
+            .header(TRUSTED_ACCOUNT_ID_HEADER, "user-123")
+            .header(TRUSTED_IDEMPOTENCY_SCOPE_HEADER, "provider:user-123")
+            .body(Body::empty())
+            .expect("trusted scope request");
+
+        let principal = take_trusted_principal(&mut request, true)
+            .expect("valid trusted scope")
+            .expect("trusted scope should be present");
+        assert_eq!(principal.account_id, "user-123");
+        assert_eq!(principal.idempotency_scope, "provider:user-123");
+
+        assert!(request.headers().get(TRUSTED_ACCOUNT_ID_HEADER).is_none());
+        assert!(
+            request
+                .headers()
+                .get(TRUSTED_IDEMPOTENCY_SCOPE_HEADER)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn trusted_principal_is_rejected_without_internal_auth() {
+        let mut request = Request::builder()
+            .header(TRUSTED_ACCOUNT_ID_HEADER, "user-123")
+            .body(Body::empty())
+            .expect("untrusted principal request");
+
+        let error = take_trusted_principal(&mut request, false).unwrap_err();
+
+        assert_eq!(
+            error,
+            "Trusted principal headers require LIX_SERVER_INTERNAL_TOKEN."
+        );
+    }
+
+    #[tokio::test]
+    async fn client_cannot_select_an_active_account_in_the_handshake() {
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111?activeAccountId=spoofed")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn cancelled_nonterminal_request_does_not_recover_its_runtime() {
+        let manager = LixRuntimeManager::new_in_memory(1);
+        let service = manager.get(LIX_A).await.expect("open lix runtime");
+        let (notifier, signal) = server_protocol::durable_terminal_storage_signal();
+        let cancellation_recovery = CancellationRecovery::new(
+            signal,
+            Arc::clone(&manager),
+            LIX_A.to_string(),
+            Arc::clone(&service),
+        );
+
+        drop(notifier);
+        drop(cancellation_recovery);
+        tokio::task::yield_now().await;
+
+        let still_active = manager.get(LIX_A).await.expect("active lix runtime");
+        assert!(Arc::ptr_eq(&service, &still_active));
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_terminal_response_recovery_still_starts_runtime_recovery() {
+        let manager = LixRuntimeManager::new_in_memory(1);
+        let service = manager.get(LIX_A).await.expect("open lix runtime");
+        let (notifier, signal) = server_protocol::durable_terminal_storage_signal();
+        let mut cancellation_recovery = CancellationRecovery::new(
+            signal,
+            Arc::clone(&manager),
+            LIX_A.to_string(),
+            Arc::clone(&service),
+        );
+
+        drop(notifier);
+        cancellation_recovery.recover_on_drop();
+        drop(cancellation_recovery);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match manager.get(LIX_A).await {
+                    Err(LixRuntimeError::Recovering) => return,
+                    Ok(_) => tokio::time::sleep(Duration::from_millis(1)).await,
+                    Err(error) => panic!("unexpected runtime state: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("cancellation recovery should start runtime recovery");
+        drop(service);
+
+        // Recovery closes the protocol on a blocking task. Do not let the
+        // Tokio test runtime start shutting down while that task still needs
+        // the runtime's drivers to finish. Reopening the same ID joins the
+        // cleanup tombstone and proves the old runtime was fully retired.
+        let replacement = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match manager.get(LIX_A).await {
+                    Ok(replacement) => return replacement,
+                    Err(LixRuntimeError::Recovering) => {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                    }
+                    Err(error) => panic!("unexpected replacement runtime state: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("cancellation recovery should finish");
+        drop(replacement);
+        manager
+            .shutdown()
+            .await
+            .expect("replacement runtime should close cleanly");
+    }
+
+    #[tokio::test]
+    async fn retryable_lix_errors_include_retry_after() {
+        for error in [
+            LixRuntimeError::AtCapacity { max: 4 },
+            LixRuntimeError::Migrating {
+                from_version: 68,
+                to_version: 71,
+            },
+            LixRuntimeError::Recovering,
+            LixRuntimeError::ShuttingDown,
+        ] {
+            let response = lix_error(error);
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(response.headers()[header::RETRY_AFTER], "1");
+            assert_eq!(
+                json_body(response).await["error"]["details"]["retryable"],
+                true
+            );
+        }
+    }
+
+    async fn protocol_execute(
+        app: Router,
+        lix_id: &str,
+        session_id: &str,
+        sql: &str,
+        params: Vec<JsonValue>,
+    ) -> Response {
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/lix/v1/{lix_id}/execute"))
+                .header(server_protocol::SESSION_ID_HEADER, session_id)
+                .header(
+                    server_protocol::IDEMPOTENCY_KEY_HEADER,
+                    format!(
+                        "lix-server-test-{}",
+                        TEST_IDEMPOTENCY_KEY_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+                    ),
+                )
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "sql": sql, "params": params }).to_string(),
+                ))
+                .expect("protocol execute request"),
+        )
+        .await
+        .expect("protocol execute response")
+    }
+
+    async fn expect_protocol_ok(response: Response) -> JsonValue {
+        let status = response.status();
+        let body = json_body(response).await;
+        assert_eq!(status, StatusCode::OK, "protocol response: {body}");
+        body
+    }
+
+    fn wire_value(value: LixValue) -> JsonValue {
+        serde_json::to_value(
+            WireValue::try_from_engine(&value).expect("test value should encode to wire format"),
+        )
+        .expect("wire value should serialize")
+    }
+
+    fn wire_blob(response: &JsonValue) -> Vec<u8> {
+        let wire: WireValue = serde_json::from_value(response["rows"][0][0].clone())
+            .expect("execute response should contain a wire value");
+        let LixValue::Blob(bytes) = wire
+            .try_into_engine()
+            .expect("wire blob should decode into an engine value")
+        else {
+            panic!("execute response should contain a blob");
+        };
+        bytes.to_vec()
+    }
+
+    async fn open_protocol_session(app: Router, lix_id: &str) -> String {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/lix/v1/{lix_id}/"))
+                    .body(Body::empty())
+                    .expect("protocol handshake request"),
+            )
+            .await
+            .expect("protocol handshake response");
+        assert_eq!(response.status(), StatusCode::OK);
+        json_body(response).await["sessionId"]
+            .as_str()
+            .expect("handshake session id")
+            .to_string()
+    }
+}

--- a/packages/server/src/store.rs
+++ b/packages/server/src/store.rs
@@ -1,0 +1,3221 @@
+use crate::{Config, config::SlateDBCacheConfig};
+use anyhow::{Context, Result};
+use axum::{body::Body, http::Request};
+use blake3::Hasher;
+use fs2::FileExt as _;
+use futures_util::TryStreamExt as _;
+use lix_sdk::server_protocol::{
+    LixServerProtocol, ServerProtocolBody, ServerProtocolContext, ServerProtocolResponse,
+};
+use lix_slatedb_storage::{
+    SlateDB, SlateDBCacheOptions, SlateDBIoCounters, SlateDBObjectStoreOptions,
+};
+#[cfg(test)]
+use object_store::memory::InMemory;
+#[cfg(test)]
+use object_store::{ClientConfigKey, ObjectStoreExt, path::Path as ObjectPath};
+use object_store::{ClientOptions, ObjectStore, RetryConfig, aws::AmazonS3Builder};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::runtime::Handle;
+#[cfg(test)]
+use tokio::sync::Notify;
+use tokio::sync::{Mutex, OnceCell, watch};
+use tokio::task::JoinSet;
+use tracing::{Instrument, info, info_span};
+
+#[cfg(test)]
+fn test_telemetry_sink() -> Arc<dyn lix_sdk::telemetry::TelemetrySink> {
+    Arc::new(lix_sdk::telemetry::CallbackTelemetrySink::new(|_| {}))
+}
+
+// The Lix SlateDB adapter fetches object-store cache parts in 2 MiB chunks.
+// A 15 second request timeout still permits a part to arrive at roughly 140
+// KiB/s, while a single stalled request can no longer occupy a lix runtime
+// for the object_store default three-minute retry budget. One retry preserves recovery
+// from a transient slow path without turning an interactive request into a
+// multi-minute wait.
+const S3_REQUEST_BUDGET: S3RequestBudget = S3RequestBudget {
+    request_timeout: Duration::from_secs(15),
+    connect_timeout: Duration::from_secs(3),
+    retry_timeout: Duration::from_secs(30),
+    max_retries: 1,
+};
+
+const CACHE_NAMESPACE_LAYOUT: &[u8] = b"lix-server-slatedb-cache\0v1";
+// This cannot be a legacy Lix cache child: Lix IDs do not permit dots.
+const CACHE_NAMESPACE_PARENT: &str = ".lix-server-cache-v1";
+
+// These identifiers describe the physical store opened by this manager, not a
+// benchmark caller's requested cohort. Keep them alongside the adapter so a
+// future backend or layout change must update the server attestation too.
+const STORAGE_BACKEND: &str = "slatedb";
+const STORAGE_LAYOUT: &str = "lix-slatedb-lz4-v1";
+
+#[derive(Clone, Copy)]
+struct S3RequestBudget {
+    request_timeout: Duration,
+    connect_timeout: Duration,
+    retry_timeout: Duration,
+    max_retries: usize,
+}
+
+pub(crate) struct LixService {
+    protocol: LixServerProtocol<SlateDB>,
+}
+
+struct LixRuntime {
+    state: Mutex<LixRuntimeState>,
+}
+
+enum LixRuntimeState {
+    Active(Arc<LixService>),
+    Recovering(Arc<LixService>),
+    Evicting,
+}
+
+pub struct LixRuntimeManager {
+    backend: StorageBackend,
+    max_open_lixes: usize,
+    recovery_watchdog: RecoveryWatchdog,
+    state: Mutex<ManagerState>,
+    telemetry: Arc<dyn lix_sdk::telemetry::TelemetrySink>,
+    #[cfg(test)]
+    open_gate: Option<TestOpenGate>,
+    // Keep this last: struct fields drop in declaration order. The exclusive
+    // cache-root lease must outlive every retained Lix runtime and its
+    // SlateDB workers during manager teardown.
+    _cache_root_lease: Option<CacheRootLease>,
+}
+
+impl fmt::Debug for LixRuntimeManager {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LixRuntimeManager")
+            .field("storage_backend", &self.storage_backend())
+            .field("storage_layout", &self.storage_layout())
+            .field("max_open_lixes", &self.max_open_lixes)
+            .finish_non_exhaustive()
+    }
+}
+
+type RecoveryTimeoutAction = dyn Fn() + Send + Sync;
+
+struct RecoveryWatchdog {
+    timeout: Duration,
+    on_timeout: Arc<RecoveryTimeoutAction>,
+}
+
+impl RecoveryWatchdog {
+    fn production(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            on_timeout: Arc::new(|| std::process::abort()),
+        }
+    }
+
+    #[cfg(test)]
+    fn test_default() -> Self {
+        Self {
+            timeout: Duration::from_secs(30),
+            on_timeout: Arc::new(|| panic!("recovery close watchdog fired in a test")),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum StorageBackend {
+    #[cfg(test)]
+    Memory { object_store: Arc<dyn ObjectStore> },
+    S3 {
+        object_store: Arc<dyn ObjectStore>,
+        prefix: String,
+        cache: SlateDBCacheOptions,
+    },
+}
+
+#[derive(Default)]
+struct ManagerState {
+    entries: HashMap<String, RuntimeEntry>,
+    cleaning: HashMap<String, CleanupTombstone>,
+    failed_upgrades: HashMap<String, FailedUpgrade>,
+    shutting_down: bool,
+    clock: u64,
+    cleanup_sequence: u64,
+    #[cfg(test)]
+    state_drop_probe: Option<CacheRootLeaseDropProbe>,
+}
+
+#[derive(Clone, Copy)]
+struct FailedMigration {
+    from_version: u32,
+    to_version: u32,
+}
+
+#[derive(Clone, Copy)]
+enum FailedUpgrade {
+    Versioned(FailedMigration),
+    Unversioned,
+}
+
+#[cfg(test)]
+struct CacheRootLeaseDropProbe {
+    root: PathBuf,
+    observed_lease_held: Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[cfg(test)]
+impl Drop for CacheRootLeaseDropProbe {
+    fn drop(&mut self) {
+        self.observed_lease_held.store(
+            CacheRootLease::acquire(&self.root).is_err(),
+            std::sync::atomic::Ordering::SeqCst,
+        );
+    }
+}
+
+struct RuntimeEntry {
+    runtime: Arc<OnceCell<Arc<LixRuntime>>>,
+    opened: watch::Receiver<RuntimeOpenState>,
+    last_used: u64,
+}
+
+#[derive(Debug)]
+struct CacheRootLease {
+    _owner_lock: File,
+}
+
+struct CleanupTombstone {
+    sequence: u64,
+    done: watch::Receiver<CleanupState>,
+}
+
+struct EvictedRuntime {
+    lix_id: String,
+    runtime: Arc<LixRuntime>,
+    service: Arc<LixService>,
+    sequence: u64,
+    done: watch::Sender<CleanupState>,
+}
+
+#[derive(Clone)]
+enum CleanupState {
+    Running,
+    Complete,
+    Failed(Arc<str>),
+}
+
+#[derive(Clone)]
+enum RuntimeOpenState {
+    Opening,
+    Migrating { from_version: u32, to_version: u32 },
+    MigrationFailed { from_version: u32, to_version: u32 },
+    UpgradeFailed,
+    Ready,
+    Failed(Arc<str>),
+}
+
+fn runtime_open_state_from_progress(progress: lix_sdk::OpenProgress) -> Option<RuntimeOpenState> {
+    match progress.phase {
+        lix_sdk::OpenPhase::Migrating | lix_sdk::OpenPhase::Validating => {
+            progress
+                .from_format
+                .map(|from_version| RuntimeOpenState::Migrating {
+                    from_version,
+                    to_version: progress.to_format,
+                })
+        }
+        lix_sdk::OpenPhase::Opening => Some(RuntimeOpenState::Opening),
+        _ => None,
+    }
+}
+
+fn runtime_error_from_failed_upgrade(failure: FailedUpgrade) -> LixRuntimeError {
+    match failure {
+        FailedUpgrade::Versioned(failure) => LixRuntimeError::MigrationFailed {
+            from_version: failure.from_version,
+            to_version: failure.to_version,
+        },
+        FailedUpgrade::Unversioned => LixRuntimeError::UpgradeFailed,
+    }
+}
+
+fn is_repository_upgrade_failure(error: &anyhow::Error) -> bool {
+    error.chain().any(|source| {
+        source
+            .downcast_ref::<lix_sdk::LixError>()
+            .is_some_and(|error| error.code == "LIX_ERROR_MIGRATION_FAILED")
+    })
+}
+
+struct PendingRuntimeOpen {
+    lix_id: String,
+    runtime: Arc<OnceCell<Arc<LixRuntime>>>,
+    done: watch::Sender<RuntimeOpenState>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct TestOpenGate {
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+    starts: Arc<std::sync::atomic::AtomicUsize>,
+    fail_next: Arc<std::sync::atomic::AtomicBool>,
+}
+
+enum GetRuntimeAction {
+    WaitForCleanup(watch::Receiver<CleanupState>),
+    EvictAndWait {
+        evicted: EvictedRuntime,
+        cleanup: watch::Receiver<CleanupState>,
+    },
+    WaitForOpen {
+        runtime: Arc<OnceCell<Arc<LixRuntime>>>,
+        opened: watch::Receiver<RuntimeOpenState>,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) enum LixRuntimeError {
+    InvalidId,
+    AtCapacity { max: usize },
+    Migrating { from_version: u32, to_version: u32 },
+    MigrationFailed { from_version: u32, to_version: u32 },
+    UpgradeFailed,
+    Recovering,
+    ShuttingDown,
+    Cleanup(Arc<str>),
+    Open(anyhow::Error),
+}
+
+impl LixRuntimeManager {
+    pub fn new(
+        config: &Config,
+        telemetry: Arc<dyn lix_sdk::telemetry::TelemetrySink>,
+    ) -> Result<Arc<Self>> {
+        let storage = &config.storage;
+        let request_budget = S3_REQUEST_BUDGET;
+        // The configured root is the single-process ownership boundary. The
+        // derived namespace is only where this backend's cached bytes live.
+        // Keeping these paths distinct prevents a backend change from
+        // bypassing cache ownership or consuming stale cached object data.
+        let owner_root = &storage.cache.root_folder;
+        let cache_root_lease = CacheRootLease::acquire(owner_root)?;
+        let namespace_root = cache_namespace_root(
+            owner_root,
+            &storage.endpoint,
+            &storage.bucket,
+            &storage.region,
+            &storage.prefix,
+            &storage.access_key_id,
+        );
+        prepare_cache_namespace(owner_root, &namespace_root)?;
+        let cache = cache_options(&storage.cache, config.max_open_lixes, namespace_root);
+        let object_store: Arc<dyn ObjectStore> = Arc::new(
+            AmazonS3Builder::new()
+                .with_endpoint(&storage.endpoint)
+                .with_bucket_name(&storage.bucket)
+                .with_access_key_id(&storage.access_key_id)
+                .with_secret_access_key(&storage.secret_access_key)
+                .with_region(&storage.region)
+                .with_virtual_hosted_style_request(false)
+                .with_client_options(s3_client_options(request_budget))
+                .with_retry(s3_retry_config(request_budget))
+                .with_allow_http(storage.allow_http)
+                .build()
+                .context("build S3 object store")?,
+        );
+        let backend = StorageBackend::S3 {
+            object_store,
+            prefix: storage.prefix.clone(),
+            cache,
+        };
+
+        Ok(Arc::new(Self {
+            backend,
+            max_open_lixes: config.max_open_lixes,
+            recovery_watchdog: RecoveryWatchdog::production(config.recovery_close_timeout),
+            state: Mutex::new(ManagerState::default()),
+            telemetry,
+            #[cfg(test)]
+            open_gate: None,
+            _cache_root_lease: Some(cache_root_lease),
+        }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_in_memory(max_open_lixes: usize) -> Arc<Self> {
+        Arc::new(Self {
+            backend: StorageBackend::Memory {
+                object_store: Arc::new(InMemory::new()),
+            },
+            max_open_lixes,
+            recovery_watchdog: RecoveryWatchdog::test_default(),
+            state: Mutex::new(ManagerState::default()),
+            telemetry: test_telemetry_sink(),
+            open_gate: None,
+            _cache_root_lease: None,
+        })
+    }
+
+    pub(crate) fn storage_backend(&self) -> &'static str {
+        STORAGE_BACKEND
+    }
+
+    pub(crate) fn storage_layout(&self) -> &'static str {
+        STORAGE_LAYOUT
+    }
+
+    pub(crate) async fn get(
+        self: &Arc<Self>,
+        lix_id: &str,
+    ) -> std::result::Result<Arc<LixService>, LixRuntimeError> {
+        if !valid_lix_id(lix_id) {
+            return Err(LixRuntimeError::InvalidId);
+        }
+
+        let runtime_cell = 'select_runtime: loop {
+            let action = {
+                let mut state = self.state.lock().await;
+                if state.shutting_down {
+                    return Err(LixRuntimeError::ShuttingDown);
+                } else if let Some(cleanup) = state.cleaning.get(lix_id) {
+                    GetRuntimeAction::WaitForCleanup(cleanup.done.clone())
+                } else if let Some(failure) = state.failed_upgrades.get(lix_id) {
+                    return Err(runtime_error_from_failed_upgrade(*failure));
+                } else if state.entries.contains_key(lix_id) {
+                    state.clock = state.clock.wrapping_add(1);
+                    let now = state.clock;
+                    let entry = state
+                        .entries
+                        .get_mut(lix_id)
+                        .expect("entry was present when updating Lix recency");
+                    entry.last_used = now;
+                    GetRuntimeAction::WaitForOpen {
+                        runtime: Arc::clone(&entry.runtime),
+                        opened: entry.opened.clone(),
+                    }
+                } else if state.entries.len() + state.cleaning.len() >= self.max_open_lixes {
+                    // An eviction remains a live SlateDB runtime until its
+                    // protocol has closed and its cache child is retired.
+                    // Count it against the same cap so churn cannot bypass
+                    // the server-wide resource bound with closing runtimes.
+                    if let Some(cleanup) = state
+                        .cleaning
+                        .values()
+                        .min_by_key(|cleanup| cleanup.sequence)
+                    {
+                        GetRuntimeAction::WaitForCleanup(cleanup.done.clone())
+                    } else {
+                        let Some((eviction_id, runtime, service)) =
+                            take_idle_lru_runtime(&mut state.entries)
+                        else {
+                            return Err(LixRuntimeError::AtCapacity {
+                                max: self.max_open_lixes,
+                            });
+                        };
+                        let (sequence, done) = start_cleanup(&mut state, eviction_id.clone())
+                            .expect("an active runtime cannot already be cleaning");
+                        let cleanup = state
+                            .cleaning
+                            .get(&eviction_id)
+                            .expect("started cleanup must retain a waiter")
+                            .done
+                            .clone();
+                        GetRuntimeAction::EvictAndWait {
+                            evicted: EvictedRuntime {
+                                lix_id: eviction_id,
+                                runtime,
+                                service,
+                                sequence,
+                                done,
+                            },
+                            cleanup,
+                        }
+                    }
+                } else {
+                    state.clock = state.clock.wrapping_add(1);
+                    let now = state.clock;
+                    let runtime = Arc::new(OnceCell::new());
+                    let (done, opened) = watch::channel(RuntimeOpenState::Opening);
+                    state.entries.insert(
+                        lix_id.to_string(),
+                        RuntimeEntry {
+                            runtime: Arc::clone(&runtime),
+                            opened: opened.clone(),
+                            last_used: now,
+                        },
+                    );
+                    // The manager, rather than this request, owns opening.
+                    // `get` callers may be cancelled without leaving an
+                    // empty entry or detaching a second same-ID opener.
+                    self.spawn_runtime_open(PendingRuntimeOpen {
+                        lix_id: lix_id.to_string(),
+                        runtime: Arc::clone(&runtime),
+                        done,
+                    });
+                    GetRuntimeAction::WaitForOpen { runtime, opened }
+                }
+            };
+
+            match action {
+                GetRuntimeAction::WaitForCleanup(mut cleanup) => {
+                    // The sender is dropped after the old runtime has closed
+                    // and its cache child has been retired and deleted.
+                    // `watch` makes this wait immune to a completion racing
+                    // with receiver registration.
+                    self.wait_for_cleanup(&mut cleanup).await?;
+                }
+                GetRuntimeAction::EvictAndWait {
+                    evicted,
+                    mut cleanup,
+                } => {
+                    self.spawn_eviction_cleanup(evicted);
+                    self.wait_for_cleanup(&mut cleanup).await?;
+                }
+                GetRuntimeAction::WaitForOpen {
+                    runtime,
+                    mut opened,
+                } => loop {
+                    let open_state = opened.borrow().clone();
+                    match open_state {
+                        RuntimeOpenState::Ready => break 'select_runtime runtime,
+                        RuntimeOpenState::Failed(error) => {
+                            return Err(LixRuntimeError::Open(anyhow::anyhow!(
+                                "open lix runtime: {error}"
+                            )));
+                        }
+                        RuntimeOpenState::Migrating {
+                            from_version,
+                            to_version,
+                        } => {
+                            return Err(LixRuntimeError::Migrating {
+                                from_version,
+                                to_version,
+                            });
+                        }
+                        RuntimeOpenState::MigrationFailed {
+                            from_version,
+                            to_version,
+                        } => {
+                            return Err(LixRuntimeError::MigrationFailed {
+                                from_version,
+                                to_version,
+                            });
+                        }
+                        RuntimeOpenState::UpgradeFailed => {
+                            return Err(LixRuntimeError::UpgradeFailed);
+                        }
+                        RuntimeOpenState::Opening => {
+                            if opened.changed().await.is_err() {
+                                return Err(LixRuntimeError::Open(anyhow::anyhow!(
+                                    "lix runtime opener stopped before completing"
+                                )));
+                            }
+                        }
+                    }
+                },
+            }
+        };
+
+        let runtime = runtime_cell
+            .get()
+            .expect("runtime opener reported success before storing its runtime");
+        if self.state.lock().await.shutting_down {
+            return Err(LixRuntimeError::ShuttingDown);
+        }
+        match runtime.acquire().await {
+            Some(service) => Ok(service),
+            None => Err(LixRuntimeError::Recovering),
+        }
+    }
+
+    fn spawn_runtime_open(self: &Arc<Self>, opener: PendingRuntimeOpen) {
+        let manager = Arc::clone(self);
+        let span = info_span!(
+            "lix.runtime.open",
+            lix.id = %opener.lix_id,
+            storage.backend = STORAGE_BACKEND,
+        );
+        tokio::spawn(
+            async move {
+                let opened = manager
+                    .open_lix_for_handler(opener.lix_id.clone(), opener.done.clone())
+                    .await;
+                match opened {
+                    Ok(runtime) => {
+                        assert!(
+                            opener.runtime.set(runtime).is_ok(),
+                            "managed opener is the sole OnceCell initializer"
+                        );
+                        opener.done.send_replace(RuntimeOpenState::Ready);
+                    }
+                    Err(error) => {
+                        let failed_upgrade = match opener.done.borrow().clone() {
+                            RuntimeOpenState::Migrating {
+                                from_version,
+                                to_version,
+                            } => Some(FailedUpgrade::Versioned(FailedMigration {
+                                from_version,
+                                to_version,
+                            })),
+                            _ if is_repository_upgrade_failure(&error) => {
+                                Some(FailedUpgrade::Unversioned)
+                            }
+                            _ => None,
+                        };
+                        // Preserve the complete anyhow/Lix error chain after it crosses
+                        // this async opener boundary while keeping one physical log line.
+                        let error = Arc::<str>::from(format!("{error:#}").replace('\n', " | "));
+                        if let Some(failure) = failed_upgrade {
+                            match failure {
+                                FailedUpgrade::Versioned(failure) => {
+                                    tracing::error!(
+                                        lix_id = %opener.lix_id,
+                                        from_version = failure.from_version,
+                                        to_version = failure.to_version,
+                                        error = %error,
+                                        "Lix repository migration failed"
+                                    );
+                                    opener.done.send_replace(RuntimeOpenState::MigrationFailed {
+                                        from_version: failure.from_version,
+                                        to_version: failure.to_version,
+                                    });
+                                }
+                                FailedUpgrade::Unversioned => {
+                                    tracing::error!(
+                                        lix_id = %opener.lix_id,
+                                        error = %error,
+                                        "Lix repository upgrade failed"
+                                    );
+                                    opener.done.send_replace(RuntimeOpenState::UpgradeFailed);
+                                }
+                            }
+                        }
+                        if let Some((sequence, done)) = manager
+                            .begin_failed_open_cleanup(&opener.lix_id, &opener.runtime)
+                            .await
+                        {
+                            let cleanup = manager
+                                .retire_and_delete_cache_child(&opener.lix_id, sequence)
+                                .await;
+                            if cleanup.is_ok() {
+                                if let Some(failure) = failed_upgrade {
+                                    manager
+                                        .state
+                                        .lock()
+                                        .await
+                                        .failed_upgrades
+                                        .insert(opener.lix_id.clone(), failure);
+                                }
+                            }
+                            manager
+                                .finish_cleanup(&opener.lix_id, sequence, done, cleanup)
+                                .await;
+                        }
+                        if failed_upgrade.is_none() {
+                            opener.done.send_replace(RuntimeOpenState::Failed(error));
+                        }
+                    }
+                }
+            }
+            .instrument(span),
+        );
+    }
+
+    async fn open_lix_for_handler(
+        self: &Arc<Self>,
+        lix_id: String,
+        opened: watch::Sender<RuntimeOpenState>,
+    ) -> Result<Arc<LixRuntime>> {
+        #[cfg(test)]
+        if let Some(gate) = &self.open_gate {
+            gate.starts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            gate.started.notify_one();
+            gate.release.notified().await;
+            if gate
+                .fail_next
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(anyhow::anyhow!("test-controlled Lix open failure"));
+            }
+        }
+        let manager = Arc::clone(self);
+        let runtime = Handle::current();
+        let span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            runtime.block_on(manager.open_lix(&lix_id, &opened).instrument(span))
+        })
+        .await
+        .context("join lix runtime initialization")?
+    }
+
+    async fn open_lix(
+        &self,
+        lix_id: &str,
+        opened: &watch::Sender<RuntimeOpenState>,
+    ) -> Result<Arc<LixRuntime>> {
+        let started = Instant::now();
+        let io = SlateDBIoCounters::default();
+        let storage_started = Instant::now();
+        let storage =
+            info_span!("lix.storage.open", lix.id = lix_id).in_scope(|| match &self.backend {
+                #[cfg(test)]
+                StorageBackend::Memory { object_store } => {
+                    SlateDB::open_object_store_with_options_and_io_counters(
+                        lix_id,
+                        Arc::clone(object_store),
+                        SlateDBObjectStoreOptions::default(),
+                        io.clone(),
+                    )
+                    .context("open in-memory Lix SlateDB storage")
+                }
+                StorageBackend::S3 {
+                    object_store,
+                    prefix,
+                    cache,
+                } => {
+                    let storage_prefix = if prefix.is_empty() {
+                        lix_id.to_string()
+                    } else {
+                        format!("{prefix}/{lix_id}")
+                    };
+                    let mut lix_cache = cache.clone();
+                    lix_cache.root_folder = cache_child_path(&cache.root_folder, lix_id)
+                        .expect("Lix IDs are validated before opening cached storage");
+                    SlateDB::open_object_store_with_options_and_io_counters(
+                        storage_prefix,
+                        Arc::clone(object_store),
+                        SlateDBObjectStoreOptions {
+                            cache: Some(lix_cache),
+                        },
+                        io.clone(),
+                    )
+                    .context("open cached S3-backed Lix SlateDB storage")
+                }
+            })?;
+        let storage_open_ms = elapsed_millis(storage_started);
+
+        let engine_started = Instant::now();
+        // The canonical protocol owns the repository engine directly. Server
+        // admission creates no hidden application session; each successful
+        // handshake owns exactly one client session.
+        let open_state = opened.clone();
+        let open_progress =
+            lix_sdk::CallbackOpenProgressSink::new(move |progress: lix_sdk::OpenProgress| {
+                if let Some(state) = runtime_open_state_from_progress(progress) {
+                    open_state.send_replace(state);
+                }
+            });
+        let protocol = async {
+            lix_sdk::open_lix()
+                .with_storage(storage)
+                .with_telemetry(Arc::clone(&self.telemetry))
+                .with_open_progress_sink(Arc::new(open_progress))
+                .serve()
+                .with_lix_id(lix_id)
+                .await
+                .context("serve Lix repository through the canonical server protocol")
+        }
+        .instrument(info_span!("lix.engine.open", lix.id = lix_id))
+        .await?;
+        let engine_open_ms = elapsed_millis(engine_started);
+        let io = io.snapshot();
+        info!(
+            lix_id,
+            elapsed_ms = elapsed_millis(started),
+            storage_open_ms,
+            engine_open_ms,
+            storage.read_objects = io.read_objects,
+            storage.read_bytes = io.read_bytes,
+            storage.write_objects = io.write_objects,
+            storage.write_bytes = io.write_bytes,
+            storage.list_operations = io.list_operations,
+            storage.cache_filesystem_reads = io.cache_filesystem_reads,
+            storage.manifest_read_objects = io.manifest.read_objects,
+            storage.manifest_write_objects = io.manifest.write_objects,
+            storage.wal_read_objects = io.wal.read_objects,
+            storage.wal_write_objects = io.wal.write_objects,
+            storage.compacted_read_objects = io.compacted.read_objects,
+            "opened lix runtime"
+        );
+        Ok(Arc::new(LixRuntime::new(LixService { protocol })))
+    }
+
+    fn spawn_eviction_cleanup(self: &Arc<Self>, evicted: EvictedRuntime) {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            let EvictedRuntime {
+                lix_id,
+                runtime,
+                service,
+                sequence,
+                done,
+            } = evicted;
+            let started = Instant::now();
+
+            match close_lix_service(service).await {
+                Ok(()) => info!(
+                    lix_id,
+                    elapsed_ms = elapsed_millis(started),
+                    "closed evicted lix runtime"
+                ),
+                Err(error) => tracing::warn!(
+                    lix_id,
+                    elapsed_ms = elapsed_millis(started),
+                    error = %error,
+                    "released evicted lix runtime after close error"
+                ),
+            }
+            // The protocol owns the Lix root and its SlateDB storage. Drop
+            // both before moving this Lix's disk-cache child out of the
+            // active cache tree.
+            drop(runtime);
+            let cleanup = manager
+                .retire_and_delete_cache_child(&lix_id, sequence)
+                .await;
+
+            // The next cold open waits on this tombstone. Releasing it only
+            // after deletion prevents eviction churn from retaining an
+            // unbounded number of workers, cache directories, or delete
+            // tasks outside the server-wide cap.
+            manager
+                .finish_cleanup(&lix_id, sequence, done, cleanup)
+                .await;
+        });
+    }
+
+    fn cache_root(&self) -> Option<PathBuf> {
+        // Cache retirement moves per-Lix children under this root. It must be
+        // owned exclusively by this server process; construction holds the
+        // cache-root lock for the manager's lifetime.
+        match &self.backend {
+            #[cfg(test)]
+            StorageBackend::Memory { .. } => None,
+            StorageBackend::S3 { cache, .. } => Some(cache.root_folder.clone()),
+        }
+    }
+
+    async fn wait_for_cleanup(
+        &self,
+        cleanup: &mut watch::Receiver<CleanupState>,
+    ) -> std::result::Result<(), LixRuntimeError> {
+        loop {
+            let cleanup_state = cleanup.borrow().clone();
+            match cleanup_state {
+                CleanupState::Complete => return Ok(()),
+                CleanupState::Failed(error) => return Err(LixRuntimeError::Cleanup(error)),
+                CleanupState::Running => {
+                    if cleanup.changed().await.is_err() {
+                        return Err(LixRuntimeError::Cleanup(Arc::from(
+                            "lix runtime cleanup stopped before completing",
+                        )));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn finish_cleanup(
+        &self,
+        lix_id: &str,
+        sequence: u64,
+        done: watch::Sender<CleanupState>,
+        result: Result<()>,
+    ) {
+        let mut state = self.state.lock().await;
+        let matches_cleanup = state
+            .cleaning
+            .get(lix_id)
+            .is_some_and(|cleanup| cleanup.sequence == sequence);
+        if !matches_cleanup {
+            done.send_replace(CleanupState::Failed(Arc::from(
+                "lix runtime cleanup lost its manager state",
+            )));
+            return;
+        }
+        match result {
+            Ok(()) => {
+                state.cleaning.remove(lix_id);
+                done.send_replace(CleanupState::Complete);
+            }
+            Err(error) => {
+                let error = Arc::<str>::from(format!("{error:#}"));
+                tracing::error!(
+                    lix_id,
+                    sequence,
+                    error = %error,
+                    "retaining failed Lix cleanup slot to preserve cache bounds"
+                );
+                done.send_replace(CleanupState::Failed(error));
+            }
+        }
+    }
+
+    async fn retire_and_delete_cache_child(&self, lix_id: &str, sequence: u64) -> Result<()> {
+        let Some(cache_root) = self.cache_root() else {
+            return Ok(());
+        };
+        let cleanup_lix_id = lix_id.to_string();
+        let retired = tokio::task::spawn_blocking(move || {
+            retire_cache_child(&cache_root, &cleanup_lix_id, sequence)
+        })
+        .await
+        .context("join disk-cache retirement task")??;
+
+        let Some(retired) = retired else {
+            return Ok(());
+        };
+        let display_path = retired.display().to_string();
+        tokio::task::spawn_blocking(move || delete_retired_cache_child(&retired))
+            .await
+            .context("join retired disk-cache deletion task")??;
+        info!(lix_id, path = %display_path, "deleted retired Lix disk cache");
+        Ok(())
+    }
+
+    async fn begin_failed_open_cleanup(
+        &self,
+        lix_id: &str,
+        expected_runtime: &Arc<OnceCell<Arc<LixRuntime>>>,
+    ) -> Option<(u64, watch::Sender<CleanupState>)> {
+        let mut state = self.state.lock().await;
+        if !state
+            .entries
+            .get(lix_id)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.runtime, expected_runtime))
+        {
+            return None;
+        }
+        state.entries.remove(lix_id);
+        let cleanup = start_cleanup(&mut state, lix_id.to_string())
+            .expect("an active opening cannot already be cleaning");
+        info!(lix_id, "removed failed lix runtime opening");
+        Some(cleanup)
+    }
+
+    pub(crate) async fn recover(self: &Arc<Self>, lix_id: &str, service: &Arc<LixService>) {
+        let runtime = {
+            let state = self.state.lock().await;
+            state
+                .entries
+                .get(lix_id)
+                .and_then(|entry| entry.runtime.get())
+                .cloned()
+        };
+        let Some(runtime) = runtime else {
+            return;
+        };
+        let Some(draining_service) = runtime.begin_recovery(service).await else {
+            return;
+        };
+
+        info!(lix_id, "lix runtime entering recovery");
+        let manager = Arc::clone(self);
+        let lix_id = lix_id.to_string();
+        tokio::spawn(async move {
+            let started = Instant::now();
+            // Close first: an SSE body holds a service lease, but close() is
+            // what ends that stream. Waiting for leases before close would
+            // leave a recovering runtime permanently stuck behind its own
+            // observation response.
+            let Some(close_result) = await_recovery_close(
+                &manager.recovery_watchdog,
+                &lix_id,
+                close_lix_service(Arc::clone(&draining_service)),
+            )
+            .await
+            else {
+                return;
+            };
+            match close_result {
+                Ok(()) => info!(
+                    lix_id,
+                    elapsed_ms = elapsed_millis(started),
+                    "closed recovered lix runtime"
+                ),
+                Err(error) => tracing::warn!(
+                    lix_id,
+                    elapsed_ms = elapsed_millis(started),
+                    error = %error,
+                    "released recovered lix runtime after close error"
+                ),
+            }
+            // The task and the recovering runtime each retain one reference.
+            // Closing above has ended protocol streams; wait for their HTTP
+            // bodies to release the remaining leases before retiring storage.
+            while Arc::strong_count(&draining_service) > 2 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            if let Some((sequence, done)) = manager
+                .begin_recovered_runtime_cleanup(&lix_id, &runtime)
+                .await
+            {
+                // Installing the tombstone above prevents new `get` calls
+                // from retaining the runtime. An in-flight caller can still
+                // own the runtime cell, whose initialized value retains this
+                // Arc even though it does not add a direct service Arc.
+                while Arc::strong_count(&runtime) > 1 {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+                // `draining_service` was closed above. Dropping every
+                // retained runtime before touching its cache path keeps
+                // SlateDB workers from observing a renamed directory.
+                drop(draining_service);
+                drop(runtime);
+                let cleanup = manager
+                    .retire_and_delete_cache_child(&lix_id, sequence)
+                    .await;
+                manager
+                    .finish_cleanup(&lix_id, sequence, done, cleanup)
+                    .await;
+            }
+        });
+    }
+
+    async fn begin_recovered_runtime_cleanup(
+        &self,
+        lix_id: &str,
+        expected_runtime: &Arc<LixRuntime>,
+    ) -> Option<(u64, watch::Sender<CleanupState>)> {
+        let mut state = self.state.lock().await;
+        if !state.entries.get(lix_id).is_some_and(|entry| {
+            entry
+                .runtime
+                .get()
+                .is_some_and(|runtime| Arc::ptr_eq(runtime, expected_runtime))
+        }) {
+            return None;
+        }
+        state.entries.remove(lix_id);
+        let cleanup = start_cleanup(&mut state, lix_id.to_string())
+            .expect("an active recovered runtime cannot already be cleaning");
+        info!(lix_id, "removed recovered lix runtime");
+        Some(cleanup)
+    }
+
+    /// Prevents new opens and closes protocol servers so their live streams
+    /// cannot keep HTTP graceful shutdown from reaching the storage owners.
+    pub async fn shutdown(&self) -> Result<()> {
+        let runtimes = {
+            let mut state = self.state.lock().await;
+            state.shutting_down = true;
+            state
+                .entries
+                .iter()
+                .map(|(lix_id, entry)| {
+                    (
+                        lix_id.clone(),
+                        Arc::clone(&entry.runtime),
+                        entry.opened.clone(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut closers = JoinSet::new();
+        for (lix_id, runtime, opened) in runtimes {
+            // Evicting runtimes already have a dedicated close task. This
+            // also waits for an opening captured by the shutdown gate and
+            // closes recovering protocols, so neither can retain an SSE.
+            closers.spawn(async move { (lix_id, close_runtime_after_open(runtime, opened).await) });
+        }
+
+        let mut first_error = None;
+        while let Some(closed) = closers.join_next().await {
+            match closed {
+                Ok((lix_id, Ok(()))) => info!(lix_id, "closed Lix protocol for shutdown"),
+                Ok((lix_id, Err(error))) => {
+                    tracing::error!(lix_id, error = %error, "failed to close Lix protocol during shutdown");
+                    if first_error.is_none() {
+                        first_error = Some(error.context(format!("close Lix runtime {lix_id}")));
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to join Lix protocol shutdown task");
+                    if first_error.is_none() {
+                        first_error =
+                            Some(anyhow::anyhow!("join Lix protocol shutdown task: {error}"));
+                    }
+                }
+            }
+        }
+
+        first_error.map_or(Ok(()), Err)
+    }
+
+    pub(crate) fn max_open_lixes(&self) -> usize {
+        self.max_open_lixes
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn cached_lix_count(&self) -> usize {
+        self.state.lock().await.entries.len()
+    }
+
+    #[cfg(test)]
+    fn has_state_drop_probe(&self) -> bool {
+        self.state
+            .try_lock()
+            .expect("inspect idle manager state")
+            .state_drop_probe
+            .is_some()
+    }
+}
+
+impl LixService {
+    pub(crate) fn handle_protocol(
+        &self,
+        request: Request<Body>,
+        context: ServerProtocolContext,
+    ) -> Pin<Box<dyn Future<Output = ServerProtocolResponse> + Send + 'static>> {
+        let (parts, body) = request.into_parts();
+        let body =
+            ServerProtocolBody::stream(body.into_data_stream().map_err(std::io::Error::other));
+        let protocol = self.protocol.clone();
+        Box::pin(async move {
+            protocol
+                .handle(Request::from_parts(parts, body), context)
+                .await
+        })
+    }
+
+    #[cfg(test)]
+    fn protocol_router(&self) -> axum::Router {
+        use axum::routing::any;
+
+        let service = self.protocol.clone();
+        axum::Router::new().fallback(any(move |request: Request<Body>| {
+            let protocol = service.clone();
+            async move {
+                let (parts, body) = request.into_parts();
+                let body = ServerProtocolBody::stream(
+                    body.into_data_stream().map_err(std::io::Error::other),
+                );
+                let response = protocol
+                    .handle(
+                        Request::from_parts(parts, body),
+                        ServerProtocolContext::anonymous(),
+                    )
+                    .await;
+                let (parts, body) = response.into_parts();
+                axum::response::Response::from_parts(parts, Body::new(body))
+            }
+        }))
+    }
+
+    async fn close(&self) -> Result<()> {
+        self.protocol
+            .close()
+            .await
+            .context("close Lix protocol sessions")
+    }
+}
+
+impl LixRuntime {
+    fn new(service: LixService) -> Self {
+        Self {
+            state: Mutex::new(LixRuntimeState::Active(Arc::new(service))),
+        }
+    }
+
+    async fn acquire(&self) -> Option<Arc<LixService>> {
+        let state = self.state.lock().await;
+        match &*state {
+            LixRuntimeState::Active(service) => Some(Arc::clone(service)),
+            LixRuntimeState::Recovering(_) | LixRuntimeState::Evicting => None,
+        }
+    }
+
+    async fn acquire_for_shutdown(&self) -> Option<Arc<LixService>> {
+        let state = self.state.lock().await;
+        match &*state {
+            LixRuntimeState::Active(service) | LixRuntimeState::Recovering(service) => {
+                Some(Arc::clone(service))
+            }
+            LixRuntimeState::Evicting => None,
+        }
+    }
+
+    async fn begin_recovery(&self, expected_service: &Arc<LixService>) -> Option<Arc<LixService>> {
+        let mut state = self.state.lock().await;
+        let service = match &*state {
+            LixRuntimeState::Active(service) if Arc::ptr_eq(service, expected_service) => {
+                Arc::clone(service)
+            }
+            LixRuntimeState::Active(_)
+            | LixRuntimeState::Recovering(_)
+            | LixRuntimeState::Evicting => {
+                return None;
+            }
+        };
+        *state = LixRuntimeState::Recovering(Arc::clone(&service));
+        Some(service)
+    }
+
+    fn try_begin_eviction(&self) -> Option<Arc<LixService>> {
+        let mut state = self.state.try_lock().ok()?;
+        match &*state {
+            LixRuntimeState::Active(service)
+                if Arc::strong_count(service) == 1 && service.protocol.is_idle() =>
+            {
+                let LixRuntimeState::Active(service) =
+                    std::mem::replace(&mut *state, LixRuntimeState::Evicting)
+                else {
+                    unreachable!("matched active runtime state")
+                };
+                Some(service)
+            }
+            LixRuntimeState::Active(_)
+            | LixRuntimeState::Recovering(_)
+            | LixRuntimeState::Evicting => None,
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        let Ok(state) = self.state.try_lock() else {
+            return false;
+        };
+        matches!(
+            &*state,
+            LixRuntimeState::Active(service)
+                if Arc::strong_count(service) == 1 && service.protocol.is_idle()
+        )
+    }
+}
+
+async fn close_lix_service(service: Arc<LixService>) -> Result<()> {
+    let runtime = Handle::current();
+    tokio::task::spawn_blocking(move || {
+        let result = runtime.block_on(service.close());
+        drop(service);
+        result
+    })
+    .await
+    .context("join Lix protocol close")?
+}
+
+async fn await_recovery_close<F, T>(
+    watchdog: &RecoveryWatchdog,
+    lix_id: &str,
+    close: F,
+) -> Option<T>
+where
+    F: Future<Output = T>,
+{
+    match tokio::time::timeout(watchdog.timeout, close).await {
+        Ok(result) => Some(result),
+        Err(_elapsed) => {
+            tracing::error!(
+                lix_id,
+                timeout_secs = watchdog.timeout.as_secs(),
+                "lix runtime recovery close exceeded its deadline; aborting process"
+            );
+            (watchdog.on_timeout)();
+            None
+        }
+    }
+}
+
+async fn close_runtime_after_open(
+    runtime: Arc<OnceCell<Arc<LixRuntime>>>,
+    mut opened: watch::Receiver<RuntimeOpenState>,
+) -> Result<()> {
+    loop {
+        let open_state = opened.borrow().clone();
+        match open_state {
+            RuntimeOpenState::Opening | RuntimeOpenState::Migrating { .. } => {
+                opened
+                    .changed()
+                    .await
+                    .context("wait for Lix runtime opening during shutdown")?;
+            }
+            RuntimeOpenState::MigrationFailed { .. }
+            | RuntimeOpenState::UpgradeFailed
+            | RuntimeOpenState::Failed(_) => return Ok(()),
+            RuntimeOpenState::Ready => {
+                let runtime = runtime
+                    .get()
+                    .expect("runtime opener reported success before storing its runtime");
+                if let Some(service) = runtime.acquire_for_shutdown().await {
+                    close_lix_service(service).await?;
+                }
+                return Ok(());
+            }
+        }
+    }
+}
+
+impl fmt::Display for LixRuntimeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidId => write!(formatter, "invalid lix ID"),
+            Self::AtCapacity { max } => write!(
+                formatter,
+                "lix service is at its capacity of {max} active runtimes"
+            ),
+            Self::Migrating {
+                from_version,
+                to_version,
+            } => write!(
+                formatter,
+                "lix repository is migrating from v{from_version} to v{to_version}"
+            ),
+            Self::MigrationFailed {
+                from_version,
+                to_version,
+            } => write!(
+                formatter,
+                "lix repository migration from v{from_version} to v{to_version} failed"
+            ),
+            Self::UpgradeFailed => write!(formatter, "lix repository upgrade failed"),
+            Self::Recovering => write!(formatter, "lix runtime is recovering"),
+            Self::ShuttingDown => write!(formatter, "lix server is shutting down"),
+            Self::Cleanup(error) => write!(formatter, "lix runtime cleanup: {error}"),
+            Self::Open(error) => write!(formatter, "open lix runtime: {error:#}"),
+        }
+    }
+}
+
+impl Error for LixRuntimeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Open(error) => Some(error.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl CacheRootLease {
+    const OWNER_LOCK_NAME: &'static str = ".lix-server-cache-owner.lock";
+
+    fn acquire(root_folder: &Path) -> Result<Self> {
+        ensure_real_directory(root_folder, "SlateDB cache root")?;
+
+        let lock_path = root_folder.join(Self::OWNER_LOCK_NAME);
+        let owner_lock = open_cache_owner_lock(&lock_path)?;
+        owner_lock.try_lock_exclusive().map_err(|error| {
+            anyhow::anyhow!(
+                "SlateDB cache root {} is already owned by another lix-server process; configure a distinct SLATEDB_CACHE_DIR",
+                root_folder.display()
+            )
+            .context(error)
+        })?;
+
+        Ok(Self {
+            _owner_lock: owner_lock,
+        })
+    }
+}
+
+fn ensure_real_directory(path: &Path, label: &str) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => require_real_directory(path, label, &metadata),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            fs::create_dir_all(path)
+                .with_context(|| format!("create {label} {}", path.display()))?;
+            let metadata = fs::symlink_metadata(path)
+                .with_context(|| format!("inspect {label} {}", path.display()))?;
+            require_real_directory(path, label, &metadata)
+        }
+        Err(error) => Err(error).with_context(|| format!("inspect {label} {}", path.display())),
+    }
+}
+
+fn ensure_direct_child_directory(parent: &Path, name: &str, label: &str) -> Result<PathBuf> {
+    let child = parent.join(name);
+    match fs::symlink_metadata(&child) {
+        Ok(metadata) => require_real_directory(&child, label, &metadata)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            match fs::create_dir(&child) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("create {label} {}", child.display()));
+                }
+            }
+            let metadata = fs::symlink_metadata(&child)
+                .with_context(|| format!("inspect {label} {}", child.display()))?;
+            require_real_directory(&child, label, &metadata)?;
+        }
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect {label} {}", child.display()));
+        }
+    }
+    Ok(child)
+}
+
+fn require_real_directory(path: &Path, label: &str, metadata: &fs::Metadata) -> Result<()> {
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        anyhow::bail!("{label} must be a real directory: {}", path.display());
+    }
+    Ok(())
+}
+
+fn open_cache_owner_lock(lock_path: &Path) -> Result<File> {
+    // Avoid following a pre-existing symlink. If another creator races our
+    // create_new call, inspect its finished entry before opening it instead.
+    for _ in 0..2 {
+        match fs::symlink_metadata(lock_path) {
+            Ok(metadata) => {
+                if !metadata.is_file() || metadata.file_type().is_symlink() {
+                    anyhow::bail!(
+                        "SlateDB cache-root lock must be a regular file: {}",
+                        lock_path.display()
+                    );
+                }
+                return OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(lock_path)
+                    .with_context(|| {
+                        format!("open SlateDB cache-root lock {}", lock_path.display())
+                    });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create_new(true)
+                    .open(lock_path)
+                {
+                    Ok(lock) => return Ok(lock),
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => {
+                        return Err(error).with_context(|| {
+                            format!("create SlateDB cache-root lock {}", lock_path.display())
+                        });
+                    }
+                }
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("inspect SlateDB cache-root lock {}", lock_path.display())
+                });
+            }
+        }
+    }
+    anyhow::bail!(
+        "SlateDB cache-root lock changed while opening: {}",
+        lock_path.display()
+    )
+}
+
+fn cache_namespace_root(
+    base_root: &Path,
+    endpoint: &str,
+    bucket: &str,
+    region: &str,
+    prefix: &str,
+    access_key_id: &str,
+) -> PathBuf {
+    let mut hasher = Hasher::new();
+    hasher.update(CACHE_NAMESPACE_LAYOUT);
+    // Access-key IDs distinguish S3-compatible multi-tenant endpoints. Hash
+    // it with public location fields, but never put credentials in a path.
+    for component in [endpoint, bucket, region, prefix, access_key_id] {
+        let bytes = component.as_bytes();
+        hasher.update(&u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_be_bytes());
+        hasher.update(bytes);
+    }
+    base_root
+        .join(CACHE_NAMESPACE_PARENT)
+        .join(hasher.finalize().to_hex().to_string())
+}
+
+fn prepare_cache_namespace(owner_root: &Path, namespace_root: &Path) -> Result<()> {
+    let namespace_parent = ensure_direct_child_directory(
+        owner_root,
+        CACHE_NAMESPACE_PARENT,
+        "SlateDB cache namespace parent",
+    )?;
+    let namespace_name = namespace_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("SlateDB cache namespace name must be valid UTF-8")?;
+    if !valid_cache_namespace_name(namespace_name)
+        || namespace_root != namespace_parent.join(namespace_name)
+    {
+        anyhow::bail!(
+            "refuse to use invalid SlateDB cache namespace {}",
+            namespace_root.display()
+        );
+    }
+
+    reap_inactive_cache_namespaces(&namespace_parent, namespace_name)?;
+    let current_namespace = ensure_direct_child_directory(
+        &namespace_parent,
+        namespace_name,
+        "SlateDB cache namespace",
+    )?;
+    reap_retired_cache_children(&current_namespace)?;
+    // Every direct Lix child belongs to a predecessor process because the
+    // base-root lease is held before this startup reaches SlateDB. Removing
+    // them deliberately cold-starts the cache after a process restart and
+    // keeps the aggregate disk budget from growing with successive working
+    // sets.
+    reap_stale_cache_children(&current_namespace)
+}
+
+fn valid_cache_namespace_name(name: &str) -> bool {
+    name.len() == 64
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn reap_inactive_cache_namespaces(namespace_parent: &Path, current_name: &str) -> Result<()> {
+    for entry in fs::read_dir(namespace_parent).with_context(|| {
+        format!(
+            "list SlateDB cache namespace parent {}",
+            namespace_parent.display()
+        )
+    })? {
+        let entry = entry.with_context(|| {
+            format!(
+                "read SlateDB cache namespace parent {}",
+                namespace_parent.display()
+            )
+        })?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name == current_name {
+            continue;
+        }
+        if !valid_cache_namespace_name(name) {
+            // Only the namespaced layout is ours. Leave legacy or operator
+            // content untouched rather than recursively deleting it.
+            continue;
+        }
+        delete_cache_directory(&entry.path(), "inactive SlateDB cache namespace")?;
+    }
+    Ok(())
+}
+
+fn reap_stale_cache_children(namespace_root: &Path) -> Result<()> {
+    for entry in fs::read_dir(namespace_root).with_context(|| {
+        format!(
+            "list active SlateDB cache namespace {}",
+            namespace_root.display()
+        )
+    })? {
+        let entry = entry.with_context(|| {
+            format!(
+                "read active SlateDB cache namespace {}",
+                namespace_root.display()
+            )
+        })?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name == ".trash" || !valid_lix_id(name) {
+            continue;
+        }
+        delete_cache_directory(&entry.path(), "stale Lix cache child")?;
+    }
+    Ok(())
+}
+
+fn valid_lix_id(lix_id: &str) -> bool {
+    !lix_id.is_empty()
+        && lix_id.len() <= 128
+        && lix_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
+fn start_cleanup(
+    state: &mut ManagerState,
+    lix_id: String,
+) -> Option<(u64, watch::Sender<CleanupState>)> {
+    if state.cleaning.contains_key(&lix_id) {
+        return None;
+    }
+    state.cleanup_sequence = state.cleanup_sequence.wrapping_add(1);
+    let sequence = state.cleanup_sequence;
+    let (done, waiter) = watch::channel(CleanupState::Running);
+    state.cleaning.insert(
+        lix_id,
+        CleanupTombstone {
+            sequence,
+            done: waiter,
+        },
+    );
+    Some((sequence, done))
+}
+
+fn take_idle_lru_runtime(
+    entries: &mut HashMap<String, RuntimeEntry>,
+) -> Option<(String, Arc<LixRuntime>, Arc<LixService>)> {
+    let mut candidates = entries
+        .iter()
+        .filter(|(_, entry)| {
+            Arc::strong_count(&entry.runtime) == 1
+                && entry
+                    .runtime
+                    .get()
+                    .is_some_and(|runtime| Arc::strong_count(runtime) == 1 && runtime.is_idle())
+        })
+        .map(|(lix_id, entry)| (lix_id.clone(), entry.last_used))
+        .collect::<Vec<_>>();
+    candidates.sort_unstable_by_key(|(_, last_used)| *last_used);
+
+    for (lix_id, _) in candidates {
+        let runtime = entries
+            .get(&lix_id)
+            .and_then(|entry| entry.runtime.get())
+            .cloned()?;
+        let Some(service) = runtime.try_begin_eviction() else {
+            continue;
+        };
+        entries.remove(&lix_id);
+        info!(lix_id = %lix_id, "evicted idle lix runtime");
+        return Some((lix_id, runtime, service));
+    }
+    None
+}
+
+fn cache_options(
+    cache: &SlateDBCacheConfig,
+    max_open_lixes: usize,
+    root_folder: PathBuf,
+) -> SlateDBCacheOptions {
+    SlateDBCacheOptions {
+        root_folder,
+        // Each active Lix has its own SlateDB cache root and evictor. Split
+        // all cache budgets across the bounded live-runtime set.
+        max_disk_cache_bytes: per_lix_usize(cache.max_disk_cache_bytes, max_open_lixes),
+        block_cache_bytes: per_lix_u64(cache.block_cache_bytes, max_open_lixes),
+        metadata_cache_bytes: per_lix_u64(cache.metadata_cache_bytes, max_open_lixes),
+    }
+}
+
+fn cache_child_path(root_folder: &Path, lix_id: &str) -> Option<PathBuf> {
+    valid_lix_id(lix_id).then(|| root_folder.join(lix_id))
+}
+
+fn retired_cache_path(root_folder: &Path, lix_id: &str, sequence: u64) -> Option<PathBuf> {
+    valid_lix_id(lix_id).then(|| {
+        root_folder
+            .join(".trash")
+            .join(format!("{lix_id}-{}-{sequence}", std::process::id()))
+    })
+}
+
+fn valid_retired_cache_child_name(name: &str) -> bool {
+    let mut components = name.rsplitn(3, '-');
+    let Some(sequence) = components.next() else {
+        return false;
+    };
+    let Some(pid) = components.next() else {
+        return false;
+    };
+    let Some(lix_id) = components.next() else {
+        return false;
+    };
+    valid_lix_id(lix_id)
+        && pid.parse::<u32>().is_ok_and(|pid| pid > 0)
+        && sequence.parse::<u64>().is_ok()
+}
+
+fn retire_cache_child(root_folder: &Path, lix_id: &str, sequence: u64) -> Result<Option<PathBuf>> {
+    let cache_child =
+        cache_child_path(root_folder, lix_id).context("validate evicted Lix cache child path")?;
+    let metadata = match fs::symlink_metadata(&cache_child) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect cache child {}", cache_child.display()));
+        }
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "refuse to retire non-directory cache child {}",
+            cache_child.display()
+        );
+    }
+
+    ensure_direct_child_directory(root_folder, ".trash", "disk-cache trash root")?;
+
+    let retired = retired_cache_path(root_folder, lix_id, sequence)
+        .context("validate retired Lix cache path")?;
+    match fs::symlink_metadata(&retired) {
+        Ok(_) => anyhow::bail!(
+            "refuse to overwrite existing retired cache child {}",
+            retired.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspect retired cache child {}", retired.display()));
+        }
+    }
+    match fs::rename(&cache_child, &retired) {
+        Ok(()) => Ok(Some(retired)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "move evicted Lix cache child {} to {}",
+                cache_child.display(),
+                retired.display()
+            )
+        }),
+    }
+}
+
+fn delete_retired_cache_child(retired: &Path) -> Result<()> {
+    delete_cache_directory(retired, "retired cache child")
+}
+
+fn delete_cache_directory(path: &Path, label: &str) -> Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect {label} {}", path.display()));
+        }
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        anyhow::bail!("refuse to delete non-directory {label} {}", path.display());
+    }
+    for entry in fs::read_dir(path).with_context(|| format!("list {label} {}", path.display()))? {
+        let entry = entry.with_context(|| format!("read {label} {}", path.display()))?;
+        let child = entry.path();
+        let child_metadata = fs::symlink_metadata(&child)
+            .with_context(|| format!("inspect {label} entry {}", child.display()))?;
+        if child_metadata.file_type().is_symlink() {
+            anyhow::bail!(
+                "refuse to recurse through symlink in {label} {}",
+                child.display()
+            );
+        }
+        if child_metadata.is_dir() {
+            delete_cache_directory(&child, label)?;
+        } else if child_metadata.is_file() {
+            fs::remove_file(&child)
+                .with_context(|| format!("delete {label} file {}", child.display()))?;
+        } else {
+            anyhow::bail!(
+                "refuse to delete non-file entry in {label} {}",
+                child.display()
+            );
+        }
+    }
+    fs::remove_dir(path).with_context(|| format!("delete {label} {}", path.display()))
+}
+
+fn reap_retired_cache_children(root_folder: &Path) -> Result<()> {
+    let trash_root = root_folder.join(".trash");
+    let metadata = match fs::symlink_metadata(&trash_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("inspect disk-cache trash root {}", trash_root.display())
+            });
+        }
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "refuse to reap non-directory disk-cache trash root {}",
+            trash_root.display()
+        );
+    }
+
+    for entry in fs::read_dir(&trash_root)
+        .with_context(|| format!("list disk-cache trash root {}", trash_root.display()))?
+    {
+        let entry = entry
+            .with_context(|| format!("read disk-cache trash root {}", trash_root.display()))?;
+        let file_name = entry.file_name();
+        let name = file_name
+            .to_str()
+            .context("retired disk-cache child name must be valid UTF-8")?;
+        if !valid_retired_cache_child_name(name) {
+            anyhow::bail!(
+                "refuse to reap unexpected retired cache child {}",
+                entry.path().display()
+            );
+        }
+        delete_retired_cache_child(&entry.path())?;
+    }
+    Ok(())
+}
+
+fn per_lix_usize(total: usize, lixes: usize) -> usize {
+    total.checked_div(lixes).unwrap_or(0).max(1)
+}
+
+fn per_lix_u64(total: u64, lixes: usize) -> u64 {
+    total
+        .checked_div(u64::try_from(lixes).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+        .max(1)
+}
+
+fn elapsed_millis(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn s3_client_options(budget: S3RequestBudget) -> ClientOptions {
+    ClientOptions::new()
+        .with_timeout(budget.request_timeout)
+        .with_connect_timeout(budget.connect_timeout)
+}
+
+fn s3_retry_config(budget: S3RequestBudget) -> RetryConfig {
+    RetryConfig {
+        max_retries: budget.max_retries,
+        retry_timeout: budget.retry_timeout,
+        ..RetryConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, header},
+    };
+    use http_body_util::BodyExt as _;
+    use serde_json::{Value as JsonValue, json};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    use tower::ServiceExt as _;
+
+    const LIX_A: &str = "11111111-1111-4111-8111-111111111111";
+    const LIX_B: &str = "22222222-2222-4222-8222-222222222222";
+
+    struct TestCacheRoot(PathBuf);
+
+    impl TestCacheRoot {
+        fn new(name: &str) -> Self {
+            static NEXT: AtomicU64 = AtomicU64::new(0);
+            let root = std::env::temp_dir().join(format!(
+                "lix-server-store-{name}-{}-{}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
+            fs::create_dir_all(&root).expect("create test cache root");
+            Self(root)
+        }
+    }
+
+    impl Drop for TestCacheRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[tokio::test]
+    async fn recovery_close_watchdog_fires_for_a_stuck_close() {
+        let fired = Arc::new(AtomicBool::new(false));
+        let fired_by_watchdog = Arc::clone(&fired);
+        let watchdog = RecoveryWatchdog {
+            timeout: Duration::from_millis(1),
+            on_timeout: Arc::new(move || {
+                fired_by_watchdog.store(true, Ordering::SeqCst);
+            }),
+        };
+
+        let result = await_recovery_close(&watchdog, LIX_A, std::future::pending::<()>()).await;
+
+        assert!(result.is_none());
+        assert!(fired.load(Ordering::SeqCst));
+    }
+
+    fn namespace_root(base_root: &Path, endpoint: &str) -> PathBuf {
+        cache_namespace_root(
+            base_root,
+            endpoint,
+            "tenant-a",
+            "us-east-1",
+            "production/lix",
+            "AKIA-TENANT-A",
+        )
+    }
+
+    #[test]
+    fn cache_namespace_is_stable_backend_scoped_and_hides_identity() {
+        let base_root = Path::new("/var/cache/lix-server");
+        let primary = cache_namespace_root(
+            base_root,
+            "https://s3.us-east-1.example",
+            "tenant-a",
+            "us-east-1",
+            "production/lix",
+            "AKIA-TENANT-A",
+        );
+
+        assert_eq!(
+            primary,
+            cache_namespace_root(
+                base_root,
+                "https://s3.us-east-1.example",
+                "tenant-a",
+                "us-east-1",
+                "production/lix",
+                "AKIA-TENANT-A",
+            )
+        );
+        assert!(primary.starts_with(base_root.join(CACHE_NAMESPACE_PARENT)));
+        assert!(!valid_lix_id(CACHE_NAMESPACE_PARENT));
+        let digest = primary
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("namespace digest is UTF-8");
+        assert_eq!(digest.len(), 64);
+        assert!(
+            digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+        let rendered = primary.to_string_lossy();
+        assert!(!rendered.contains("s3.us-east-1.example"));
+        assert!(!rendered.contains("tenant-a"));
+        assert!(!rendered.contains("production/lix"));
+        assert!(!rendered.contains("AKIA-TENANT-A"));
+
+        for changed_backend in [
+            cache_namespace_root(
+                base_root,
+                "https://s3.us-west-2.example",
+                "tenant-a",
+                "us-east-1",
+                "production/lix",
+                "AKIA-TENANT-A",
+            ),
+            cache_namespace_root(
+                base_root,
+                "https://s3.us-east-1.example",
+                "tenant-b",
+                "us-east-1",
+                "production/lix",
+                "AKIA-TENANT-A",
+            ),
+            cache_namespace_root(
+                base_root,
+                "https://s3.us-east-1.example",
+                "tenant-a",
+                "us-west-2",
+                "production/lix",
+                "AKIA-TENANT-A",
+            ),
+            cache_namespace_root(
+                base_root,
+                "https://s3.us-east-1.example",
+                "tenant-a",
+                "us-east-1",
+                "staging/lix",
+                "AKIA-TENANT-A",
+            ),
+            cache_namespace_root(
+                base_root,
+                "https://s3.us-east-1.example",
+                "tenant-a",
+                "us-east-1",
+                "production/lix",
+                "AKIA-TENANT-B",
+            ),
+        ] {
+            assert_ne!(primary, changed_backend);
+        }
+        assert_ne!(
+            cache_namespace_root(base_root, "a", "bc", "", "", "key"),
+            cache_namespace_root(base_root, "ab", "c", "", "", "key")
+        );
+    }
+
+    #[test]
+    fn cache_namespace_separates_same_lix_id_across_backends() {
+        let base_root = Path::new("/var/cache/lix-server");
+        let first = namespace_root(base_root, "https://first.example").join("lix-123");
+        let second = namespace_root(base_root, "https://second.example").join("lix-123");
+
+        assert_ne!(first, second);
+        assert!(first.starts_with(base_root.join(CACHE_NAMESPACE_PARENT)));
+        assert!(second.starts_with(base_root.join(CACHE_NAMESPACE_PARENT)));
+        assert_eq!(
+            first.file_name().and_then(|name| name.to_str()),
+            Some("lix-123")
+        );
+        assert_eq!(
+            second.file_name().and_then(|name| name.to_str()),
+            Some("lix-123")
+        );
+    }
+
+    fn memory_manager(max_open_lixes: usize) -> Arc<LixRuntimeManager> {
+        LixRuntimeManager::new_in_memory(max_open_lixes)
+    }
+
+    fn memory_manager_with_open_gate(
+        max_open_lixes: usize,
+        open_gate: TestOpenGate,
+    ) -> Arc<LixRuntimeManager> {
+        Arc::new(LixRuntimeManager {
+            backend: StorageBackend::Memory {
+                object_store: Arc::new(InMemory::new()),
+            },
+            max_open_lixes,
+            recovery_watchdog: RecoveryWatchdog::test_default(),
+            state: Mutex::new(ManagerState::default()),
+            telemetry: test_telemetry_sink(),
+            _cache_root_lease: None,
+            open_gate: Some(open_gate),
+        })
+    }
+
+    #[tokio::test]
+    async fn concurrent_gets_share_one_runtime() {
+        let manager = memory_manager(2);
+        let (left, right) = tokio::join!(manager.get(LIX_A), manager.get(LIX_A));
+        let left = left.expect("open left runtime");
+        let right = right.expect("open right runtime");
+
+        assert!(Arc::ptr_eq(&left, &right));
+    }
+
+    #[tokio::test]
+    async fn cancelled_get_does_not_cancel_the_manager_owned_open() {
+        let gate = TestOpenGate {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+            starts: Arc::new(AtomicUsize::new(0)),
+            fail_next: Arc::new(AtomicBool::new(false)),
+        };
+        let manager = memory_manager_with_open_gate(1, gate.clone());
+        let started = gate.started.notified();
+        let opening_manager = Arc::clone(&manager);
+        let opening = tokio::spawn(async move { opening_manager.get(LIX_A).await });
+        started.await;
+        opening.abort();
+        let _ = opening.await;
+
+        let waiting_manager = Arc::clone(&manager);
+        let mut later_get = tokio::spawn(async move { waiting_manager.get(LIX_A).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut later_get)
+                .await
+                .is_err(),
+            "a later caller must wait on the original managed opener"
+        );
+        assert_eq!(gate.starts.load(Ordering::SeqCst), 1);
+
+        gate.release.notify_one();
+        let service = tokio::time::timeout(Duration::from_secs(10), later_get)
+            .await
+            .expect("managed opener should finish")
+            .expect("later get task")
+            .expect("open in-memory Lix");
+        assert_eq!(gate.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(manager.cached_lix_count().await, 1);
+        drop(service);
+    }
+
+    #[tokio::test]
+    async fn get_reports_manager_owned_migration_without_waiting_for_open() {
+        let manager = memory_manager(1);
+        let runtime = Arc::new(OnceCell::new());
+        let (_migration_owner, opened) = watch::channel(RuntimeOpenState::Migrating {
+            from_version: 68,
+            to_version: 71,
+        });
+        manager.state.lock().await.entries.insert(
+            LIX_A.to_string(),
+            RuntimeEntry {
+                runtime,
+                opened,
+                last_used: 1,
+            },
+        );
+
+        let result = tokio::time::timeout(Duration::from_millis(25), manager.get(LIX_A))
+            .await
+            .expect("migration state must return without waiting for the opener");
+        assert!(matches!(
+            result,
+            Err(LixRuntimeError::Migrating {
+                from_version: 68,
+                to_version: 71,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_migration_remains_terminal_for_every_caller() {
+        let manager = memory_manager(1);
+        manager.state.lock().await.failed_upgrades.insert(
+            LIX_A.to_string(),
+            FailedUpgrade::Versioned(FailedMigration {
+                from_version: 68,
+                to_version: 71,
+            }),
+        );
+
+        assert!(matches!(
+            manager.get(LIX_A).await,
+            Err(LixRuntimeError::MigrationFailed {
+                from_version: 68,
+                to_version: 71,
+            })
+        ));
+        assert!(matches!(
+            manager.get(LIX_A).await,
+            Err(LixRuntimeError::MigrationFailed {
+                from_version: 68,
+                to_version: 71,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn failed_managed_open_removes_its_entry_before_a_retry() {
+        let gate = TestOpenGate {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+            starts: Arc::new(AtomicUsize::new(0)),
+            fail_next: Arc::new(AtomicBool::new(true)),
+        };
+        let manager = memory_manager_with_open_gate(1, gate.clone());
+        let first_started = gate.started.notified();
+        let first_manager = Arc::clone(&manager);
+        let first = tokio::spawn(async move { first_manager.get(LIX_A).await });
+        first_started.await;
+        gate.release.notify_one();
+        assert!(matches!(
+            first.await.expect("first get task"),
+            Err(LixRuntimeError::Open(_))
+        ));
+        assert_eq!(manager.cached_lix_count().await, 0);
+
+        let retry_started = gate.started.notified();
+        let retry_manager = Arc::clone(&manager);
+        let retry = tokio::spawn(async move { retry_manager.get(LIX_A).await });
+        retry_started.await;
+        gate.release.notify_one();
+        let service = retry
+            .await
+            .expect("retry get task")
+            .expect("retry opens after failed opener cleanup");
+        assert_eq!(gate.starts.load(Ordering::SeqCst), 2);
+        drop(service);
+    }
+
+    #[tokio::test]
+    async fn evicts_the_least_recently_used_idle_runtime() {
+        let manager = memory_manager(1);
+        let first = manager.get(LIX_A).await.expect("open first runtime");
+        drop(first);
+        let second = manager.get(LIX_B).await.expect("open second runtime");
+
+        assert_eq!(manager.cached_lix_count().await, 1);
+        drop(second);
+        let reopened = manager.get(LIX_A).await.expect("reopen first runtime");
+        assert_eq!(manager.cached_lix_count().await, 1);
+        drop(reopened);
+    }
+
+    #[tokio::test]
+    async fn active_service_lease_prevents_runtime_eviction() {
+        let manager = memory_manager(1);
+        let active = manager.get(LIX_A).await.expect("open active runtime");
+
+        assert!(matches!(
+            manager.get(LIX_B).await,
+            Err(LixRuntimeError::AtCapacity { max: 1 })
+        ));
+
+        drop(active);
+        manager
+            .get(LIX_B)
+            .await
+            .expect("evict runtime after its final service lease is released");
+    }
+
+    #[tokio::test]
+    async fn live_protocol_session_prevents_runtime_eviction_between_requests() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt as _;
+
+        let manager = memory_manager(1);
+        let service = manager.get(LIX_A).await.expect("open lix runtime");
+        let handshake = service
+            .protocol_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(handshake.status(), http::StatusCode::OK);
+        drop(handshake);
+        drop(service);
+
+        assert!(matches!(
+            manager.get(LIX_B).await,
+            Err(LixRuntimeError::AtCapacity { max: 1 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_active_observation_streams() {
+        use axum::{
+            body::Body,
+            http::{Request, header},
+        };
+        use http_body_util::BodyExt as _;
+        use tower::ServiceExt as _;
+
+        let manager = memory_manager(1);
+        let service = manager.get(LIX_A).await.expect("open lix runtime");
+        let protocol_router = service.protocol_router();
+        let handshake = protocol_router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(handshake.status(), http::StatusCode::OK);
+        let handshake = serde_json::from_slice::<serde_json::Value>(
+            &handshake
+                .into_body()
+                .collect()
+                .await
+                .expect("handshake body")
+                .to_bytes(),
+        )
+        .expect("handshake JSON");
+        let session_id = handshake["sessionId"]
+            .as_str()
+            .expect("handshake session ID")
+            .to_string();
+
+        let observation = protocol_router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/observe")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("Lix-Session-Id", session_id)
+                    .body(Body::from(r#"{"sql":"SELECT 1","params":[]}"#))
+                    .expect("observation request"),
+            )
+            .await
+            .expect("observation response");
+        assert_eq!(observation.status(), http::StatusCode::OK);
+        let mut body = observation.into_body();
+        let first_frame = tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("observation should produce an initial frame")
+            .expect("observation body should remain open")
+            .expect("valid observation frame");
+        assert!(first_frame.is_data());
+
+        manager.shutdown().await.expect("close active protocols");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while let Some(frame) = body.frame().await {
+                frame.expect("valid observation frame while closing");
+            }
+        })
+        .await
+        .expect("shutdown should end the observation stream");
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_recovering_observation_streams() {
+        use axum::{
+            body::Body,
+            http::{Request, header},
+        };
+        use http_body_util::BodyExt as _;
+        use tower::ServiceExt as _;
+
+        let manager = memory_manager(1);
+        let service = manager.get(LIX_A).await.expect("open lix runtime");
+        let protocol_router = service.protocol_router();
+        let handshake = protocol_router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(handshake.status(), http::StatusCode::OK);
+        let handshake = serde_json::from_slice::<serde_json::Value>(
+            &handshake
+                .into_body()
+                .collect()
+                .await
+                .expect("handshake body")
+                .to_bytes(),
+        )
+        .expect("handshake JSON");
+        let session_id = handshake["sessionId"]
+            .as_str()
+            .expect("handshake session ID")
+            .to_string();
+
+        let observation = protocol_router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/observe")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("Lix-Session-Id", session_id)
+                    .body(Body::from(r#"{"sql":"SELECT 1","params":[]}"#))
+                    .expect("observation request"),
+            )
+            .await
+            .expect("observation response");
+        assert_eq!(observation.status(), http::StatusCode::OK);
+        let mut body = observation.into_body();
+        let first_frame = tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("observation should produce an initial frame")
+            .expect("observation body should remain open")
+            .expect("valid observation frame");
+        assert!(first_frame.is_data());
+
+        manager.recover(LIX_A, &service).await;
+        manager
+            .shutdown()
+            .await
+            .expect("close recovering protocols");
+
+        let stream_closed = tokio::time::timeout(Duration::from_secs(1), async {
+            while let Some(frame) = body.frame().await {
+                frame.expect("valid observation frame while closing");
+            }
+        })
+        .await;
+        // Keep a failing regression self-cleaning: recovery owns the close
+        // after the last handler lease is released.
+        drop(service);
+        stream_closed.expect("shutdown should end a recovering observation stream");
+    }
+
+    #[tokio::test]
+    async fn recovery_closes_observation_streams_before_waiting_for_response_leases() {
+        let manager = memory_manager(1);
+        let service = manager.get(LIX_A).await.expect("open lix runtime");
+        let protocol_router = service.protocol_router();
+        let handshake = protocol_router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(handshake.status(), http::StatusCode::OK);
+        let handshake = serde_json::from_slice::<serde_json::Value>(
+            &handshake
+                .into_body()
+                .collect()
+                .await
+                .expect("handshake body")
+                .to_bytes(),
+        )
+        .expect("handshake JSON");
+        let session_id = handshake["sessionId"]
+            .as_str()
+            .expect("handshake session ID")
+            .to_string();
+
+        let observation = protocol_router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/observe")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("Lix-Session-Id", session_id)
+                    .body(Body::from(r#"{"sql":"SELECT 1","params":[]}"#))
+                    .expect("observation request"),
+            )
+            .await
+            .expect("observation response");
+        assert_eq!(observation.status(), http::StatusCode::OK);
+        let mut body = observation.into_body();
+        let first_frame = tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("observation should produce an initial frame")
+            .expect("observation body should remain open")
+            .expect("valid observation frame");
+        assert!(first_frame.is_data());
+
+        manager.recover(LIX_A, &service).await;
+
+        let stream_closed = tokio::time::timeout(Duration::from_secs(1), async {
+            while let Some(frame) = body.frame().await {
+                frame.expect("valid observation frame while recovering");
+            }
+        })
+        .await;
+        drop(service);
+        stream_closed.expect("recovery should end an observation stream");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while manager.cached_lix_count().await != 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("recovery should retire the closed runtime");
+    }
+
+    #[tokio::test]
+    async fn recovery_releases_an_eof_drained_observation_body_lease() {
+        let manager = memory_manager(1);
+        let app = crate::router(
+            Arc::clone(&manager),
+            None,
+            Duration::from_secs(60),
+            crate::telemetry::InFlightSqlRegistry::default(),
+        );
+        let session = open_protocol_session(&app, LIX_A).await;
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/observe")
+                    .header(lix_sdk::server_protocol::SESSION_ID_HEADER, session)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"sql":"SELECT 1","params":[]}"#))
+                    .expect("observation request"),
+            )
+            .await
+            .expect("observation response");
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let mut body = response.into_body();
+        let first_frame = tokio::time::timeout(Duration::from_secs(1), body.frame())
+            .await
+            .expect("observation should produce an initial frame")
+            .expect("observation body should remain open")
+            .expect("valid observation frame");
+        assert!(first_frame.is_data());
+
+        let service = manager.get(LIX_A).await.expect("get active service");
+        manager.recover(LIX_A, &service).await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while let Some(frame) = body.frame().await {
+                frame.expect("valid observation frame while recovering");
+            }
+        })
+        .await
+        .expect("recovery should end the observation stream");
+        drop(service);
+
+        // Keep the completed Body alive: EOF must release its lease so this
+        // response object cannot hold the terminal runtime in recovery.
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while manager.cached_lix_count().await != 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("EOF-drained observation body must not delay retirement");
+        drop(body);
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_runtime_opening_at_signal() {
+        use axum::{body::Body, http::Request};
+        use http_body_util::BodyExt as _;
+        use tower::ServiceExt as _;
+
+        let gate = TestOpenGate {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+            starts: Arc::new(AtomicUsize::new(0)),
+            fail_next: Arc::new(AtomicBool::new(false)),
+        };
+        let manager = memory_manager_with_open_gate(1, gate.clone());
+        let started = gate.started.notified();
+        let opening_manager = Arc::clone(&manager);
+        let opening = tokio::spawn(async move { opening_manager.get(LIX_A).await });
+        started.await;
+        opening.abort();
+        assert!(matches!(opening.await, Err(error) if error.is_cancelled()));
+
+        let shutdown_manager = Arc::clone(&manager);
+        let mut shutdown = tokio::spawn(async move { shutdown_manager.shutdown().await });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if manager.state.lock().await.shutting_down {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shutdown should block new opens");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut shutdown)
+                .await
+                .is_err(),
+            "shutdown must wait for the manager-owned opening"
+        );
+        assert!(matches!(
+            manager.get(LIX_B).await,
+            Err(LixRuntimeError::ShuttingDown)
+        ));
+
+        gate.release.notify_one();
+        shutdown
+            .await
+            .expect("join shutdown")
+            .expect("close opened runtime");
+
+        let runtime = {
+            let state = manager.state.lock().await;
+            Arc::clone(
+                state
+                    .entries
+                    .get(LIX_A)
+                    .expect("manager should retain opened runtime")
+                    .runtime
+                    .get()
+                    .expect("opening should finish before shutdown returns"),
+            )
+        };
+        let service = runtime
+            .acquire()
+            .await
+            .expect("shutdown leaves the closed protocol inspectable");
+        let response = service
+            .protocol_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/")
+                    .body(Body::empty())
+                    .expect("handshake request"),
+            )
+            .await
+            .expect("handshake response");
+        assert_eq!(response.status(), http::StatusCode::SERVICE_UNAVAILABLE);
+        let body = serde_json::from_slice::<serde_json::Value>(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("handshake body")
+                .to_bytes(),
+        )
+        .expect("handshake JSON");
+        assert_eq!(body["error"]["code"], "LIX_ERROR_PROTOCOL_SERVER_CLOSED");
+    }
+
+    #[tokio::test]
+    async fn rejects_unsafe_lix_ids() {
+        let manager = memory_manager(1);
+        for lix_id in ["", "../escape", "contains/slash", "contains space"] {
+            assert!(matches!(
+                manager.get(lix_id).await,
+                Err(LixRuntimeError::InvalidId)
+            ));
+        }
+    }
+
+    #[test]
+    fn s3_request_policy_is_bounded() {
+        let options = s3_client_options(S3_REQUEST_BUDGET);
+        assert_eq!(
+            options
+                .get_config_value(&ClientConfigKey::Timeout)
+                .as_deref(),
+            Some("15s")
+        );
+        assert_eq!(
+            options
+                .get_config_value(&ClientConfigKey::ConnectTimeout)
+                .as_deref(),
+            Some("3s")
+        );
+
+        let retry = s3_retry_config(S3_REQUEST_BUDGET);
+        assert_eq!(retry.max_retries, 1);
+        assert_eq!(retry.retry_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn partitions_all_cache_budgets_per_active_lix() {
+        let cache = SlateDBCacheConfig {
+            root_folder: PathBuf::from("/tmp/lix-server-cache"),
+            max_disk_cache_bytes: 2_048,
+            block_cache_bytes: 128,
+            metadata_cache_bytes: 32,
+        };
+
+        let namespace = namespace_root(&cache.root_folder, "https://s3.example");
+        let options = cache_options(&cache, 4, namespace.clone());
+
+        assert_eq!(options.root_folder, namespace);
+        assert_eq!(options.max_disk_cache_bytes, 512);
+        assert_eq!(options.block_cache_bytes, 32);
+        assert_eq!(options.metadata_cache_bytes, 8);
+        assert_eq!(
+            cache_child_path(&options.root_folder, LIX_A),
+            Some(options.root_folder.join(LIX_A))
+        );
+    }
+
+    #[test]
+    fn retires_only_the_validated_lix_cache_child() {
+        let root = TestCacheRoot::new("retire-cache-child");
+        let namespace = namespace_root(&root.0, "https://s3.example");
+        let lix_cache = namespace.join(LIX_A);
+        let untouched = namespace.join("lix-b");
+        fs::create_dir_all(lix_cache.join("nested")).expect("create Lix cache child");
+        fs::write(lix_cache.join("nested/cache-part"), b"cached bytes").expect("write cache part");
+        fs::create_dir_all(&untouched).expect("create untouched cache child");
+
+        let retired = retire_cache_child(&namespace, LIX_A, 7)
+            .expect("retire cache child")
+            .expect("cache child is present");
+
+        assert!(!lix_cache.exists());
+        assert!(retired.starts_with(namespace.join(".trash")));
+        assert!(retired.is_dir());
+        assert!(untouched.is_dir());
+        assert!(namespace.is_dir());
+
+        delete_retired_cache_child(&retired).expect("delete retired cache child");
+        assert!(!retired.exists());
+        assert!(untouched.is_dir());
+        assert!(namespace.is_dir());
+    }
+
+    #[test]
+    fn cache_cleanup_rejects_unsafe_lix_ids() {
+        let root = TestCacheRoot::new("invalid-cache-child");
+
+        assert_eq!(cache_child_path(&root.0, "../escape"), None);
+        assert!(retire_cache_child(&root.0, "../escape", 1).is_err());
+        assert!(root.0.is_dir());
+    }
+
+    #[test]
+    fn cache_base_lease_excludes_a_second_backend_namespace_owner() {
+        let root = TestCacheRoot::new("cache-root-lease");
+        let first_namespace = namespace_root(&root.0, "https://first.example");
+        let second_namespace = namespace_root(&root.0, "https://second.example");
+        assert_ne!(first_namespace, second_namespace);
+        let first = CacheRootLease::acquire(&root.0).expect("acquire first cache-root lease");
+        prepare_cache_namespace(&root.0, &first_namespace)
+            .expect("prepare first backend namespace");
+        let error = CacheRootLease::acquire(&root.0).expect_err("reject second cache-root lease");
+        assert!(
+            format!("{error:#}").contains("already owned by another lix-server process"),
+            "unexpected cache-root lease error: {error:#}"
+        );
+        drop(first);
+        CacheRootLease::acquire(&root.0).expect("acquire cache-root lease after release");
+    }
+
+    #[test]
+    fn cache_root_lease_outlives_manager_state_on_drop() {
+        let root = TestCacheRoot::new("cache-root-drop-order");
+        let observed_lease_held = Arc::new(AtomicBool::new(false));
+        let manager = Arc::new(LixRuntimeManager {
+            backend: StorageBackend::Memory {
+                object_store: Arc::new(InMemory::new()),
+            },
+            max_open_lixes: 1,
+            recovery_watchdog: RecoveryWatchdog::test_default(),
+            state: Mutex::new(ManagerState {
+                state_drop_probe: Some(CacheRootLeaseDropProbe {
+                    root: root.0.clone(),
+                    observed_lease_held: Arc::clone(&observed_lease_held),
+                }),
+                ..ManagerState::default()
+            }),
+            telemetry: test_telemetry_sink(),
+            _cache_root_lease: Some(
+                CacheRootLease::acquire(&root.0).expect("acquire cache-root lease"),
+            ),
+            open_gate: None,
+        });
+        assert!(manager.has_state_drop_probe());
+
+        drop(manager);
+
+        assert!(
+            observed_lease_held.load(Ordering::SeqCst),
+            "manager state must drop before releasing the cache-root lease"
+        );
+        CacheRootLease::acquire(&root.0).expect("lease is released after manager state drops");
+    }
+
+    #[test]
+    fn cache_namespace_setup_reaps_only_managed_current_and_inactive_entries() {
+        let root = TestCacheRoot::new("cache-root-reap");
+        let current = namespace_root(&root.0, "https://current.example");
+        let inactive = namespace_root(&root.0, "https://inactive.example");
+        let retired = retired_cache_path(&current, LIX_A, 7).expect("valid retired path");
+        fs::create_dir_all(retired.join("nested")).expect("create retired cache child");
+        fs::write(retired.join("nested/cache-part"), b"cached bytes")
+            .expect("write retired cache part");
+        let stale_current_lix = current.join("lix-stale");
+        let current_unknown = current.join(".operator-notes");
+        fs::create_dir_all(stale_current_lix.join("nested"))
+            .expect("create stale current Lix cache");
+        fs::write(stale_current_lix.join("nested/cache-part"), b"cached bytes")
+            .expect("write stale current Lix cache part");
+        fs::create_dir_all(&current_unknown).expect("create current unknown entry");
+        fs::create_dir_all(inactive.join("lix-old")).expect("create inactive namespace");
+        fs::write(inactive.join("lix-old/cache-part"), b"cached bytes")
+            .expect("write inactive namespace part");
+        let legacy_trash = root.0.join(".trash/legacy");
+        let legacy_v1_lix = root.0.join("v1/legacy");
+        fs::create_dir_all(&legacy_trash).expect("create legacy trash");
+        fs::create_dir_all(&legacy_v1_lix).expect("create legacy Lix cache");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        prepare_cache_namespace(&root.0, &current)
+            .expect("reap active trash and inactive namespace");
+
+        assert!(!retired.exists());
+        assert!(!inactive.exists());
+        assert!(!stale_current_lix.exists());
+        assert!(current.is_dir());
+        assert!(current_unknown.is_dir());
+        assert!(legacy_trash.is_dir());
+        assert!(legacy_v1_lix.is_dir());
+        assert!(root.0.is_dir());
+    }
+
+    #[test]
+    fn cache_namespace_setup_leaves_unknown_parent_entries_untouched() {
+        let root = TestCacheRoot::new("cache-root-unknown-namespace");
+        let current = namespace_root(&root.0, "https://current.example");
+        let unknown = root.0.join(CACHE_NAMESPACE_PARENT).join("operator-notes");
+        fs::create_dir_all(&unknown).expect("create unknown namespace entry");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        prepare_cache_namespace(&root.0, &current)
+            .expect("leave unknown namespace entry untouched");
+
+        assert!(unknown.is_dir());
+        assert!(current.is_dir());
+    }
+
+    #[test]
+    fn cache_namespace_setup_refuses_unexpected_active_trash_children() {
+        let root = TestCacheRoot::new("cache-root-reap-unexpected");
+        let current = namespace_root(&root.0, "https://current.example");
+        fs::create_dir_all(current.join(".trash/unmanaged"))
+            .expect("create unexpected retired cache child");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        let error = prepare_cache_namespace(&root.0, &current)
+            .expect_err("refuse an unexpected retired cache child");
+
+        assert!(format!("{error:#}").contains("unexpected retired cache child"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_namespace_setup_rejects_symlinked_namespace_parent() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestCacheRoot::new("cache-root-symlinked-parent");
+        let outside = root.0.join("outside");
+        fs::create_dir_all(&outside).expect("create symlink target");
+        symlink(&outside, root.0.join(CACHE_NAMESPACE_PARENT))
+            .expect("create namespace parent symlink");
+        let current = namespace_root(&root.0, "https://current.example");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        let error = prepare_cache_namespace(&root.0, &current)
+            .expect_err("reject symlinked namespace parent");
+
+        assert!(format!("{error:#}").contains("must be a real directory"));
+        assert!(outside.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_namespace_setup_rejects_symlinked_current_namespace() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestCacheRoot::new("cache-root-symlinked-current");
+        let current = namespace_root(&root.0, "https://current.example");
+        let outside = root.0.join("outside");
+        fs::create_dir_all(current.parent().expect("namespace parent"))
+            .expect("create namespace parent");
+        fs::create_dir_all(&outside).expect("create symlink target");
+        symlink(&outside, &current).expect("create current namespace symlink");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        let error = prepare_cache_namespace(&root.0, &current)
+            .expect_err("reject symlinked current namespace");
+
+        assert!(format!("{error:#}").contains("must be a real directory"));
+        assert!(outside.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_namespace_setup_rejects_symlinked_inactive_namespace() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestCacheRoot::new("cache-root-symlinked-inactive");
+        let current = namespace_root(&root.0, "https://current.example");
+        let inactive = namespace_root(&root.0, "https://inactive.example");
+        let outside = root.0.join("outside");
+        fs::create_dir_all(inactive.parent().expect("namespace parent"))
+            .expect("create namespace parent");
+        fs::create_dir_all(&outside).expect("create symlink target");
+        symlink(&outside, &inactive).expect("create inactive namespace symlink");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        let error = prepare_cache_namespace(&root.0, &current)
+            .expect_err("refuse to remove a symlinked inactive namespace");
+
+        assert!(format!("{error:#}").contains("refuse to delete non-directory"));
+        assert!(outside.is_dir());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_base_lease_rejects_a_symlinked_lock() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestCacheRoot::new("cache-root-symlinked-lock");
+        let outside = root.0.join("outside-lock");
+        fs::write(&outside, b"not a lock").expect("write lock target");
+        symlink(&outside, root.0.join(CacheRootLease::OWNER_LOCK_NAME))
+            .expect("create cache lock symlink");
+
+        let error = CacheRootLease::acquire(&root.0).expect_err("reject cache lock symlink");
+
+        assert!(format!("{error:#}").contains("must be a regular file"));
+        assert_eq!(fs::read(&outside).expect("read lock target"), b"not a lock");
+    }
+
+    #[test]
+    fn cache_namespace_setup_rejects_malformed_namespace_paths() {
+        let root = TestCacheRoot::new("cache-root-malformed-namespace");
+        let malformed = root
+            .0
+            .join(CACHE_NAMESPACE_PARENT)
+            .join("not-a-digest")
+            .join("unexpected-child");
+
+        let _lease = CacheRootLease::acquire(&root.0).expect("acquire base cache lease");
+        let error = prepare_cache_namespace(&root.0, &malformed)
+            .expect_err("reject malformed namespace path");
+
+        assert!(format!("{error:#}").contains("invalid SlateDB cache namespace"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_deletion_refuses_nested_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let root = TestCacheRoot::new("cache-delete-symlink");
+        let cache = root.0.join("retired-cache");
+        let outside = root.0.join("outside");
+        fs::create_dir_all(&cache).expect("create retired cache");
+        fs::create_dir_all(&outside).expect("create symlink target");
+        fs::write(outside.join("keep"), b"outside").expect("write symlink target file");
+        symlink(&outside, cache.join("escape")).expect("create nested cache symlink");
+
+        let error = delete_cache_directory(&cache, "test cache")
+            .expect_err("refuse to recurse through nested cache symlink");
+
+        assert!(format!("{error:#}").contains("refuse to recurse through symlink"));
+        assert!(outside.join("keep").is_file());
+    }
+
+    #[tokio::test]
+    async fn same_lix_open_waits_for_eviction_cleanup() {
+        let manager = memory_manager(1);
+        let (done, cleanup_waiter) = watch::channel(CleanupState::Running);
+        {
+            let mut state = manager.state.lock().await;
+            state.cleaning.insert(
+                LIX_A.to_string(),
+                CleanupTombstone {
+                    sequence: 1,
+                    done: cleanup_waiter,
+                },
+            );
+        }
+
+        let waiting_manager = Arc::clone(&manager);
+        let mut opening = tokio::spawn(async move { waiting_manager.get(LIX_A).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut opening)
+                .await
+                .is_err(),
+            "same-ID open must wait until cache retirement has finished"
+        );
+
+        manager.finish_cleanup(LIX_A, 1, done, Ok(())).await;
+        let service = tokio::time::timeout(Duration::from_secs(10), opening)
+            .await
+            .expect("same-ID open should resume after cleanup")
+            .expect("same-ID open task")
+            .expect("open in-memory Lix");
+        drop(service);
+    }
+
+    #[tokio::test]
+    async fn new_lix_open_waits_for_inflight_cleanup_capacity() {
+        let manager = memory_manager(1);
+        let (sequence, done) = {
+            let mut state = manager.state.lock().await;
+            start_cleanup(&mut state, LIX_A.to_string()).expect("start test cleanup")
+        };
+
+        let waiting_manager = Arc::clone(&manager);
+        let mut opening = tokio::spawn(async move { waiting_manager.get(LIX_B).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut opening)
+                .await
+                .is_err(),
+            "an evicting runtime must retain its capacity slot"
+        );
+
+        manager.finish_cleanup(LIX_A, sequence, done, Ok(())).await;
+        let service = tokio::time::timeout(Duration::from_secs(10), opening)
+            .await
+            .expect("new Lix should open after cleanup")
+            .expect("new Lix open task")
+            .expect("open in-memory Lix");
+        drop(service);
+    }
+
+    #[tokio::test]
+    async fn failed_cleanup_keeps_cold_admission_closed() {
+        let manager = memory_manager(1);
+        let (sequence, done) = {
+            let mut state = manager.state.lock().await;
+            start_cleanup(&mut state, LIX_A.to_string()).expect("start test cleanup")
+        };
+        manager
+            .finish_cleanup(
+                LIX_A,
+                sequence,
+                done,
+                Err(anyhow::anyhow!("test-controlled cache delete failure")),
+            )
+            .await;
+
+        assert!(matches!(
+            manager.get(LIX_B).await,
+            Err(LixRuntimeError::Cleanup(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn recovery_removes_the_runtime_before_a_same_id_reopen() {
+        let manager = memory_manager(1);
+        let service = manager.get(LIX_A).await.expect("open Lix to recover");
+        manager.recover(LIX_A, &service).await;
+        drop(service);
+
+        let reopened = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                match manager.get(LIX_A).await {
+                    Ok(service) => break service,
+                    Err(LixRuntimeError::Recovering) => {
+                        tokio::time::sleep(Duration::from_millis(1)).await;
+                    }
+                    Err(error) => panic!("unexpected recovery result: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("recovery must release the runtime");
+        drop(reopened);
+    }
+
+    #[tokio::test]
+    async fn recovery_waits_for_inflight_runtime_cell_before_releasing_capacity() {
+        let manager = memory_manager(1);
+        let service = manager.get(LIX_A).await.expect("open Lix to recover");
+        let held_runtime_cell = {
+            let state = manager.state.lock().await;
+            Arc::clone(
+                &state
+                    .entries
+                    .get(LIX_A)
+                    .expect("opened Lix must have a runtime entry")
+                    .runtime,
+            )
+        };
+
+        manager.recover(LIX_A, &service).await;
+        drop(service);
+
+        let cleanup_started = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let state = manager.state.lock().await;
+                if state.cleaning.contains_key(LIX_A) {
+                    return true;
+                }
+                if !state.entries.contains_key(LIX_A) {
+                    return false;
+                }
+                drop(state);
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("recovery should either start cleanup or remove the runtime");
+        assert!(
+            cleanup_started,
+            "recovery completed while an in-flight runtime cell still retained the closed service"
+        );
+
+        let replacement_manager = Arc::clone(&manager);
+        let mut replacement = tokio::spawn(async move { replacement_manager.get(LIX_B).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut replacement)
+                .await
+                .is_err(),
+            "the retained runtime cell must keep recovery capacity occupied"
+        );
+
+        drop(held_runtime_cell);
+        let replacement = tokio::time::timeout(Duration::from_secs(1), replacement)
+            .await
+            .expect("replacement should resume after the runtime cell is released")
+            .expect("join replacement open")
+            .expect("open replacement Lix");
+        drop(replacement);
+    }
+
+    #[tokio::test]
+    async fn fenced_protocol_runtime_retires_without_waiting_for_finite_error_body() {
+        let manager = memory_manager(1);
+        let app = crate::router(
+            Arc::clone(&manager),
+            None,
+            Duration::from_secs(60),
+            crate::telemetry::InFlightSqlRegistry::default(),
+        );
+        let session = open_protocol_session(&app, LIX_A).await;
+        let object_store = match &manager.backend {
+            StorageBackend::Memory { object_store } => Arc::clone(object_store),
+            StorageBackend::S3 { .. } => unreachable!("memory manager must use in-memory storage"),
+        };
+        let fencer = SlateDB::open_object_store_with_options(
+            LIX_A,
+            object_store,
+            SlateDBObjectStoreOptions::default(),
+        )
+        .expect("open newer SlateDB writer");
+
+        // A completed second open fences the old SlateDB client, but the old
+        // client's asynchronous manifest poll is what surfaces that terminal
+        // state. Probe with an idempotent read rather than falsely assuming a
+        // just-fenced non-durable mutation will fail synchronously.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let response = loop {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/lix/v1/11111111-1111-4111-8111-111111111111/execute")
+                        .header(lix_sdk::server_protocol::SESSION_ID_HEADER, &session)
+                        .header("content-type", "application/json")
+                        .body(Body::from(r#"{"sql":"SELECT 1"}"#))
+                        .expect("fence probe request"),
+                )
+                .await
+                .expect("fence probe response");
+            if response.status() == http::StatusCode::CONFLICT {
+                break response;
+            }
+            assert_eq!(
+                response.status(),
+                http::StatusCode::OK,
+                "fence probe must either succeed before SlateDB closes the old writer or report its terminal error"
+            );
+            drop(response);
+            assert!(
+                Instant::now() < deadline,
+                "SlateDB did not report the fenced writer within the test deadline"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+
+        assert_eq!(response.status(), http::StatusCode::CONFLICT);
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
+        assert!(matches!(
+            manager.get(LIX_A).await,
+            Err(LixRuntimeError::Recovering)
+        ));
+
+        // A finite JSON error is already serialized. Holding its body must
+        // not keep the fenced runtime (and its capacity slot) alive forever.
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while manager.cached_lix_count().await != 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("fenced runtime must retire without waiting for its finite response body");
+
+        let error: JsonValue = serde_json::from_slice(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("fenced response body")
+                .to_bytes(),
+        )
+        .expect("fenced response JSON");
+        assert_eq!(error["error"]["code"], "LIX_STORAGE_FENCED");
+        assert_eq!(
+            error["error"]["details"],
+            json!({
+                "retryable": false,
+                "outcome": "unknown",
+            })
+        );
+
+        drop(fencer);
+        let reopened_session = open_protocol_session(&app, LIX_A).await;
+        let reopened = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/lix/v1/11111111-1111-4111-8111-111111111111/execute")
+                    .header(
+                        lix_sdk::server_protocol::SESSION_ID_HEADER,
+                        reopened_session,
+                    )
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"sql":"SELECT 1"}"#))
+                    .expect("reopened query request"),
+            )
+            .await
+            .expect("reopened query response");
+        assert_eq!(reopened.status(), http::StatusCode::OK);
+    }
+
+    async fn open_protocol_session(app: &axum::Router, lix_id: &str) -> String {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/lix/v1/{lix_id}/"))
+                    .body(Body::empty())
+                    .expect("protocol handshake request"),
+            )
+            .await
+            .expect("protocol handshake response");
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let body: JsonValue = serde_json::from_slice(
+            &response
+                .into_body()
+                .collect()
+                .await
+                .expect("protocol handshake body")
+                .to_bytes(),
+        )
+        .expect("protocol handshake JSON");
+        body["sessionId"]
+            .as_str()
+            .expect("protocol handshake session id")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn s3_request_policy_times_out_a_blackholed_head_request() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind blackhole listener");
+        let endpoint = format!(
+            "http://{}",
+            listener.local_addr().expect("blackhole listener address")
+        );
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let blackhole = tokio::spawn(async move {
+            let (connection, _) = listener
+                .accept()
+                .await
+                .expect("accept object-store request");
+            let _ = accepted_tx.send(());
+            std::future::pending::<()>().await;
+            drop(connection);
+        });
+        let test_budget = S3RequestBudget {
+            request_timeout: Duration::from_millis(100),
+            connect_timeout: Duration::from_millis(50),
+            retry_timeout: Duration::from_millis(100),
+            max_retries: 0,
+        };
+        let object_store = AmazonS3Builder::new()
+            .with_endpoint(endpoint)
+            .with_bucket_name("test-bucket")
+            .with_access_key_id("test-access-key")
+            .with_secret_access_key("test-secret-key")
+            .with_region("auto")
+            .with_client_options(s3_client_options(test_budget))
+            .with_retry(s3_retry_config(test_budget))
+            .with_allow_http(true)
+            .build()
+            .expect("build blackhole object store");
+
+        let started = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            object_store.head(&ObjectPath::from("blackholed-head")),
+        )
+        .await;
+        let acceptance = tokio::time::timeout(Duration::from_secs(1), accepted_rx).await;
+        blackhole.abort();
+        let _ = blackhole.await;
+        assert!(
+            matches!(acceptance, Ok(Ok(()))),
+            "the object-store request never reached the blackhole"
+        );
+
+        assert!(
+            matches!(result, Ok(Err(_))),
+            "unexpected result: {result:?}"
+        );
+        let elapsed = started.elapsed();
+        eprintln!("blackholed S3 HEAD returned after {elapsed:?}");
+        assert!(
+            elapsed < Duration::from_millis(750),
+            "blackholed request exceeded the configured budget: {:?}",
+            elapsed
+        );
+    }
+}

--- a/packages/server/src/telemetry.rs
+++ b/packages/server/src/telemetry.rs
@@ -1,0 +1,335 @@
+use anyhow::{Context, Result};
+use lix_sdk::telemetry::{OpenTelemetryTracingSink, TelemetrySink};
+use opentelemetry::{KeyValue, trace::TracerProvider as _};
+use opentelemetry_otlp::{Compression, Protocol, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::{
+    runtime,
+    trace::{
+        BatchConfigBuilder, SdkTracerProvider, SpanExporter,
+        span_processor_with_async_runtime::BatchSpanProcessor,
+    },
+};
+use std::{
+    collections::HashMap,
+    env,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tracing::{Subscriber, field::Visit, span::Attributes};
+use tracing_subscriber::{
+    EnvFilter, Layer,
+    fmt::format::FmtSpan,
+    layer::{Context as LayerContext, SubscriberExt},
+    registry::LookupSpan,
+};
+
+const PERF_SPAN_EVENTS_ENV: &str = "LIX_SERVER_PERF_SPANS";
+const OTEL_TELEMETRY_FILTER: &str = "lix_server=info,lix=info,lix_sql=info";
+
+#[derive(Clone, Debug, Default)]
+/// Tracks SQL spans that have started under a protocol request but have not closed.
+pub struct InFlightSqlRegistry {
+    inner: Arc<Mutex<InFlightSqlState>>,
+}
+
+#[derive(Debug, Default)]
+struct InFlightSqlState {
+    request_by_sql_span: HashMap<tracing::span::Id, tracing::span::Id>,
+    activity_by_request:
+        HashMap<tracing::span::Id, HashMap<tracing::span::Id, InFlightSqlActivity>>,
+    errors_by_request: HashMap<tracing::span::Id, Vec<InFlightSqlActivity>>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct InFlightSqlActivity {
+    pub(crate) operation: Option<String>,
+    pub(crate) fingerprint: Option<String>,
+    pub(crate) execution_kind: Option<String>,
+    pub(crate) batch_index: Option<u64>,
+    pub(crate) error_code: Option<String>,
+}
+
+impl InFlightSqlRegistry {
+    pub(crate) fn current(&self) -> Vec<InFlightSqlActivity> {
+        let Some(request_span_id) = tracing::Span::current().id() else {
+            return Vec::new();
+        };
+        let state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut activities = state
+            .activity_by_request
+            .get(&request_span_id)
+            .map(|activities| activities.values().cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
+        activities.sort_by_key(|activity| activity.batch_index);
+        activities
+    }
+
+    /// Drains completed SQL failures for the current protocol request.
+    ///
+    /// Lix SQL spans finish before the protocol response is returned. Keeping
+    /// only their redacted fingerprint and stable error code until this call
+    /// lets the HTTP boundary log actionable failures without buffering or
+    /// parsing request/response bodies.
+    pub(crate) fn take_errors(&self) -> Vec<InFlightSqlActivity> {
+        let Some(request_span_id) = tracing::Span::current().id() else {
+            return Vec::new();
+        };
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .errors_by_request
+            .remove(&request_span_id)
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct InFlightSqlLayer {
+    registry: InFlightSqlRegistry,
+}
+
+impl<S> Layer<S> for InFlightSqlLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(
+        &self,
+        attributes: &Attributes<'_>,
+        id: &tracing::span::Id,
+        context: LayerContext<'_, S>,
+    ) {
+        if attributes.metadata().name() != "lix.sql.query" {
+            return;
+        }
+        let Some(sql_span) = context.span(id) else {
+            return;
+        };
+        let mut ancestor = sql_span.parent();
+        let mut request_span_id = None;
+        while let Some(span) = ancestor {
+            if span.metadata().name() == "lix.protocol.request" {
+                request_span_id = Some(span.id().clone());
+                break;
+            }
+            ancestor = span.parent();
+        }
+        let Some(request_span_id) = request_span_id else {
+            return;
+        };
+
+        let mut activity = InFlightSqlActivity::default();
+        attributes.record(&mut SqlActivityVisitor(&mut activity));
+        let mut state = self
+            .registry
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state
+            .request_by_sql_span
+            .insert(id.clone(), request_span_id.clone());
+        state
+            .activity_by_request
+            .entry(request_span_id)
+            .or_default()
+            .insert(id.clone(), activity);
+    }
+
+    fn on_record(
+        &self,
+        id: &tracing::span::Id,
+        values: &tracing::span::Record<'_>,
+        _context: LayerContext<'_, S>,
+    ) {
+        let mut state = self
+            .registry
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(request_span_id) = state.request_by_sql_span.get(id).cloned() else {
+            return;
+        };
+        let Some(activity) = state
+            .activity_by_request
+            .get_mut(&request_span_id)
+            .and_then(|activities| activities.get_mut(id))
+        else {
+            return;
+        };
+        values.record(&mut SqlActivityVisitor(activity));
+    }
+
+    fn on_close(&self, id: tracing::span::Id, context: LayerContext<'_, S>) {
+        let mut state = self
+            .registry
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if context
+            .span(&id)
+            .is_some_and(|span| span.metadata().name() == "lix.protocol.request")
+        {
+            state.activity_by_request.remove(&id);
+            state.errors_by_request.remove(&id);
+            state
+                .request_by_sql_span
+                .retain(|_, request_span_id| request_span_id != &id);
+            return;
+        }
+        let Some(request_span_id) = state.request_by_sql_span.remove(&id) else {
+            return;
+        };
+        let (activity, remove_request) = state
+            .activity_by_request
+            .get_mut(&request_span_id)
+            .map_or((None, false), |activities| {
+                let activity = activities.remove(&id);
+                (activity, activities.is_empty())
+            });
+        if remove_request {
+            state.activity_by_request.remove(&request_span_id);
+        }
+        if let Some(activity) = activity {
+            if activity.error_code.is_some() {
+                state
+                    .errors_by_request
+                    .entry(request_span_id)
+                    .or_default()
+                    .push(activity);
+            }
+        }
+    }
+}
+
+struct SqlActivityVisitor<'a>(&'a mut InFlightSqlActivity);
+
+impl Visit for SqlActivityVisitor<'_> {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        match field.name() {
+            "db.operation.name" => self.0.operation = Some(value.to_string()),
+            "lix.sql.fingerprint" => self.0.fingerprint = Some(value.to_string()),
+            "lix.execution.kind" => self.0.execution_kind = Some(value.to_string()),
+            "error.type" => self.0.error_code = Some(value.to_string()),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "lix.batch.index" {
+            self.0.batch_index = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+/// Host-owned telemetry runtime. Lix receives only the vendor-neutral sink;
+/// exporters and filtering remain server concerns.
+pub struct TelemetryRuntime {
+    pub trace_provider: SdkTracerProvider,
+    pub in_flight_sql: InFlightSqlRegistry,
+    pub lix_sink: Arc<dyn TelemetrySink>,
+}
+
+impl std::fmt::Debug for TelemetryRuntime {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TelemetryRuntime")
+            .field("trace_provider", &self.trace_provider)
+            .field("in_flight_sql", &self.in_flight_sql)
+            .field("lix_sink", &"dyn TelemetrySink")
+            .finish()
+    }
+}
+
+/// Installs server tracing and builds the explicitly configured Lix sink.
+pub fn init() -> TelemetryRuntime {
+    let provider = match provider_from_env() {
+        Ok(provider) => provider,
+        Err(error) => {
+            eprintln!("failed to initialize OTLP telemetry; continuing without export: {error:#}");
+            SdkTracerProvider::builder().build()
+        }
+    };
+    let tracer = provider.tracer("lix-server");
+    let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let span_events = if perf_span_events_enabled() {
+        FmtSpan::CLOSE
+    } else {
+        FmtSpan::NONE
+    };
+    let in_flight_sql = InFlightSqlRegistry::default();
+    let log_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let telemetry_filter = EnvFilter::new(OTEL_TELEMETRY_FILTER);
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_span_events(span_events)
+                .with_filter(log_filter),
+        )
+        .with(telemetry_layer.with_filter(telemetry_filter))
+        .with(InFlightSqlLayer {
+            registry: in_flight_sql.clone(),
+        });
+    let dispatch = tracing::Dispatch::new(subscriber);
+    tracing::dispatcher::set_global_default(dispatch.clone())
+        .expect("install the lix-server tracing dispatch once");
+
+    TelemetryRuntime {
+        trace_provider: provider,
+        in_flight_sql,
+        lix_sink: Arc::new(OpenTelemetryTracingSink::new(dispatch)),
+    }
+}
+
+fn perf_span_events_enabled() -> bool {
+    env::var(PERF_SPAN_EVENTS_ENV)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "1" | "true"))
+}
+
+fn provider_from_env() -> Result<SdkTracerProvider> {
+    let Some(endpoint) = optional_nonempty_env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")? else {
+        return Ok(SdkTracerProvider::builder().build());
+    };
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .with_endpoint(endpoint)
+        .with_timeout(Duration::from_secs(5))
+        .with_compression(Compression::Gzip)
+        .build()
+        .context("build OTLP HTTP exporter")?;
+    let resource = opentelemetry_sdk::Resource::builder()
+        .with_service_name("lix-server")
+        .with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
+        .build();
+    Ok(SdkTracerProvider::builder()
+        .with_resource(resource)
+        .with_span_processor(batch_span_processor(exporter))
+        .build())
+}
+
+fn batch_span_processor<T>(exporter: T) -> BatchSpanProcessor<runtime::Tokio>
+where
+    T: SpanExporter + 'static,
+{
+    BatchSpanProcessor::builder(exporter, runtime::Tokio)
+        .with_batch_config(
+            BatchConfigBuilder::default()
+                .with_max_export_timeout(Duration::from_secs(5))
+                .build(),
+        )
+        .build()
+}
+
+fn optional_nonempty_env(name: &str) -> Result<Option<String>> {
+    match env::var(name) {
+        Ok(value) if value.trim().is_empty() => anyhow::bail!("{name} must not be empty when set"),
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {name}")),
+    }
+}


### PR DESCRIPTION
## Summary

- move the production-proven LixRay protocol data plane into `packages/server` as a supported reference implementation
- keep the Lix Server Protocol implementation-neutral: alternative servers can implement the documented HTTP and behavioral contract without using this binary
- publish `ghcr.io/opral/lix-server` once per Lix main commit with immutable `sha-<commit>` tags, a `main` convenience tag, and release tags
- preserve the multi-Lix SlateDB/S3 runtime pool, cache isolation, eviction, streaming leases, timeouts, recovery, and generic OTLP telemetry
- require internal bearer authentication and accept trusted account/idempotency identity only from the authenticated host boundary

## Boundary

This is an internal data plane, not a public product gateway. Supabase authentication/authorization, repository membership and existence policy, demo identity behavior, MCP routes, Railway configuration, and PostHog projection remain in LixRay.

`/healthz`, bearer authentication, and trusted identity headers are implementation-specific. `/lix/v1/{lix_id}` remains the protocol surface. The documentation explicitly permits independent compatible implementations in any language.

This PR does not switch LixRay yet. A follow-up will run the existing LixRay E2E suite against the published image, pin its digest, and then remove Rust compilation from the LixRay hot path.

## Validation

- `cargo test --package lix-server --lib` — 73 passed
- `cargo clippy --package lix-server --all-targets -- -D warnings`
- `cargo build --release --locked --package lix-server`
- `node scripts/validate-publish-surface.mjs`
- `node --test scripts/release.test.mjs` — 15 passed
- workflow YAML lint and `git diff --check`

The first GHCR publication creates a private package. An organization administrator must make `lix-server` public once; the workflow logs out and verifies an anonymous pull by exact digest, so it will fail visibly until that one-time setting is complete.

Based on latest `main` at `035aa6aff4cdbc321fa8c407198718cdcfba6f8d`.