### PR TITLE
refactor(lix): remove obsolete SQL row pk column

### DIFF
--- a/.changenotes/remove-hidden-row-identity-column.md
+++ b/.changenotes/remove-hidden-row-identity-column.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Removed the obsolete hidden JSON primary-key projection from current SQL relations.
+
+Current relations now derive identity exclusively from their declared primary-key columns. Cross-relation addresses continue to use opaque row references, and derived columnar accelerators use a private physical identity field that is not part of any SQL schema.

--- a/packages/lix/src/hot_state/mod.rs
+++ b/packages/lix/src/hot_state/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod visibility;
 /// below both state planes; this facade only exists so the move did not have to
 /// touch every call site at once and can be dropped as those are migrated.
 pub(crate) use crate::row_columnar::{
-    ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY, ROW_COLUMNAR_ROW_PK_FIELD, RowColumnarWriteSets,
+    ROW_COLUMNAR_IDENTITY_FIELD, ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY, RowColumnarWriteSets,
     row_group_set_id,
 };
 #[allow(unused_imports)]

--- a/packages/lix/src/row_columnar.rs
+++ b/packages/lix/src/row_columnar.rs
@@ -7,7 +7,10 @@ use crate::columnar_row_group::{RowGroupRowLocation, RowGroupSetId};
 
 pub(crate) const ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY: &str =
     "lix.row_columnar.lossless_snapshot.v1";
