### PR TITLE
fix: install mold in Lix server image builder

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -3,6 +3,13 @@
 FROM rust:1.93-bookworm AS builder
 WORKDIR /app
 
+# The repository Cargo configuration selects mold for Linux builds. Keep the
+# container builder aligned with CI so release builds have the configured
+# linker available.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends mold \
+    && rm -rf /var/lib/apt/lists/*
+
 # The build context is the Lix repository root. The reference server links the
 # exact protocol and SlateDB implementation from the same revision.
 COPY . .


### PR DESCRIPTION
## Summary

- install mold in the Lix reference-server Docker builder
- align the container with the repository Cargo linker configuration and CI hosts

## Why

The first post-merge GHCR publication failed because .cargo/config.toml selects mold on Linux while rust:1.93-bookworm does not include it.

## Validation

- git diff --check
- the post-merge Publish Lix reference server workflow will perform the authoritative Buildx build and push