### PR TITLE
ci: reduce redundant Rust jobs and repair build caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,19 @@ jobs:
     name: Changelog
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
+    outputs:
+      rust: ${{ steps.scope.outputs.rust }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Include both parents of the tested PR merge for scope detection.
+          fetch-depth: 2
+
+      - name: Select Rust CI scope
+        id: scope
+        run: node scripts/ci-rust-scope.mjs
 
       - name: Validate change fragments
         run: node scripts/validate-changes.mjs
@@ -39,7 +48,7 @@ jobs:
         run: node scripts/validate-server-protocol-docs.mjs
 
       - name: Validate CI workflow invariants
-        run: node --test scripts/ci-workflow.test.mjs
+        run: node --test scripts/ci-workflow.test.mjs scripts/ci-rust-scope.test.mjs
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})
@@ -67,8 +76,13 @@ jobs:
 
   cargo:
     name: Cargo ${{ matrix.name }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changelog
+    if: needs.changelog.outputs.rust != 'false' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ${{ matrix.runner }}
+    env:
+      # The root Cargo config otherwise sends --manifest-path tooling builds
+      # to root/target, while the cache and reports expect tooling/target.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/${{ matrix.workspace }}/target
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +90,9 @@ jobs:
           - name: Clippy
             task: clippy
             workspace: .
+            cache_workspaces: |
+              . -> target
+              tooling -> target
             runner: blacksmith-32vcpu-ubuntu-2404
           - name: Test
             task: test
@@ -128,14 +145,14 @@ jobs:
         with:
           tool: nextest
 
-      # Pull requests restore dependency artifacts seeded by main but never
-      # publish branch-specific target caches. Workspace crates remain
-      # excluded so source changes always rebuild Lix itself.
+      # Main seeds dependency caches; PRs only restore them. Clippy executes
+      # both workspaces, so retain tooling dependencies as well as root ones.
       - name: Restore Cargo dependency cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: cargo-${{ matrix.task }}
-          workspaces: ${{ matrix.workspace }}
+          key: explicit-targets-v1
+          workspaces: ${{ matrix.cache_workspaces || matrix.workspace }}
           cache-targets: true
           cache-workspace-crates: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -154,6 +171,8 @@ jobs:
         if: matrix.task == 'clippy'
         run: |
           cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings
+          # Keep tooling artifacts in the second cached target directory.
+          export CARGO_TARGET_DIR="$GITHUB_WORKSPACE/tooling/target"
           cargo clippy --locked --manifest-path tooling/Cargo.toml --profile test --workspace --exclude lix_e2e --all-targets --all-features -- -D warnings
           cargo clippy --locked --manifest-path tooling/Cargo.toml --profile test -p lix_e2e --all-targets --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace,system-allocation-profiler -- -D warnings
 
@@ -353,7 +372,10 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci
+          # Native uses test/dev profiles; Browser uses release Wasm. A single
+          # immutable key lets the first writer seed only its own build modes.
+          shared-key: ci-js-${{ matrix.runtime }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Restore compiler cache
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/scripts/ci-rust-scope.mjs
+++ b/scripts/ci-rust-scope.mjs
@@ -1,0 +1,87 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+// Only the SDK's handwritten TypeScript is known not to affect the Rust-only
+// suites. Both SDK jobs still build Rust and run their native/browser tests.
+// Unknown paths (including fixtures, manifests and build scripts) run full CI.
+export function isSdkOnlyChange(paths) {
+	const sdkSource = (path) =>
+		/^packages\/js-sdk\/src\/.+\.ts$/.test(path) &&
+		!path.startsWith("packages/js-sdk/src/wasm/");
+	return (
+		paths.some(sdkSource) &&
+		paths.every(
+			(path) => sdkSource(path) || /^\.changenotes\/[^/]+\.md$/.test(path),
+		)
+	);
+}
+
+export function selectRustScope({ eventName, event, cwd = process.cwd() }) {
+	if (eventName !== "pull_request") return true;
+	try {
+		const git = (...args) =>
+			execFileSync("git", args, {
+				cwd,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+				maxBuffer: 16 * 1024 * 1024,
+			});
+		const [head, base, prHead, ...extra] = git(
+			"rev-list",
+			"--parents",
+			"-n",
+			"1",
+			"HEAD",
+		)
+			.trim()
+			.split(/\s+/);
+		// Diff the actual tested merge against its first parent, including base
+		// updates. Missing/shallow history or a head checkout must run full CI.
+		if (
+			!base ||
+			!prHead ||
+			extra.length ||
+			prHead !== event?.pull_request?.head?.sha
+		) {
+			return true;
+		}
+		// Disable rename detection so moving a Rust input into an allowed path
+		// still exposes the deleted Rust path. NUL delimiters preserve filenames.
+		const paths = git(
+			"diff",
+			"--name-only",
+			"--no-renames",
+			"-z",
+			base,
+			head,
+			"--",
+		)
+			.split("\0")
+			.filter(Boolean);
+		return !isSdkOnlyChange(paths);
+	} catch {
+		return true;
+	}
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	let rust = true;
+	try {
+		rust = selectRustScope({
+			eventName: process.env.GITHUB_EVENT_NAME,
+			event: JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8")),
+		});
+	} catch {
+		// An unreadable event must never suppress the Rust checks.
+	}
+	appendFileSync(process.env.GITHUB_OUTPUT, `rust=${rust}\n`);
+	console.log(
+		rust
+			? "Run all Rust checks (Rust/unknown inputs, push, dispatch, or uncertain diff)."
+			: "SDK TypeScript-only PR: run both SDK suites; skip the four Rust-only jobs.",
+	);
+}

--- a/scripts/ci-rust-scope.test.mjs
+++ b/scripts/ci-rust-scope.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { isSdkOnlyChange, selectRustScope } from "./ci-rust-scope.mjs";
+
+test("SDK TypeScript and changenotes do not require Rust-only suites", () => {
+	assert.equal(
+		isSdkOnlyChange([
+			"packages/js-sdk/src/binding.browser.ts",
+			"packages/js-sdk/src/remote/client-initialization.test.ts",
+			".changenotes/share-sdk-wasm-initialization.md",
+		]),
+		true,
+	);
+});
+
+test("mixed, unknown, generated, and Rust inputs always require Rust CI", () => {
+	for (const path of [
+		"packages/lix/src/lib.rs",
+		"packages/js-sdk/src/lib.rs",
+		"packages/js-sdk/src/wasm/lix_js_sdk.d.ts",
+		"packages/js-sdk/build.rs",
+		"packages/js-sdk/package.json",
+		"packages/js-sdk/scripts/build-wasm.js",
+		"packages/e2e/tests/fixtures/example.json",
+		"plugins/markdown/schema/markdown_node.json",
+		"Cargo.lock",
+		"tooling/Cargo.toml",
+		"rust-toolchain.toml",
+		".cargo/config.toml",
+		".github/workflows/ci.yml",
+		"scripts/ci-rust-scope.mjs",
+		"new-package/source.ts",
+		"packages/js-sdk/src/file.ts\nCargo.toml",
+	]) {
+		assert.equal(
+			isSdkOnlyChange(["packages/js-sdk/src/index.ts", path]),
+			false,
+			path,
+		);
+	}
+	assert.equal(isSdkOnlyChange([]), false);
+	assert.equal(isSdkOnlyChange([".changenotes/release.md"]), false);
+});
+
+test("pushes, manual runs and unavailable history keep full CI", () => {
+	for (const eventName of ["push", "workflow_dispatch", undefined]) {
+		assert.equal(selectRustScope({ eventName }), true);
+	}
+	assert.equal(
+		selectRustScope({ eventName: "pull_request", cwd: "/nonexistent-ci-repo" }),
+		true,
+	);
+});
+
+test("classify the tested merge, preserve rename deletions, and fail open on shallow history", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "lix-ci-scope-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const cwd = join(root, "repo");
+	mkdirSync(cwd);
+	const git = (...args) =>
+		execFileSync("git", args, {
+			cwd,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		}).trim();
+	const write = (path, contents) => {
+		mkdirSync(dirname(join(cwd, path)), { recursive: true });
+		writeFileSync(join(cwd, path), contents);
+	};
+	const commit = () => {
+		git("add", ".");
+		git("commit", "-qm", "fixture");
+		return git("rev-parse", "HEAD");
+	};
+	git("init", "-b", "main");
+	git("config", "user.name", "CI test");
+	git("config", "user.email", "ci@example.invalid");
+	write("packages/lix/src/lib.rs", "pub fn initial() {}\n");
+	write("packages/js-sdk/src/index.ts", "export const initial = true;\n");
+	const originalBase = commit();
+	git("checkout", "-qb", "sdk");
+	write("packages/js-sdk/src/index.ts", "export const changed = true;\n");
+	const prHead = commit();
+	const event = {
+		pull_request: { base: { sha: originalBase }, head: { sha: prHead } },
+	};
+	// A direct head checkout is insufficient evidence to skip.
+	assert.equal(
+		selectRustScope({ eventName: "pull_request", event, cwd }),
+		true,
+	);
+	git("checkout", "main");
+	write("packages/lix/src/lib.rs", "pub fn updated_base() {}\n");
+	commit();
+	git("merge", "--no-ff", "sdk", "-m", "tested merge");
+	assert.equal(
+		selectRustScope({ eventName: "pull_request", event, cwd }),
+		false,
+	);
+	assert.equal(
+		selectRustScope({ eventName: "pull_request", event: {}, cwd }),
+		true,
+	);
+	const shallow = join(root, "shallow");
+	git("clone", "--depth=1", `file://${cwd}`, shallow);
+	assert.equal(
+		selectRustScope({ eventName: "pull_request", event, cwd: shallow }),
+		true,
+	);
+	const twoParents = join(root, "two-parents");
+	git("clone", "--depth=2", `file://${cwd}`, twoParents);
+	assert.equal(
+		selectRustScope({ eventName: "pull_request", event, cwd: twoParents }),
+		false,
+	);
+	// Renaming an existing Rust file to .ts must not hide the Rust deletion.
+	git("checkout", "-qb", "rename");
+	git("mv", "packages/lix/src/lib.rs", "packages/js-sdk/src/renamed.ts");
+	const renameHead = commit();
+	git("checkout", "main");
+	git("merge", "--no-ff", "rename", "-m", "rename merge");
+	assert.equal(
+		selectRustScope({
+			eventName: "pull_request",
+			event: { pull_request: { head: { sha: renameHead } } },
+			cwd,
+		}),
+		true,
+	);
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -40,10 +40,32 @@ test("Rust test scopes run independently with workspace-specific caches", () => 
 			),
 		);
 	}
-	assert.match(workflow, /workspaces: \$\{\{ matrix\.workspace \}\}/);
+	assert.match(workflow, /workspaces: \$\{\{ matrix\.cache_workspaces \|\| matrix\.workspace \}\}/);
 	assert.match(workflow, /name: rust-nextest-junit-\$\{\{ matrix\.task \}\}/);
 	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
 	assert.match(workflow, /name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/);
+});
+
+test("Rust scope gates only Rust jobs and keeps both SDK integration suites", () => {
+	const cargo = workflow.split("\n  cargo:\n")[1].split("\n  js-sdk-test:\n")[0];
+	assert.match(cargo, /needs: changelog/);
+	assert.match(cargo, /if: needs\.changelog\.outputs\.rust != 'false'/);
+	const sdk = workflow.split("\n  js-sdk-test:\n")[1].split("\n  preview-artifact-changes:\n")[0];
+	assert.doesNotMatch(sdk, /needs:|outputs\.rust/);
+	assert.match(workflow, /fetch-depth: 2/);
+	assert.match(workflow, /rust: \$\{\{ steps\.scope\.outputs\.rust \}\}/);
+	assert.match(workflow, /run: node scripts\/ci-rust-scope\.mjs/);
+});
+
+test("Clippy caches both workspaces and SDK build modes have separate main-seeded caches", () => {
+	assert.match(workflow, /cache_workspaces: \|\n\s+\. -> target\n\s+tooling -> target/);
+	assert.match(workflow, /shared-key: ci-js-\$\{\{ matrix\.runtime \}\}\n\s+save-if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/);
+});
+
+test("Cargo output directories match the workspace caches and timing uploads", () => {
+	assert.match(workflow, /CARGO_TARGET_DIR: \$\{\{ github\.workspace \}\}\/\$\{\{ matrix\.workspace \}\}\/target/);
+	assert.match(workflow, /export CARGO_TARGET_DIR="\$GITHUB_WORKSPACE\/tooling\/target"\n\s+cargo clippy/);
+	assert.match(workflow, /path: \$\{\{ matrix\.workspace \}\}\/target\/cargo-timings\/\*\.html/);
 });
 
 test("short support jobs use free standard runners for the public repository", () => {


### PR DESCRIPTION
SDK TypeScript-only PRs currently run four Rust-only jobs even when their Rust inputs are unchanged. In [run 34051607514](https://github.com/opral/lix/actions/runs/34051607514), these jobs accounted for 26.3 runner-minutes, or 65.6% of the six Blacksmith jobs' elapsed core-minutes. This is a compute estimate, not a measured invoice reduction.

This change:

- Uses the existing Changelog job to detect PRs changing only handwritten `packages/js-sdk/src/**/*.ts` files and accompanying changenotes. These PRs skip Clippy, Cargo Test, Tooling Test, and E2E Test. Both native and browser SDK jobs still build Rust and run their integration suites. Pushes, manual runs, Rust/build/fixture changes, and unknown paths run the full pipeline. The detector compares the actual tested merge with its first parent, handles rename deletions, and defaults to full CI when history or event data is uncertain.
- Makes Cargo target directories match the caches and timing uploads. The sampled Tooling job restored `tooling/target`, but actually built into root `target` and uploaded no Cargo timing report. Clippy now uses and caches separate root and tooling target directories.
- Splits the SDK Rust cache by native/browser runtime. Both previously restored the same immutable 2.5 GB cache despite building different test/dev/release profiles. Main seeds the new caches; PRs restore them without uploading branch-specific target caches.

All runner labels, Rust feature coverage, production Wasm optimization settings, and release workflows are unchanged. New cache keys require a successful main run to populate; warm-cache savings have not yet been measured. Compiled workspace-crate caching remains disabled; simply enabling it would not establish reliable reuse across fresh checkouts.

Validation:

- 31 tests passed: `node --test scripts/ci-workflow.test.mjs scripts/ci-rust-scope.test.mjs scripts/release.test.mjs`.
- Git fixture tests cover updated merge bases, renames, unknown/mixed changes, shallow history, direct head checkouts, push and manual events.
- Replayed the exact tested merge `0393858b3bf0678bf419fee8650c1db031d78a2f` from #1676: classified as SDK-only.
- `actionlint` 1.7.12; Prettier on the workflow and new scripts; change-fragment, server-protocol, and publish-surface validation; `git diff --check`.
- Verified `cargo metadata` with the new tooling target setting resolves to `tooling/target`.

All 12 jobs passed in [full PR CI](https://github.com/opral/lix/actions/runs/34052590466) on bc77390952ad0bda49998e96551dfd99711d5de9. The live Tooling job wrote its Cargo timing report to tooling/target and uploaded it successfully. Warm-cache performance still needs measurement after the new caches are seeded.