-pub(crate) const ROW_COLUMNAR_ROW_PK_FIELD: &str = "lixcol_row_pk";
+// Persisted in immutable v1 row-group manifests. This is a private physical
+// field name, not a column in any SQL surface, and cannot be renamed without a
+// storage-format migration.
+pub(crate) const ROW_COLUMNAR_IDENTITY_FIELD: &str = "lixcol_row_pk";
 
 pub(crate) fn row_identity_column_index(
     manifest: &crate::columnar_row_group::RowGroupManifest,
@@ -19,7 +22,7 @@ pub(crate) fn row_identity_column_index(
         == Some("true"))
     .then(|| manifest.fields.len().checked_sub(1))
     .flatten()
-    .filter(|&index| manifest.fields[index].name == ROW_COLUMNAR_ROW_PK_FIELD)
+    .filter(|&index| manifest.fields[index].name == ROW_COLUMNAR_IDENTITY_FIELD)
 }
 
 pub(crate) struct RowColumnarWriteSets {

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -449,7 +449,6 @@ fn filesystem_schema(include_data: bool) -> SchemaRef {
         ]
     };
     fields.extend([
-        json_field("lixcol_row_pk", false),
         Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         Field::new("lixcol_global", DataType::Boolean, true),
@@ -580,7 +579,6 @@ fn row_hidden_columns(spec: &SchemaSurfaceSpec) -> Vec<PublicColumn> {
 
 fn filesystem_system_columns() -> Vec<PublicColumn> {
     vec![
-        PublicColumn::hidden("lixcol_row_pk", false),
         PublicColumn::hidden("lixcol_schema_key", false),
         PublicColumn::hidden("lixcol_file_id", true),
         PublicColumn::public_insert_only("lixcol_global", false).with_default("FALSE"),
@@ -595,9 +593,7 @@ fn filesystem_system_columns() -> Vec<PublicColumn> {
 
 fn row_system_columns(_spec: &SchemaSurfaceSpec, variant: SchemaSurfaceShape) -> Vec<PublicColumn> {
     debug_assert_ne!(variant, SchemaSurfaceShape::History);
-    let row_pk = PublicColumn::hidden("lixcol_row_pk", false);
     vec![
-        row_pk,
         PublicColumn::public_read_only("lixcol_schema_key", false),
         PublicColumn::public_insert_only("lixcol_file_id", true).optional_on_insert(),
         PublicColumn::public("lixcol_metadata", true).optional_on_insert(),

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -25,8 +25,7 @@ pub(crate) enum SchemaSurfaceShape {
 /// Relation payload must never use these names or introduce another
 /// `lixcol_` segment. Derived surfaces may preserve these names directly or
 /// through a structural side prefix such as `from_lixcol_created_at`.
-pub(crate) const TRACKED_ROW_SYSTEM_COLUMN_NAMES: [&str; 10] = [
-    "lixcol_row_pk",
+pub(crate) const TRACKED_ROW_SYSTEM_COLUMN_NAMES: [&str; 9] = [
     "lixcol_schema_key",
     "lixcol_file_id",
     "lixcol_metadata",
@@ -462,7 +461,6 @@ pub(crate) fn row_system_fields(shape: SchemaSurfaceShape) -> Vec<Field> {
     }
 
     vec![
-        json_field("lixcol_row_pk", true),
         Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         json_field("lixcol_metadata", true),

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -3560,7 +3560,7 @@ fn returning_expr_column_type(
     }
     match expr {
         BoundExpr::Column(column) | BoundExpr::ExcludedColumn(column) => match column.name.as_str() {
-            "lixcol_row_pk" | "lixcol_metadata" => Some(crate::ResultColumnType::Jsonb),
+            "lixcol_metadata" => Some(crate::ResultColumnType::Jsonb),
             "lixcol_global" | "lixcol_untracked" => Some(crate::ResultColumnType::Boolean),
             "lixcol_schema_key" | "lixcol_file_id" | "lixcol_created_at"
             | "lixcol_updated_at" | "lixcol_change_id" | "lixcol_commit_id" => {
@@ -4322,7 +4322,6 @@ enum InsertColumnTarget {
         column_type: SchemaColumnType,
         read_nullable: bool,
     },
-    RowPk,
     FileId,
     Metadata,
     Global,
@@ -4352,7 +4351,6 @@ impl InsertRowLayout {
                     });
                 }
                 Ok(match column.name.as_str() {
-                    "lixcol_row_pk" => InsertColumnTarget::RowPk,
                     "lixcol_file_id" => InsertColumnTarget::FileId,
                     "lixcol_metadata" => InsertColumnTarget::Metadata,
                     "lixcol_global" => InsertColumnTarget::Global,
@@ -5357,7 +5355,6 @@ fn certified_row_insert_rows<'a>(
                 ));
             }
 
-            let mut explicit_row_pk = None;
             let mut file_id = None;
             let mut metadata = None;
             let mut global = None;
@@ -5423,9 +5420,6 @@ fn certified_row_insert_rows<'a>(
                     InsertColumnTarget::Visible { .. } => {
                         unreachable!("visible columns handled above")
                     }
-                    InsertColumnTarget::RowPk => {
-                        explicit_row_pk = Some(row_pk_from_value(&value, "lixcol_row_pk")?);
-                    }
                     InsertColumnTarget::FileId => {
                         file_id = text_value(value, "lixcol_file_id")?;
                     }
@@ -5471,22 +5465,7 @@ fn certified_row_insert_rows<'a>(
                     ),
                 )
             })?;
-            let explicit_row_pk_parts = explicit_row_pk
-                .as_ref()
-                .map(|explicit| explicit.clone().into_parts());
             let derived_row_pk_parts = derived_row_pk.clone().into_parts();
-            if explicit_row_pk_parts
-                .as_ref()
-                .is_some_and(|explicit| explicit != &derived_row_pk_parts)
-            {
-                return Err(LixError::new(
-                    LixError::CODE_SCHEMA_VALIDATION,
-                    format!(
-                        "INSERT into {} has an internal identity that does not match its public primary-key columns",
-                        layout.schema_key
-                    ),
-                ));
-            }
 
             let start = normalized.len();
             normalized.push(b'{');
@@ -5709,9 +5688,6 @@ fn append_row_insert_row(
         let value = eval_value.into_json();
         match target {
             InsertColumnTarget::Visible { .. } => unreachable!("visible columns handled above"),
-            InsertColumnTarget::RowPk => {
-                row_pk = Some(row_pk_from_value(&value, "lixcol_row_pk")?);
-            }
             InsertColumnTarget::FileId => {
                 file_id = text_value(value, "lixcol_file_id")?;
             }
@@ -5760,17 +5736,6 @@ fn append_row_insert_row(
         };
         let (derived_row_pk, typed) =
             finalize_typed_row_with_plan(&layout.schema_key, native_schema_plan, typed)?;
-        if row_pk.as_ref().is_some_and(|explicit_row_pk| {
-            explicit_row_pk.clone().into_parts() != derived_row_pk.clone().into_parts()
-        }) {
-            return Err(LixError::new(
-                LixError::CODE_SCHEMA_VALIDATION,
-                format!(
-                    "INSERT into {} has an internal identity that does not match its public primary-key columns",
-                    layout.schema_key
-                ),
-            ));
-        }
         let global = global.unwrap_or(false);
         let branch_id = row_branch_id(plan, global)?;
         rows.push_typed_parts(
@@ -5813,17 +5778,6 @@ fn append_row_insert_row(
                 ),
             )
         })?;
-        if row_pk.as_ref().is_some_and(|explicit_row_pk| {
-            explicit_row_pk.clone().into_parts() != derived_row_pk.clone().into_parts()
-        }) {
-            return Err(LixError::new(
-                LixError::CODE_SCHEMA_VALIDATION,
-                format!(
-                    "INSERT into {} has an internal identity that does not match its public primary-key columns",
-                    layout.schema_key
-                ),
-            ));
-        }
         row_pk = Some(derived_row_pk);
     }
     let global = global.unwrap_or(false);
@@ -6012,13 +5966,6 @@ enum RowEvalRowRef<'a> {
 }
 
 impl<'a> RowEvalRowRef<'a> {
-    fn row_pk(self) -> Option<&'a RowPk> {
-        match self {
-            Self::Live(row) => Some(row.row_pk()),
-            Self::Staged(row) => row.row_pk,
-        }
-    }
-
     fn schema_key(self) -> &'a str {
         match self {
             Self::Live(row) => row.schema_key(),
@@ -6900,7 +6847,7 @@ fn is_identity_json_expr(expr: &BoundExpr) -> bool {
     matches!(
         expr,
         BoundExpr::Column(column) | BoundExpr::ExcludedColumn(column)
-            if matches!(column.name.as_str(), "row_pk" | "lixcol_row_pk")
+            if column.name == "row_pk"
     )
 }
 
@@ -6918,7 +6865,7 @@ fn bound_expr_is_json(expr: &BoundExpr, spec: &SchemaSurfaceSpec) -> bool {
         BoundExpr::Column(column) | BoundExpr::ExcludedColumn(column) => {
             spec.visible_column(&column.name)
                 .is_some_and(|column| column.column_type == SchemaColumnType::Jsonb)
-                || matches!(column.name.as_str(), "lixcol_row_pk" | "lixcol_metadata")
+                || column.name == "lixcol_metadata"
         }
         BoundExpr::Literal(BoundLiteral::Json(_)) => true,
         BoundExpr::Function { name, .. } => matches!(
@@ -7589,15 +7536,6 @@ fn column_eval_value(
         return Ok(RowEvalValue::SqlNull);
     };
     match column_name {
-        "lixcol_row_pk" => row
-            .row_pk()
-            .map(RowPk::as_json_array_value)
-            .transpose()
-            .map(|value| {
-                value
-                    .map(RowEvalValue::Json)
-                    .unwrap_or(RowEvalValue::SqlNull)
-            }),
         "lixcol_schema_key" => Ok(RowEvalValue::Json(JsonValue::String(
             row.schema_key().to_string(),
         ))),
@@ -7672,11 +7610,6 @@ fn excluded_column_eval_value(
         return Ok(RowEvalValue::SqlNull);
     };
     match column_name {
-        "lixcol_row_pk" => row
-            .row_pk
-            .map(|row_pk| row_pk.as_json_array_value().map(RowEvalValue::Json))
-            .transpose()
-            .map(|value| value.unwrap_or(RowEvalValue::SqlNull)),
         "lixcol_schema_key" => Ok(RowEvalValue::Json(JsonValue::String(
             row.schema_key.to_string(),
         ))),
@@ -7811,23 +7744,6 @@ fn bool_value(value: JsonValue, column_name: &str) -> Result<Option<bool>, LixEr
             LixError::CODE_TYPE_MISMATCH,
             format!("row write expected boolean column '{column_name}', got {other}"),
         )),
-    }
-}
-
-fn row_pk_from_value(value: &JsonValue, column_name: &str) -> Result<RowPk, LixError> {
-    match value {
-        JsonValue::String(value) => RowPk::from_json_array_text(value).map_err(|error| {
-            LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                format!("row write has invalid {column_name}: {error}"),
-            )
-        }),
-        value => RowPk::from_json_array_value(value).map_err(|error| {
-            LixError::new(
-                LixError::CODE_TYPE_MISMATCH,
-                format!("row write has invalid {column_name}: {error}"),
-            )
-        }),
     }
 }
 

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -2640,7 +2640,7 @@ fn is_identity_json_bound_expr(expr: &BoundExpr) -> bool {
     matches!(
         expr,
         BoundExpr::Column(column) | BoundExpr::ExcludedColumn(column)
-            if matches!(column.name.as_str(), "row_pk" | "lixcol_row_pk")
+            if column.name == "row_pk"
     )
 }
 

--- a/packages/lix/src/sql2/mod.rs
+++ b/packages/lix/src/sql2/mod.rs
@@ -112,7 +112,7 @@ pub(crate) use row_batch::{CurrentRowSnapshotReader, RowSnapshotReader};
 pub(crate) use row_columnar_layout::{
     EncodedRowGroups, LOW_CARDINALITY_CLUSTER_MAX_VALUES,
     ROW_COLUMNAR_BASE_COORDINATES_METADATA_KEY, ROW_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY,
-    ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY, ROW_COLUMNAR_ROW_PK_FIELD, RowColumnarRowRef,
+    ROW_COLUMNAR_IDENTITY_FIELD, ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY, RowColumnarRowRef,
     RowGroupLocations, encode_registered_row_groups, encode_unclustered_registered_row_groups,
 };
 pub(crate) use row_projection::RowProjectionDecoder;

--- a/packages/lix/src/sql2/predicate_typecheck.rs
+++ b/packages/lix/src/sql2/predicate_typecheck.rs
@@ -468,7 +468,7 @@ fn is_json_expr<'a>(
 
 fn is_identity_json_expr(expr: &Expr) -> bool {
     match expr {
-        Expr::Column(column) => matches!(column.name.as_str(), "row_pk" | "lixcol_row_pk"),
+        Expr::Column(column) => column.name == "row_pk",
         Expr::Alias(alias) => is_identity_json_expr(&alias.expr),
         Expr::Cast(cast) => is_identity_json_expr(&cast.expr),
         Expr::TryCast(cast) => is_identity_json_expr(&cast.expr),

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -218,9 +218,7 @@ impl DiffRelation {
         }
         fields.push(Field::new("diff_type", DataType::Utf8, false));
         for column in surface.columns.iter().filter(|column| {
-            column.is_public()
-                && column.name != "lixcol_row_pk"
-                && !primary_key_columns.contains(&column.name)
+            column.is_public() && !primary_key_columns.contains(&column.name)
         }) {
             let field = source_schema
                 .field_with_name(&column.name)
@@ -542,7 +540,7 @@ impl DiffRoute {
                 .any(|(_, column)| {
                     !matches!(
                         column,
-                        "id" | "lixcol_row_pk"
+                        "id"
                             | "lixcol_schema_key"
                             | "lixcol_file_id"
                             | "lixcol_created_at"
@@ -597,7 +595,6 @@ struct DiffSide {
     schema_key: String,
     global: bool,
     file_id: Option<String>,
-    row_pk: RowPk,
     created_at: String,
     updated_at: String,
     change_id: String,
@@ -1011,7 +1008,6 @@ fn diff_side(
             row_pk: entry.identity.row_pk().clone(),
         }),
         file_id: entry.identity.file_id().map(str::to_string),
-        row_pk: entry.identity.row_pk().clone(),
         created_at: row.created_at.to_string(),
         updated_at: row.updated_at.to_string(),
         change_id: row.change_id.to_string(),
@@ -1104,7 +1100,7 @@ where
         .any(|(_, column)| {
             !matches!(
                 column,
-                "id" | "lixcol_row_pk"
+                "id"
                     | "lixcol_schema_key"
                     | "lixcol_file_id"
                     | "lixcol_created_at"
@@ -1350,7 +1346,6 @@ fn materialized_side(
         schema_key: row.schema_key().to_string(),
         global: row.schema_key() == crate::checkpoint::CHECKPOINT_SCHEMA_KEY,
         file_id: row.file_id().map(str::to_string),
-        row_pk: row.row_pk().clone(),
         created_at: row.created_at().to_string(),
         updated_at: row.updated_at().to_string(),
         change_id: row.change_id().to_string(),
@@ -1593,12 +1588,6 @@ fn side_value(side: Option<&DiffSide>, column: &str) -> Result<Option<lix_schema
     Ok(match column {
         "id" => side.id.clone().map(lix_schema::Value::Text),
         "path" => side.path.clone().map(lix_schema::Value::Text),
-        "lixcol_row_pk" => Some(lix_schema::Value::Jsonb(
-            side.row_pk
-                .as_json_array_value()
-                .map_err(lix_error_to_datafusion_error)?
-                .into(),
-        )),
         "lixcol_schema_key" => Some(lix_schema::Value::Text(side.schema_key.clone())),
         "lixcol_file_id" => side.file_id.clone().map(lix_schema::Value::Text),
         "lixcol_created_at" => Some(lix_schema::Value::Text(side.created_at.clone())),
@@ -1725,7 +1714,6 @@ mod tests {
         assert!(field_is_row_ref(
             relation.schema.field_with_name("row_ref").unwrap()
         ));
-        assert!(!names.contains(&"lixcol_row_pk"));
         assert!(!names.contains(&"from_key"));
         assert!(!names.contains(&"to_key"));
         assert_eq!(names.last(), Some(&"row_count"));

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -1214,7 +1214,6 @@ fn lix_directory_surface_name(branch_binding: &BranchBinding) -> &'static str {
 }
 
 trait DirectoryLiveRow {
-    fn row_pk_json(&self) -> Result<String, LixError>;
     fn schema_key(&self) -> &str;
     fn file_id(&self) -> Option<&str>;
     fn global(&self) -> bool;
@@ -1227,10 +1226,6 @@ trait DirectoryLiveRow {
 }
 
 impl DirectoryLiveRow for MaterializedHotStateRow {
-    fn row_pk_json(&self) -> Result<String, LixError> {
-        self.row_pk.as_json_array_text()
-    }
-
     fn schema_key(&self) -> &str {
         &self.schema_key
     }
@@ -1269,10 +1264,6 @@ impl DirectoryLiveRow for MaterializedHotStateRow {
 }
 
 impl DirectoryLiveRow for MaterializedHotStateRowRef<'_> {
-    fn row_pk_json(&self) -> Result<String, LixError> {
-        (*self).row_pk().as_json_array_text()
-    }
-
     fn schema_key(&self) -> &str {
         (*self).schema_key()
     }
@@ -1606,7 +1597,6 @@ fn lix_directory_write_rows_from_batch_with_options_and_path_resolvers(
     let mut rows = RawWriteBatch::with_capacity(batch.num_rows().saturating_mul(3));
     for row_index in 0..batch.num_rows() {
         if reject_read_only_fields {
-            reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_row_pk")?;
             reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_schema_key")?;
             reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_change_id")?;
             reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_created_at")?;
@@ -1948,7 +1938,6 @@ where
     let mut paths = Vec::new();
     let mut parent_ids = Vec::new();
     let mut names = Vec::new();
-    let mut row_pks = Vec::new();
     let mut schema_keys = Vec::new();
     let mut file_ids = Vec::new();
     let mut globals = Vec::new();
@@ -1964,7 +1953,6 @@ where
         paths.push(path);
         parent_ids.push(directory.parent_id);
         names.push(Some(directory.name));
-        row_pks.push(Some(directory.live.row_pk_json()?));
         schema_keys.push(Some(directory.live.schema_key().to_owned()));
         file_ids.push(directory.live.file_id().map(str::to_owned));
         globals.push(Some(directory.live.global()));
@@ -1983,7 +1971,6 @@ where
             "path" => Arc::new(StringArray::from(paths.clone())),
             "parent_id" => Arc::new(StringArray::from(parent_ids.clone())),
             "name" => Arc::new(StringArray::from(names.clone())),
-            "lixcol_row_pk" => Arc::new(StringArray::from(row_pks.clone())),
             "lixcol_schema_key" => Arc::new(StringArray::from(schema_keys.clone())),
             "lixcol_file_id" => Arc::new(StringArray::from(file_ids.clone())),
             "lixcol_global" => Arc::new(BooleanArray::from(globals.clone())),
@@ -2250,7 +2237,6 @@ pub(super) fn lix_directory_schema() -> SchemaRef {
         Field::new("path", DataType::Utf8, true),
         Field::new("parent_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, false),
-        json_field("lixcol_row_pk", false),
         Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         Field::new("lixcol_global", DataType::Boolean, true),

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -4026,7 +4026,6 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
 
     for row_index in 0..batch.num_rows() {
         if reject_read_only_fields {
-            reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_row_pk")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_schema_key")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_change_id")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_created_at")?;
@@ -4678,12 +4677,6 @@ fn lix_file_record_batch_from_path_selection(
             "content" => Arc::new(LargeBinaryArray::from(
                 entries.iter().map(|_| Some(&[][..])).collect::<Vec<_>>(),
             )),
-            "lixcol_row_pk" => Arc::new(StringArray::from(
-                entries
-                    .iter()
-                    .map(|entry| file_id_row_pk(entry.id())?.as_json_array_text().map(Some))
-                    .collect::<Result<Vec<_>, _>>()?,
-            )),
             "lixcol_schema_key" => {
                 Arc::new(StringArray::from(vec![
                     Some(FILE_DESCRIPTOR_SCHEMA_KEY);
@@ -4762,7 +4755,6 @@ struct LixFileRecordBatchRow {
     directory_id: Option<String>,
     name: String,
     data: Option<Vec<u8>>,
-    row_pk: String,
     file_id: Option<String>,
     global: bool,
     change_id: Option<String>,
@@ -4780,7 +4772,6 @@ struct LixFileRecordBatchColumns {
     directory_ids: Vec<Option<String>>,
     names: Vec<Option<String>>,
     data_values: Vec<Option<Vec<u8>>>,
-    row_pks: Vec<Option<String>>,
     schema_keys: Vec<Option<String>>,
     file_ids: Vec<Option<String>>,
     globals: Vec<Option<bool>>,
@@ -4799,7 +4790,6 @@ impl LixFileRecordBatchColumns {
         self.directory_ids.push(row.directory_id);
         self.names.push(Some(row.name));
         self.data_values.push(row.data);
-        self.row_pks.push(Some(row.row_pk));
         self.schema_keys
             .push(Some(FILE_DESCRIPTOR_SCHEMA_KEY.to_string()));
         self.file_ids.push(row.file_id);
@@ -4820,7 +4810,6 @@ impl LixFileRecordBatchColumns {
             directory_ids,
             names,
             data_values,
-            row_pks,
             schema_keys,
             file_ids,
             globals,
@@ -4841,7 +4830,6 @@ impl LixFileRecordBatchColumns {
                 .map(|value| value.as_deref())
                 .collect::<Vec<_>>(),
         ));
-        let row_pks: ArrayRef = Arc::new(StringArray::from(row_pks));
         let schema_keys: ArrayRef = Arc::new(StringArray::from(schema_keys));
         let file_ids: ArrayRef = Arc::new(StringArray::from(file_ids));
         let globals: ArrayRef = Arc::new(BooleanArray::from(globals));
@@ -4860,7 +4848,6 @@ impl LixFileRecordBatchColumns {
                 "directory_id" => Arc::clone(&directory_ids),
                 "name" => Arc::clone(&names),
                 "content" => Arc::clone(&data_values),
-                "lixcol_row_pk" => Arc::clone(&row_pks),
                 "lixcol_schema_key" => Arc::clone(&schema_keys),
                 "lixcol_file_id" => Arc::clone(&file_ids),
                 "lixcol_global" => Arc::clone(&globals),
@@ -4975,7 +4962,6 @@ async fn lix_file_record_batch_from_prepared(
             directory_id,
             name,
             data,
-            row_pk: live.row_pk().as_json_array_text()?,
             file_id: live.file_id().map(str::to_owned),
             global: live.global(),
             change_id: projected_change_id.map(|id| id.to_string()),
@@ -6878,7 +6864,6 @@ pub(super) fn lix_file_schema() -> SchemaRef {
         Field::new("directory_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, false),
         Field::new("content", DataType::LargeBinary, false),
-        json_field("lixcol_row_pk", false),
         Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         Field::new("lixcol_global", DataType::Boolean, true),
@@ -7538,7 +7523,6 @@ mod tests {
             "path",
             "directory_id",
             "name",
-            "lixcol_row_pk",
             "lixcol_schema_key",
             "lixcol_commit_id",
             "lixcol_metadata",
@@ -7577,10 +7561,6 @@ mod tests {
             "01920000-0000-7000-8000-0000000000d3"
         );
         assert_eq!(string_value("name"), "readme.md");
-        assert_eq!(
-            string_value("lixcol_row_pk"),
-            "[\"01920000-0000-7000-8000-0000000000d2\"]"
-        );
         assert_eq!(
             string_value("lixcol_schema_key"),
             super::FILE_DESCRIPTOR_SCHEMA_KEY

--- a/packages/lix/src/sql2/providers/history_util.rs
+++ b/packages/lix/src/sql2/providers/history_util.rs
@@ -2,8 +2,7 @@ use crate::LixError;
 use crate::common::SharedStr;
 use crate::tracked_state::{MaterializedTrackedStateBatch, MaterializedTrackedStateRowRef};
 
-/// Project a single-string history row pk as the canonical JSON array
-/// text exposed by the `lixcol_row_pk` column.
+/// Project a single-string history row primary key as canonical JSON array text.
 pub(super) fn row_pk_json_array(row_pk: &str) -> Result<String, LixError> {
     serde_json::to_string(&[row_pk]).map_err(|error| {
         LixError::unknown(format!("failed to encode history row pk as JSON: {error}"))

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use base64::Engine as _;
 #[cfg(test)]
 use datafusion::arrow::array::Array;
 use datafusion::arrow::array::{
@@ -61,7 +62,7 @@ use super::spec::{
     row_source, scan_row_source, take_record_batch_rows,
 };
 use super::values::{
-    optional_bool_value, optional_string_value, required_string_value, string_expr_literal,
+    optional_bool_value, optional_string_value, string_expr_literal,
 };
 
 /// Executes the already-proved unique registered-schema point shape without
@@ -350,17 +351,12 @@ impl SchemaSpec {
         batch: &RecordBatch,
         row_index: usize,
     ) -> Result<RowReturningKey> {
-        let row_pk = RowPk::from_json_array_text(&required_string_value(
+        let row_pk = row_pk_from_primary_key_columns(
             batch,
             row_index,
-            "lixcol_row_pk",
-            "UPDATE schema surface RETURNING",
-        )?)
-        .map_err(|error| {
-            DataFusionError::Execution(format!(
-                "UPDATE schema surface RETURNING has invalid lixcol_row_pk: {error}"
-            ))
-        })?;
+            &self.spec,
+            SchemaRowIdentityUse::UpdateReturning,
+        )?;
         let branch_id = String::new();
         Ok(RowReturningKey { row_pk, branch_id })
     }
@@ -967,7 +963,7 @@ async fn row_columnar_scan_source(
         .fields
         .iter()
         .position(|field| {
-            field.name == crate::sql2::ROW_COLUMNAR_ROW_PK_FIELD
+            field.name == crate::sql2::ROW_COLUMNAR_IDENTITY_FIELD
                 && field.data_type.to_arrow() == datafusion::arrow::datatypes::DataType::Utf8
         })
         .ok_or_else(|| {
@@ -1568,6 +1564,85 @@ fn contains_like_filter(expr: &Expr) -> bool {
     }
 }
 
+#[derive(Clone, Copy)]
+enum SchemaRowIdentityUse {
+    Delete,
+    Update,
+    UpdateReturning,
+}
+
+impl SchemaRowIdentityUse {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Delete => "DELETE FROM schema surface",
+            Self::Update => "UPDATE schema surface",
+            Self::UpdateReturning => "UPDATE schema surface RETURNING",
+        }
+    }
+}
+
+fn row_pk_from_primary_key_columns(
+    batch: &RecordBatch,
+    row_index: usize,
+    spec: &SchemaSurfaceSpec,
+    purpose: SchemaRowIdentityUse,
+) -> Result<RowPk> {
+    let purpose = purpose.label();
+    let parts = spec
+        .primary_key_paths
+        .iter()
+        .zip(&spec.primary_key_component_types)
+        .map(|(path, component_type)| {
+            let [column_name] = path.as_slice() else {
+                return Err(DataFusionError::Execution(format!(
+                    "{purpose} cannot derive a row identity from a nested primary-key path"
+                )));
+            };
+            let column_index = batch.schema().index_of(column_name).map_err(|_| {
+                DataFusionError::Execution(format!(
+                    "{purpose} is missing primary-key column '{column_name}'"
+                ))
+            })?;
+            let value = ScalarValue::try_from_array(batch.column(column_index).as_ref(), row_index)
+                .map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "{purpose} failed to decode primary-key column '{column_name}': {error}"
+                    ))
+                })?;
+            match (component_type, value) {
+                (
+                    crate::row_pk::RowPkComponentType::String
+                    | crate::row_pk::RowPkComponentType::Uuid,
+                    ScalarValue::Utf8(Some(value))
+                    | ScalarValue::LargeUtf8(Some(value))
+                    | ScalarValue::Utf8View(Some(value)),
+                ) => Ok(value),
+                (
+                    crate::row_pk::RowPkComponentType::Integer,
+                    ScalarValue::Int64(Some(value)),
+                ) => {
+                    Ok(value.to_string())
+                }
+                (
+                    crate::row_pk::RowPkComponentType::Bytes,
+                    ScalarValue::Binary(Some(value))
+                    | ScalarValue::LargeBinary(Some(value))
+                    | ScalarValue::BinaryView(Some(value)),
+                ) => Ok(base64::engine::general_purpose::STANDARD.encode(value)),
+                (_, value) => Err(DataFusionError::Execution(format!(
+                    "{purpose} primary-key column '{column_name}' has invalid value {value:?}"
+                ))),
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RowPk::from_external_parts(parts, &spec.primary_key_component_types).map_err(|error| {
+        DataFusionError::Execution(format!(
+            "{purpose} failed to derive row identity for schema '{}': {error}",
+            spec.schema_key
+        ))
+    })
+}
+
 fn row_delete_stage_rows_from_batch(
     batch: &RecordBatch,
     spec: &SchemaSurfaceSpec,
@@ -1590,17 +1665,12 @@ fn row_delete_stage_rows_from_batch(
                 .expect("active row surface has an active branch")
                 .to_owned()
         };
-        let row_pk = RowPk::from_json_array_text(&required_string_value(
+        let row_pk = row_pk_from_primary_key_columns(
             batch,
             row_index,
-            "lixcol_row_pk",
-            "DELETE FROM schema surface",
-        )?)
-        .map_err(|error| {
-            DataFusionError::Execution(format!(
-                "DELETE FROM schema surface has invalid lixcol_row_pk: {error}"
-            ))
-        })?;
+            spec,
+            SchemaRowIdentityUse::Delete,
+        )?;
         let metadata = optional_string_value(
             batch,
             row_index,
@@ -1670,17 +1740,12 @@ fn row_update_stage_rows_from_batch(
                 .expect("active row surface has an active branch")
                 .to_owned()
         };
-        let row_pk = RowPk::from_json_array_text(&required_string_value(
+        let row_pk = row_pk_from_primary_key_columns(
             batch,
             row_index,
-            "lixcol_row_pk",
-            "UPDATE schema surface",
-        )?)
-        .map_err(|error| {
-            DataFusionError::Execution(format!(
-                "UPDATE schema surface has invalid lixcol_row_pk: {error}"
-            ))
-        })?;
+            spec,
+            SchemaRowIdentityUse::Update,
+        )?;
         let snapshot_content = update_snapshots
             .get(&RowUpdateSnapshotKey {
                 row_pk: row_pk.clone(),
@@ -3287,18 +3352,6 @@ fn row_pk_constraint_from_in_list_filter(
         return None;
     }
     match column.name.as_str() {
-        "lixcol_row_pk" => in_list
-            .list
-            .iter()
-            .map(string_expr_literal)
-            .collect::<Option<Vec<_>>>()?
-            .into_iter()
-            .map(|value| {
-                let parts = RowPk::from_json_array_text(&value).ok()?.into_parts();
-                RowPk::from_external_parts(parts, component_types).ok()
-            })
-            .collect::<Option<BTreeSet<_>>>()
-            .map(RowPkConstraint::Full),
         column_name if primary_key_columns.contains(&column_name) => {
             let component_type =
                 primary_key_component_type(column_name, primary_key_columns, component_types)?;
@@ -3326,12 +3379,6 @@ fn row_pk_constraint_from_column_literal_filter(
         return None;
     };
     match column.name.as_str() {
-        "lixcol_row_pk" => RowPk::from_json_array_text(&string_expr_literal(literal_expr)?)
-            .ok()
-            .and_then(|identity| {
-                RowPk::from_external_parts(identity.into_parts(), component_types).ok()
-            })
-            .map(|identity| RowPkConstraint::Full(BTreeSet::from([identity]))),
         column_name if primary_key_columns.contains(&column_name) => {
             let component_type =
                 primary_key_component_type(column_name, primary_key_columns, component_types)?;
@@ -4128,12 +4175,6 @@ fn row_system_column_array(
 ) -> Result<ArrayRef> {
     #[expect(trivial_casts)]
     let array = match column_name {
-        "row_pk" => Arc::new(StringArray::from(
-            rows.iter()
-                .map(|row| row.row_pk().as_json_array_text().map(Some))
-                .collect::<std::result::Result<Vec<_>, LixError>>()
-                .map_err(lix_error_to_datafusion_error)?,
-        )) as ArrayRef,
         "schema_key" => Arc::new(StringArray::from_iter(
             rows.iter().map(|row| Some(row.schema_key())),
         )) as ArrayRef,
@@ -4669,7 +4710,7 @@ mod tests {
     #[test]
     fn direct_row_batch_accepts_exact_payload_reads() {
         let payload_schema = Schema::new(vec![Field::new("body", DataType::Utf8, true)]);
-        let system_schema = Schema::new(vec![Field::new("lixcol_row_pk", DataType::Utf8, true)]);
+        let system_schema = Schema::new(vec![Field::new("lixcol_metadata", DataType::Utf8, true)]);
         let mut request = HotStateScanRequest::default();
         assert!(super::direct_row_batch_eligible(
             &payload_schema,
@@ -5238,7 +5279,7 @@ mod tests {
             spec.visible_column("meta").map(|column| column.column_type),
             Some(SchemaColumnType::Jsonb)
         );
-        assert!(spec.visible_column("lixcol_row_pk").is_none());
+        assert!(spec.visible_column("lixcol_metadata").is_none());
     }
 
     #[test]
@@ -5272,8 +5313,25 @@ mod tests {
         .expect("schema should derive schema surface spec");
 
         let schema = schema_surface_schema(&spec, SchemaSurfaceShape::Active);
-        assert!(schema.field_with_name("body").is_ok());
-        assert!(schema.field_with_name("lixcol_row_pk").is_ok());
+        assert_eq!(
+            schema
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "body",
+                "lixcol_schema_key",
+                "lixcol_file_id",
+                "lixcol_metadata",
+                "lixcol_created_at",
+                "lixcol_updated_at",
+                "lixcol_global",
+                "lixcol_change_id",
+                "lixcol_commit_id",
+                "lixcol_untracked",
+            ]
+        );
         assert!(schema.field_with_name("lixcol_branch_id").is_err());
     }
 
@@ -5297,13 +5355,6 @@ mod tests {
                 .expect("id field")
                 .is_nullable(),
             "read nullability must not encode that INSERT may omit a defaulted id"
-        );
-        assert!(
-            schema
-                .field_with_name("lixcol_row_pk")
-                .expect("row pk field")
-                .is_nullable(),
-            "opaque identity projection should be nullable for normal primary-key inserts"
         );
     }
 
@@ -5365,16 +5416,6 @@ mod tests {
                 .expect("count is i64")
                 .value(0),
             7
-        );
-        assert_eq!(
-            batch
-                .column_by_name("lixcol_row_pk")
-                .expect("row pk column")
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .expect("row pk is string")
-                .value(0),
-            "[\"row-1\"]"
         );
     }
 
@@ -5560,7 +5601,6 @@ mod tests {
 
         for field in [
             "lixcol_metadata",
-            "lixcol_row_pk",
             "lixcol_file_id",
             "lixcol_global",
             "lixcol_untracked",
@@ -6126,11 +6166,11 @@ mod tests {
             "branch-a".to_string(),
             None,
         );
-        let row_pk_index = provider
+        let identity_index = provider
             .schema
-            .index_of("lixcol_row_pk")
-            .expect("system row-pk column should exist");
-        let projection = vec![row_pk_index];
+            .index_of("id")
+            .expect("declared primary-key column should exist");
+        let projection = vec![identity_index];
 
         let (_schema, request, row_filters) = provider
             .plan_scan_parts(Some(&projection), &[eq_filter("kind", "todo")], Some(5))
@@ -6176,11 +6216,11 @@ mod tests {
             "branch-a".to_string(),
             None,
         );
-        let row_pk_index = provider
+        let identity_index = provider
             .schema
-            .index_of("lixcol_row_pk")
-            .expect("system row-pk column should exist");
-        let projection = vec![row_pk_index];
+            .index_of("id")
+            .expect("declared primary-key column should exist");
+        let projection = vec![identity_index];
         let range_filter = Expr::BinaryExpr(BinaryExpr::new(
             Box::new(column("score")),
             Operator::Gt,
@@ -6215,11 +6255,11 @@ mod tests {
             "branch-a".to_string(),
             None,
         );
-        let row_pk_index = provider
+        let identity_index = provider
             .schema
-            .index_of("lixcol_row_pk")
-            .expect("system row-pk column should exist");
-        let projection = vec![row_pk_index];
+            .index_of("id")
+            .expect("declared primary-key column should exist");
+        let projection = vec![identity_index];
         let filter = Expr::BinaryExpr(BinaryExpr::new(
             Box::new(column("count")),
             Operator::Eq,
@@ -6601,7 +6641,7 @@ mod tests {
         ]));
         let physical_schema = Arc::new(Schema::new(vec![
             Field::new(
-                crate::sql2::ROW_COLUMNAR_ROW_PK_FIELD,
+                crate::sql2::ROW_COLUMNAR_IDENTITY_FIELD,
                 DataType::Utf8,
                 false,
             ),

--- a/packages/lix/src/sql2/providers/state_at.rs
+++ b/packages/lix/src/sql2/providers/state_at.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::{Mutex, OnceLock};
 
 use async_trait::async_trait;
-use datafusion::arrow::datatypes::{Schema, SchemaRef};
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::{TableFunctionImpl, TableProvider};
 use datafusion::common::{DataFusionError, Result};
@@ -159,20 +159,6 @@ where
                 "lix_state_at does not support relation '{relation_name}'"
             ))
         })?;
-        // Historical relation state has the same typed relation columns as the
-        // live surface. The durable JSON row key is an engine implementation
-        // detail, however, and must not reappear through this table function.
-        // Callers can construct a universal address from the typed key columns
-        // with `lix_row_ref(relation, ...)` when they need one.
-        let schema = Arc::new(Schema::new_with_metadata(
-            schema
-                .fields()
-                .iter()
-                .filter(|field| field.name() != "lixcol_row_pk")
-                .map(|field| field.as_ref().clone())
-                .collect::<Vec<_>>(),
-            schema.metadata().clone(),
-        ));
         let kind = match &surface.kind {
             PublicSurfaceKind::SchemaBase { schema_key } => StateRelationKind::Schema {
                 schema_key: schema_key.clone(),

--- a/packages/lix/src/sql2/row_columnar_layout.rs
+++ b/packages/lix/src/sql2/row_columnar_layout.rs
@@ -29,7 +29,7 @@ pub(crate) const ROW_COLUMNAR_LAYOUT_FINGERPRINT_METADATA_KEY: &str =
 pub(crate) const ROW_COLUMNAR_BASE_COORDINATES_METADATA_KEY: &str =
     "lix.row_columnar.base_coordinates.v1";
 pub(crate) use crate::hot_state::{
-    ROW_COLUMNAR_ROW_PK_FIELD, ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY,
+    ROW_COLUMNAR_IDENTITY_FIELD, ROW_COLUMNAR_LOSSLESS_SNAPSHOT_METADATA_KEY,
 };
 pub(crate) const LOW_CARDINALITY_CLUSTER_MAX_VALUES: usize = 64;
 const LOW_CARDINALITY_CLUSTER_MAX_BUCKETS: usize = 8;
@@ -204,7 +204,7 @@ pub(crate) fn encode_unclustered_registered_row_groups(
 
     let mut fields = row_visible_fields(spec);
     fields.push(Field::new(
-        ROW_COLUMNAR_ROW_PK_FIELD,
+        ROW_COLUMNAR_IDENTITY_FIELD,
         DataType::Utf8,
         false,
     ));
@@ -241,7 +241,7 @@ where
 {
     let mut fields = row_visible_fields(spec);
     fields.push(Field::new(
-        ROW_COLUMNAR_ROW_PK_FIELD,
+        ROW_COLUMNAR_IDENTITY_FIELD,
         DataType::Utf8,
         false,
     ));
@@ -484,7 +484,7 @@ mod tests {
             .manifest
             .fields
             .iter()
-            .position(|field| field.name == ROW_COLUMNAR_ROW_PK_FIELD)
+            .position(|field| field.name == ROW_COLUMNAR_IDENTITY_FIELD)
             .expect("hidden identity field");
         assert_eq!(
             encoded.manifest.fields[identity_index].data_type.to_arrow(),
@@ -695,7 +695,7 @@ mod tests {
             .manifest
             .fields
             .iter()
-            .position(|field| field.name == ROW_COLUMNAR_ROW_PK_FIELD)
+            .position(|field| field.name == ROW_COLUMNAR_IDENTITY_FIELD)
             .expect("hidden identity field");
 
         assert_eq!(encoded.input_locations.len(), identities.len());

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -247,13 +247,11 @@ simulation_test!(state_at_matches_live_columns_and_unchanged_row_metadata, |sim|
         )
         .await
         .expect("historical wildcard should load");
-    assert!(
-        historical_star
-            .columns()
-            .iter()
-            .all(|column| column != "lixcol_row_pk"),
-        "lix_state_at must not expose the durable JSON row key"
-    );
+    let current_star = session
+        .execute("SELECT * FROM lix_key_value WHERE key = 'stable'", &[])
+        .await
+        .expect("current wildcard should load");
+    assert_eq!(historical_star.columns(), current_star.columns());
 });
 
 simulation_test!(state_at_omits_deleted_and_untracked_rows, |sim| async move {


### PR DESCRIPTION
## Summary

- remove the obsolete hidden JSON row-primary-key projection from active schema, file, and directory SQL surfaces
- derive UPDATE, DELETE, and RETURNING identities from each relation's declared primary-key columns
- remove the obsolete predicate/projection paths while retaining the immutable v1 row-group wire spelling for storage compatibility

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p lix --lib --tests`
- `cargo nextest run -p lix --no-fail-fast` (3012 passed, 28 skipped)
- `cargo test -p lix --doc` (10 passed)