### PR TITLE
Export remote snapshots through Lix

### DIFF
--- a/packages/js-sdk/src/remote/client.test.ts
+++ b/packages/js-sdk/src/remote/client.test.ts
@@ -38,6 +38,54 @@ test.each([
 	await binding.close();
 });
 
+test("remote exportSnapshot streams the canonical authenticated endpoint", async () => {
+	const requests: Request[] = [];
+	let headerCalls = 0;
+	const lix = await openLix({
+		server: {
+			mode: "remote",
+			url: "https://lixray.test/lix/01936f4e-7b6c-7c3d-8f9a-123456789abc",
+			headers: () => ({
+				Authorization: `Bearer token-${++headerCalls}`,
+				"Lix-Session-Id": "caller-session",
+			}),
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				requests.push(request);
+				const pathname = new URL(request.url).pathname;
+				if (pathname.endsWith("/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/")) {
+					return handshakeResponse();
+				}
+				if (pathname.endsWith("/snapshot")) {
+					return new Response(new Uint8Array([0x4c, 0x49, 0x58]), {
+						headers: {
+							"content-type": "application/vnd.lix.snapshot",
+						},
+					});
+				}
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				throw new Error(`Unexpected request: ${request.url}`);
+			},
+		},
+	});
+
+	const snapshot = lix.exportSnapshot();
+	expect(requests).toHaveLength(1);
+	expect(new Uint8Array(await new Response(snapshot).arrayBuffer())).toEqual(
+		new Uint8Array([0x4c, 0x49, 0x58]),
+	);
+	expect(new URL(requests[1]!.url).pathname).toBe(
+		"/lix/v1/01936f4e-7b6c-7c3d-8f9a-123456789abc/snapshot",
+	);
+	expect(requests[1]!.headers.get("authorization")).toBe("Bearer token-2");
+	expect(requests[1]!.headers.has("lix-session-id")).toBe(false);
+	expect(requests[1]!.headers.get("accept")).toBe("application/vnd.lix.snapshot");
+
+	await lix.close();
+});
+
 test("Lix Server Protocol handshake requests a restored initial active branch", async () => {
 	const accountId = "01920000-0000-7000-8000-000000000601";
 	const requests: Request[] = [];

--- a/packages/js-sdk/src/remote/client.ts
+++ b/packages/js-sdk/src/remote/client.ts
@@ -1,4 +1,4 @@
-import type { LixBinding } from "../binding-types.js";
+import type { LixBinding, SnapshotExportBinding } from "../binding-types.js";
 import { initializeBrowserWasm } from "../browser-wasm-init.js";
 import type { RemoteLixServerOptions } from "../types.js";
 
@@ -67,14 +67,118 @@ export async function openRemoteLixBinding(
 	) {
 		throw new TypeError("initialActiveBranchId must be a non-empty string");
 	}
-	const protocolLocator = connectionUrl(options.url).toString();
+	const locator = connectionUrl(options.url);
+	const protocolLocator = locator.toString();
 	await initializeWasm();
-	return openRemote(
+	const binding = (await openRemote(
 		protocolLocator,
 		remoteFetch,
 		options.headers,
 		clientOptions.initialActiveBranchId,
-	) as Promise<LixBinding>;
+	)) as LixBinding;
+	binding.exportSnapshot = () =>
+		remoteSnapshotExport({
+			url: snapshotUrl(locator),
+			fetch: remoteFetch,
+			headers: options.headers,
+		});
+	return binding;
+}
+
+function remoteSnapshotExport({
+	url,
+	fetch,
+	headers: headerSource,
+}: {
+	readonly url: URL;
+	readonly fetch: typeof globalThis.fetch;
+	readonly headers: RemoteLixServerOptions["headers"];
+}): SnapshotExportBinding {
+	const controller = new AbortController();
+	let canceled = false;
+	let readerPromise: Promise<ReadableStreamDefaultReader<Uint8Array>> | undefined;
+	const reader = () =>
+		(readerPromise ??= (async () => {
+			const resolvedHeaders =
+				typeof headerSource === "function" ? await headerSource() : headerSource;
+			const headers = new Headers(resolvedHeaders);
+			headers.delete("lix-session-id");
+			headers.delete("content-encoding");
+			headers.set("accept", "application/vnd.lix.snapshot");
+			const response = await fetch(url, {
+				headers,
+				signal: controller.signal,
+			});
+			if (!response.ok) throw await remoteSnapshotHttpError(response);
+			if (response.body === null) {
+				throw remoteSnapshotError(
+					"LIX_REMOTE_REQUEST_FAILED",
+					"Remote snapshot response did not contain a body",
+					{ httpStatus: response.status },
+				);
+			}
+			return response.body.getReader();
+		})());
+	return {
+		next: async () => {
+			if (canceled) return undefined;
+			const result = await (await reader()).read();
+			return result.done ? undefined : result.value;
+		},
+		cancel: async () => {
+			if (canceled) return;
+			canceled = true;
+			controller.abort();
+			const activeReader = await readerPromise?.catch(() => undefined);
+			await activeReader?.cancel().catch(() => undefined);
+		},
+	};
+}
+
+function snapshotUrl(locator: URL): URL {
+	const url = new URL(locator);
+	const lixId = url.pathname.slice("/lix/".length);
+	url.pathname = `/lix/v1/${lixId}/snapshot`;
+	return url;
+}
+
+async function remoteSnapshotHttpError(response: Response): Promise<Error> {
+	let body: {
+		error?: {
+			code?: string;
+			message?: string;
+			hint?: string;
+			details?: unknown;
+		};
+	} = {};
+	try {
+		body = (await response.json()) as typeof body;
+	} catch {
+		// A non-JSON proxy response still becomes a structured remote error.
+	}
+	const error = remoteSnapshotError(
+		body.error?.code ?? "LIX_REMOTE_REQUEST_FAILED",
+		body.error?.message ?? `Remote Lix request failed with status ${response.status}`,
+		{ httpStatus: response.status, remote: body.error?.details },
+	);
+	if (body.error?.hint !== undefined) error.hint = body.error.hint;
+	return error;
+}
+
+function remoteSnapshotError(
+	code: string,
+	message: string,
+	details: unknown,
+): Error & { code: string; details: unknown; hint?: string } {
+	const error = new Error(message) as Error & {
+		code: string;
+		details: unknown;
+		hint?: string;
+	};
+	error.name = "LixError";
+	error.code = code;
+	error.details = details;
+	return error;
 }
 
 function connectionUrl(value: string | URL): URL {


### PR DESCRIPTION
## Summary
- make `remoteLix.exportSnapshot()` stream the canonical server snapshot endpoint
- preserve configured authentication while excluding session-only transport headers
- return structured remote errors and support stream cancellation

## Verification
- `npm run typecheck`
- `npx vitest run src/remote/client.test.ts` (47 tests)