### PR TITLE
ci: use free public runners and reuse unchanged builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
+    - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-16vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404-arm

--- a/.github/actions/prepare-linux-runner/action.yml
+++ b/.github/actions/prepare-linux-runner/action.yml
@@ -1,0 +1,17 @@
+name: Prepare Linux build runner
+description: Free space for Rust and Docker outputs on standard GitHub runners.
+
+runs:
+  using: composite
+  steps:
+    - name: Reclaim unused preinstalled SDK space
+      if: runner.environment == 'github-hosted'
+      shell: bash
+      run: |
+        # Fresh, disposable GitHub VMs include SDKs this Rust/Node repository
+        # never uses. Keep Rust, LLVM, Node, browsers and Docker intact.
+        sudo rm -rf /usr/local/lib/android /usr/share/dotnet /usr/share/swift \
+          /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+        sudo apt-get clean
+        df -h "$GITHUB_WORKSPACE"
+        free -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       runner_provider:
-        description: Standard GitHub runners by default; Blacksmith is an explicit compilation fallback
+        description: Use the smallest qualified runners by default; Blacksmith forces larger compilation runners
         type: choice
-        default: github
+        default: default
         options:
-          - github
+          - default
           - blacksmith
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -86,7 +86,7 @@ jobs:
     name: Cargo ${{ matrix.name }}
     needs: changelog
     if: needs.changelog.outputs.rust != 'false' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || matrix.default_runner || 'ubuntu-24.04' }}
     timeout-minutes: 45
     env:
       # The root Cargo config otherwise sends --manifest-path tooling builds
@@ -107,6 +107,9 @@ jobs:
             task: test
             workspace: .
             junit: target/nextest/ci/junit.xml
+            # The 16 GiB GitHub VM shut down twice during this compilation.
+            # Use 32 GiB here; the other Rust/SDK jobs passed on free runners.
+            default_runner: blacksmith-8vcpu-ubuntu-2404
             blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
           - name: Tooling Test
             task: tooling
@@ -126,10 +129,10 @@ jobs:
       - name: Prepare Linux build runner
         uses: ./.github/actions/prepare-linux-runner
 
-      - name: Limit root test compilation concurrency on GitHub
+      - name: Limit root test compilation concurrency
         if: matrix.task == 'test' && inputs.runner_provider != 'blacksmith'
-        # Leave headroom for the large root test crate on the 16 GiB VM.
-        run: echo 'CARGO_BUILD_JOBS=2' >> "$GITHUB_ENV"
+        # Leave headroom for the large root test crate on the 32 GiB VM.
+        run: echo 'CARGO_BUILD_JOBS=4' >> "$GITHUB_ENV"
 
       - name: set envs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
           package_archive="$(find target/package -maxdepth 1 -type f -name 'lix-[0-9]*.crate' | head -n 1)"
           schema_archive="$(find target/package -maxdepth 1 -type f -name 'lix-schema-*.crate' | head -n 1)"
           tar -tf "$package_archive" |
-            rg '^[^/]+/wit/lix-plugin\.wit$'
+            grep -E '^[^/]+/wit/lix-plugin\.wit$'
           packaged_lix="$(mktemp -d)"
           packaged_schema="$(mktemp -d)"
           tar -xf "$package_archive" -C "$packaged_lix" --strip-components=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: node scripts/validate-server-protocol-docs.mjs
 
       - name: Validate CI workflow invariants
-        run: node --test scripts/ci-workflow.test.mjs scripts/ci-rust-scope.test.mjs
+        run: node --test scripts/ci-workflow.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})
@@ -98,7 +98,7 @@ jobs:
             task: test
             workspace: .
             junit: target/nextest/ci/junit.xml
-            runner: blacksmith-32vcpu-ubuntu-2404
+            runner: blacksmith-16vcpu-ubuntu-2404
           - name: Tooling Test
             task: tooling
             workspace: tooling
@@ -357,19 +357,35 @@ jobs:
           BINSTALL_NO_CONFIRM=true
           EOF
 
+      - name: Fingerprint SDK binary build inputs
+        id: binary-key
+        run: node scripts/ci-sdk-cache.mjs key '${{ matrix.runtime }}'
+
+      - name: Restore exact-input SDK binaries
+        id: binaries
+        uses: actions/cache/restore@v4
+        with:
+          path: .ci-sdk-cache/${{ matrix.runtime }}
+          key: ${{ steps.binary-key.outputs.key }}
+
+      - name: Validate restored SDK binaries
+        id: binary-cache
+        run: node scripts/ci-sdk-cache.mjs check '${{ matrix.runtime }}' '${{ steps.binary-key.outputs.key }}'
+
       - name: Install LLVM build dependencies
-        if: matrix.runtime == 'native'
+        if: matrix.runtime == 'native' && steps.binary-cache.outputs.reuse != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y llvm-dev libclang-dev clang mold
 
       - name: Install mold for WebAssembly host tooling
-        if: matrix.runtime == 'browser'
+        if: matrix.runtime == 'browser' && steps.binary-cache.outputs.reuse != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y mold
 
       - name: Restore Rust cache
+        if: steps.binary-cache.outputs.reuse != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           # Native uses test/dev profiles; Browser uses release Wasm. A single
@@ -378,9 +394,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Restore compiler cache
+        if: steps.binary-cache.outputs.reuse != 'true'
         uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Enable compiler cache
+        if: steps.binary-cache.outputs.reuse != 'true'
         run: |
           grep -v "^#" << "EOF" >> "$GITHUB_ENV"
           SCCACHE_GHA_ENABLED=true
@@ -388,12 +406,15 @@ jobs:
           EOF
 
       - name: Install plugin build target
+        if: steps.binary-cache.outputs.reuse != 'true'
         run: rustup target add wasm32-wasip2
 
       - name: Install WebAssembly build target
+        if: steps.binary-cache.outputs.reuse != 'true'
         run: rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-bindgen CLI
+        if: steps.binary-cache.outputs.reuse != 'true'
         uses: taiki-e/install-action@v2
         with:
           tool: wasm-bindgen-cli@0.2.122
@@ -427,15 +448,26 @@ jobs:
         working-directory: packages/js-sdk
         run: npx playwright install --with-deps chromium
 
-      - name: Build native JS SDK
-        if: matrix.runtime == 'native'
-        working-directory: packages/js-sdk
+      - name: Build JS SDK with exact-input binary reuse
+        env:
+          REUSE_BINARIES: ${{ steps.binary-cache.outputs.reuse }}
+          BINARY_KEY: ${{ steps.binary-key.outputs.key }}
+          SDK_RUNTIME: ${{ matrix.runtime }}
         run: |
-          npm run clean
-          npm run build:native
-          npm run build:wasm:dev
-          npm run build:ts
-          npm run build:plugins
+          npm --prefix packages/js-sdk run clean
+          if [ "$REUSE_BINARIES" = true ]; then
+            node scripts/ci-sdk-cache.mjs restore "$SDK_RUNTIME" "$BINARY_KEY"
+          else
+            if [ "$SDK_RUNTIME" = native ]; then
+              npm --prefix packages/js-sdk run build:native
+              npm --prefix packages/js-sdk run build:wasm:dev
+            else
+              npm --prefix packages/js-sdk run build:wasm
+            fi
+            npm --prefix packages/js-sdk run build:plugins
+            node scripts/ci-sdk-cache.mjs save "$SDK_RUNTIME" "$BINARY_KEY"
+          fi
+          npm --prefix packages/js-sdk run build:ts
 
       - name: Build and check filesystem storage package
         if: matrix.runtime == 'native'
@@ -454,13 +486,6 @@ jobs:
         if: matrix.runtime == 'native'
         working-directory: packages/js-sdk
         run: npm exec -- vitest run
-
-      - name: Build browser JS SDK
-        if: matrix.runtime == 'browser'
-        working-directory: packages/js-sdk
-        # This is also the artifact consumed by LixRay. Build and test the
-        # production-sized WASM once here instead of recompiling it downstream.
-        run: npm run build:browser
 
       - name: Build and check OPFS storage package
         if: matrix.runtime == 'browser'
@@ -512,6 +537,13 @@ jobs:
           compression-level: 0
           retention-days: 90
 
+      - name: Cache successfully tested SDK binaries
+        if: steps.binary-cache.outputs.reuse != 'true' && steps.binaries.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .ci-sdk-cache/${{ matrix.runtime }}
+          key: ${{ steps.binary-key.outputs.key }}
+
   preview-artifact-changes:
     name: Select preview artifacts
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
@@ -534,7 +566,7 @@ jobs:
         run: |
           if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
             .cargo \
-            .github/workflows/ci.yml \
+            .dockerignore \
             Cargo.lock \
             Cargo.toml \
             rust-toolchain.toml \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      runner_provider:
+        description: Standard GitHub runners by default; Blacksmith is an explicit compilation fallback
+        type: choice
+        default: github
+        options:
+          - github
+          - blacksmith
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
@@ -78,7 +86,8 @@ jobs:
     name: Cargo ${{ matrix.name }}
     needs: changelog
     if: needs.changelog.outputs.rust != 'false' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || 'ubuntu-24.04' }}
+    timeout-minutes: 45
     env:
       # The root Cargo config otherwise sends --manifest-path tooling builds
       # to root/target, while the cache and reports expect tooling/target.
@@ -93,26 +102,29 @@ jobs:
             cache_workspaces: |
               . -> target
               tooling -> target
-            runner: blacksmith-32vcpu-ubuntu-2404
+            blacksmith_runner: blacksmith-32vcpu-ubuntu-2404
           - name: Test
             task: test
             workspace: .
             junit: target/nextest/ci/junit.xml
-            runner: blacksmith-16vcpu-ubuntu-2404
+            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
           - name: Tooling Test
             task: tooling
             workspace: tooling
             junit: tooling/target/nextest/ci/junit.xml
-            runner: blacksmith-16vcpu-ubuntu-2404
+            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
           - name: E2E Test
             task: e2e
             workspace: tooling
             junit: tooling/target/nextest/ci-e2e/junit.xml
-            runner: blacksmith-16vcpu-ubuntu-2404
+            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Prepare Linux build runner
+        uses: ./.github/actions/prepare-linux-runner
 
       - name: set envs
         run: |
@@ -310,10 +322,17 @@ jobs:
           cp packages/lix/examples/plugin_minimal.rs "$downstream/src/lib.rs"
           cargo build --manifest-path "$downstream/Cargo.toml" --target wasm32-wasip2
 
+      - name: Report remaining runner resources
+        if: always()
+        run: |
+          df -h "$GITHUB_WORKSPACE"
+          free -h
+
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || 'ubuntu-24.04' }}
+    timeout-minutes: 45
     env:
       # Pull request workflows normally check out GitHub's synthetic merge
       # commit. Consumers pin the real source commit as a submodule, so build
@@ -325,10 +344,10 @@ jobs:
         include:
           - name: Native
             runtime: native
-            runner: blacksmith-16vcpu-ubuntu-2404
+            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
           - name: Browser
             runtime: browser
-            runner: blacksmith-32vcpu-ubuntu-2404
+            blacksmith_runner: blacksmith-32vcpu-ubuntu-2404
 
     steps:
       - name: Checkout repository
@@ -371,6 +390,10 @@ jobs:
       - name: Validate restored SDK binaries
         id: binary-cache
         run: node scripts/ci-sdk-cache.mjs check '${{ matrix.runtime }}' '${{ steps.binary-key.outputs.key }}'
+
+      - name: Prepare Linux build runner
+        if: steps.binary-cache.outputs.reuse != 'true'
+        uses: ./.github/actions/prepare-linux-runner
 
       - name: Install LLVM build dependencies
         if: matrix.runtime == 'native' && steps.binary-cache.outputs.reuse != 'true'
@@ -544,6 +567,12 @@ jobs:
           path: .ci-sdk-cache/${{ matrix.runtime }}
           key: ${{ steps.binary-key.outputs.key }}
 
+      - name: Report remaining runner resources
+        if: always()
+        run: |
+          df -h "$GITHUB_WORKSPACE"
+          free -h
+
   preview-artifact-changes:
     name: Select preview artifacts
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
@@ -586,7 +615,8 @@ jobs:
     name: Lix server preview artifact
     if: needs.preview-artifact-changes.outputs.server == 'true'
     needs: preview-artifact-changes
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ${{ inputs.runner_provider == 'blacksmith' && 'blacksmith-32vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
+    timeout-minutes: 45
     env:
       LIX_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
 
@@ -595,6 +625,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.LIX_SOURCE_SHA }}
+
+      - name: Prepare Linux build runner
+        uses: ./.github/actions/prepare-linux-runner
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -645,3 +678,9 @@ jobs:
           if-no-files-found: error
           compression-level: 0
           retention-days: 14
+
+      - name: Report remaining runner resources
+        if: always()
+        run: |
+          df -h "$GITHUB_WORKSPACE"
+          free -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
       - name: Prepare Linux build runner
         uses: ./.github/actions/prepare-linux-runner
 
+      - name: Limit root test compilation concurrency on GitHub
+        if: matrix.task == 'test' && inputs.runner_provider != 'blacksmith'
+        # Leave headroom for the large root test crate on the 16 GiB VM.
+        run: echo 'CARGO_BUILD_JOBS=2' >> "$GITHUB_ENV"
+
       - name: set envs
         run: |
           grep -v "^#" << "EOF" >> "$GITHUB_ENV"
@@ -531,8 +536,6 @@ jobs:
         run: |
           npm run test:browser:built
           npm run test:browser:production
-          npm run benchmark
-          npm run benchmark:multi-tab
 
       - name: Describe reusable browser SDK artifact
         if: matrix.runtime == 'browser'
@@ -547,18 +550,18 @@ jobs:
           }, null, 2));
           EOF
 
-      - name: Upload tested browser SDK for submodule consumers
+      - name: Share browser SDK with performance checks
         if: matrix.runtime == 'browser'
         uses: actions/upload-artifact@v4
         with:
-          name: lix-browser-sdk-${{ env.LIX_SOURCE_SHA }}
+          name: lix-browser-sdk-build-${{ env.LIX_SOURCE_SHA }}
           path: |
             packages/js-sdk/dist
             packages/storage-opfs/dist
             ci-artifact/browser.json
           if-no-files-found: error
           compression-level: 0
-          retention-days: 90
+          retention-days: 1
 
       - name: Cache successfully tested SDK binaries
         if: steps.binary-cache.outputs.reuse != 'true' && steps.binaries.outputs.cache-hit != 'true'
@@ -572,6 +575,63 @@ jobs:
         run: |
           df -h "$GITHUB_WORKSPACE"
           free -h
+
+  opfs-benchmarks:
+    name: OPFS performance budgets
+    needs: js-sdk-test
+    # Preserve hardware-sensitive latency budgets on Blacksmith. This small
+    # job downloads the functional-test output and never recompiles Rust/Wasm.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    env:
+      LIX_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.LIX_SOURCE_SHA }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            packages/js-sdk/package-lock.json
+            packages/storage-opfs/package-lock.json
+
+      - name: Install browser test dependencies
+        run: |
+          npm --prefix packages/js-sdk ci
+          npm --prefix packages/storage-opfs ci
+
+      - name: Download functionally tested browser SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: lix-browser-sdk-build-${{ env.LIX_SOURCE_SHA }}
+
+      - name: Install Chromium
+        working-directory: packages/js-sdk
+        run: npx playwright install --with-deps chromium
+
+      - name: Check OPFS performance budgets with the existing SDK
+        working-directory: packages/storage-opfs
+        run: |
+          npm run benchmark
+          npm run benchmark:multi-tab
+
+      - name: Upload tested browser SDK for submodule consumers
+        uses: actions/upload-artifact@v4
+        with:
+          name: lix-browser-sdk-${{ env.LIX_SOURCE_SHA }}
+          path: |
+            packages/js-sdk/dist
+            packages/storage-opfs/dist
+            ci-artifact/browser.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
 
   preview-artifact-changes:
     name: Select preview artifacts

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -131,7 +131,8 @@ jobs:
 
   publish-lix-server:
     name: Publish Lix reference server
-    runs-on: ${{ needs.release-version.outputs.server_digest != '' && 'blacksmith-4vcpu-ubuntu-2404' || 'blacksmith-32vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     needs: release-version
     permissions:
       contents: read
@@ -142,6 +143,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-version.outputs.release_sha }}
+
+      - name: Prepare Linux build runner
+        if: needs.release-version.outputs.server_digest == ''
+        uses: ./.github/actions/prepare-linux-runner
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -379,7 +384,7 @@ jobs:
 
   test-js-sdk:
     name: Test @lix-js/sdk
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs:
       - release-version
       - build-js-sdk

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -27,6 +27,8 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       release_sha: ${{ steps.version.outputs.release_sha }}
       has_release: ${{ steps.version.outputs.has_release }}
+      server_tag: ${{ steps.server.outputs.tag }}
+      server_digest: ${{ steps.server.outputs.digest }}
 
     permissions:
       contents: write
@@ -120,9 +122,16 @@ jobs:
             echo "version=${tag#v}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx for image lookup
+        uses: docker/setup-buildx-action@v3
+
+      - name: Look up server image before allocating a build runner
+        id: server
+        run: node scripts/ci-server-image.mjs
+
   publish-lix-server:
     name: Publish Lix reference server
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ${{ needs.release-version.outputs.server_digest != '' && 'blacksmith-4vcpu-ubuntu-2404' || 'blacksmith-32vcpu-ubuntu-2404' }}
     needs: release-version
     permissions:
       contents: read
@@ -149,27 +158,13 @@ jobs:
         env:
           RELEASE_SHA: ${{ needs.release-version.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.release-version.outputs.tag }}
+          SERVER_TAG: ${{ needs.release-version.outputs.server_tag }}
           HAS_RELEASE: ${{ needs.release-version.outputs.has_release }}
         run: |
-          server_inputs="$(
-            {
-              git ls-tree HEAD -- \
-                .cargo \
-                Cargo.lock \
-                Cargo.toml \
-                rust-toolchain.toml
-              git ls-tree -r HEAD -- \
-                packages/lix \
-                packages/lix-schema \
-                packages/server \
-                packages/storage-slatedb \
-                plugins
-            } | git hash-object --stdin
-          )"
           {
             echo 'tags<<EOF'
             echo "ghcr.io/opral/lix-server:sha-$RELEASE_SHA"
-            echo "ghcr.io/opral/lix-server:content-$server_inputs"
+            echo "$SERVER_TAG"
             if [ "${{ github.event_name }}" = push ]; then
               echo 'ghcr.io/opral/lix-server:main'
             fi
@@ -181,6 +176,7 @@ jobs:
 
       - name: Build and publish immutable server image
         id: publish
+        if: needs.release-version.outputs.server_digest == ''
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -195,11 +191,28 @@ jobs:
           cache-from: type=gha,scope=lix-server-release
           cache-to: type=gha,mode=max,scope=lix-server-release
 
+      - name: Retag the existing immutable server image
+        if: needs.release-version.outputs.server_digest != ''
+        env:
+          SERVER_DIGEST: ${{ needs.release-version.outputs.server_digest }}
+          IMAGE_TAGS: ${{ steps.image-tags.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tags=()
+          while IFS= read -r tag; do
+            tags+=(--tag "$tag")
+          done <<< "$IMAGE_TAGS"
+          # Preserve the original build's revision label and manifest digest.
+          docker buildx imagetools create --prefer-index=false "${tags[@]}" \
+            "ghcr.io/opral/lix-server@$SERVER_DIGEST"
+
       - name: Verify the reference image is publicly pullable
+        env:
+          SERVER_DIGEST: ${{ steps.publish.outputs.digest || needs.release-version.outputs.server_digest }}
         run: |
           docker logout ghcr.io
           docker manifest inspect \
-            "ghcr.io/opral/lix-server@${{ steps.publish.outputs.digest }}"
+            "ghcr.io/opral/lix-server@$SERVER_DIGEST"
 
   build-js-sdk-native-packages:
     name: Build @lix-js/sdk native package (${{ matrix.suffix }})

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -7,7 +7,6 @@ on:
       - main
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -39,6 +38,13 @@ jobs:
           echo "has_release=true" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Validate prepared release metadata
+        if: steps.prepare.outputs.has_release == 'true'
+        run: |
+          node scripts/validate-publish-surface.mjs
+          node --test scripts/release.test.mjs
+          git diff --check
+
       - name: Create or update release PR
         if: steps.prepare.outputs.has_release == 'true'
         id: release_pr
@@ -47,82 +53,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/v${{ steps.prepare.outputs.version }}
           delete-branch: true
+          draft: always-true
           commit-message: Release v${{ steps.prepare.outputs.version }}
           title: Release v${{ steps.prepare.outputs.version }}
           body: |
             This PR was generated from `.changenotes/*` fragments.
 
+            Mark this PR ready for review when the release is ready. This runs full CI.
+            Automated updates return it to draft; metadata is validated on every update.
+
             Merging this PR updates `CHANGELOG.md`, bumps lockstep package versions,
             and enables the release workflow to create `v${{ steps.prepare.outputs.version }}` and publish packages.
-
-      - name: Run CI for release changes
-        if: steps.prepare.outputs.has_release == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_SHA: ${{ steps.release_pr.outputs.pull-request-head-sha }}
-          TARGET_BRANCH: release/v${{ steps.prepare.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          # Creating or updating the release PR can already trigger ordinary
-          # pull_request CI. Reuse that run when GitHub accepted it instead of
-          # paying for a second full workflow_dispatch run for the same SHA.
-          # GITHUB_TOKEN-authored PR events can be approval-blocked, so retain
-          # workflow_dispatch as a fail-open fallback.
-          if [ -n "$RELEASE_SHA" ]; then
-            for attempt in 1 2 3 4 5 6; do
-              if ! runs="$(gh run list \
-                --workflow ci.yml \
-                --event pull_request \
-                --commit "$RELEASE_SHA" \
-                --limit 100 \
-                --json status,conclusion,url)"; then
-                echo "Could not inspect pull request CI; dispatching the fallback run."
-                break
-              fi
-
-              if jq -e 'def blocked:
-                  . == "action_required" or . == "cancelled" or
-                  . == "skipped" or . == "stale";
-                any(.[];
-                .status == "queued" or
-                .status == "in_progress" or
-                (.status == "completed" and
-                  (.conclusion | blocked | not)))' \
-                <<< "$runs" >/dev/null; then
-                echo "Reusing pull request CI for $RELEASE_SHA."
-                jq -r 'def blocked:
-                    . == "action_required" or . == "cancelled" or
-                    . == "skipped" or . == "stale";
-                  .[] | select(
-                  .status == "queued" or
-                  .status == "in_progress" or
-                  (.status == "completed" and
-                    (.conclusion | blocked | not))) |
-                  .url' <<< "$runs"
-                exit 0
-              fi
-
-              if jq -e 'def blocked:
-                  . == "action_required" or . == "cancelled" or
-                  . == "skipped" or . == "stale";
-                any(.[];
-                .status == "completed" and
-                (.conclusion | blocked))' \
-                <<< "$runs" >/dev/null; then
-                echo "Pull request CI cannot provide a reusable check; dispatching the fallback run."
-                break
-              fi
-
-              if [ "$attempt" -lt 6 ]; then
-                sleep 5
-              fi
-            done
-          else
-            echo "The release PR action did not return a head SHA; dispatching the fallback run."
-          fi
-
-          gh workflow run ci.yml --ref "$TARGET_BRANCH"
 
       - name: Close superseded release PRs
         if: steps.prepare.outputs.has_release == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,6 @@ __pycache__/
 
 # Built plugin archive artifacts
 packages/*/*.lixplugin
+
+# Exact-input CI binary snapshots
+.ci-sdk-cache/

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -12,7 +12,12 @@ RUN apt-get update \
 
 # The build context is the Lix repository root. The reference server links the
 # exact protocol and SlateDB implementation from the same revision.
-COPY . .
+# Cargo needs every workspace member manifest, but repository automation and
+# release notes must not invalidate the server compilation layer.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml README.md ./
+COPY .cargo .cargo
+COPY packages packages
+COPY plugins plugins
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \

--- a/scripts/ci-sdk-cache.mjs
+++ b/scripts/ci-sdk-cache.mjs
@@ -1,0 +1,184 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+	appendFileSync,
+	cpSync,
+	lstatSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	readlinkSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function validateRuntime(runtime) {
+	if (!["native", "browser"].includes(runtime))
+		throw new Error(`Invalid runtime: ${runtime}`);
+}
+
+export function isBuildInput(path) {
+	// Only handwritten SDK TypeScript and release prose are proven independent
+	// of the binaries. Unknown paths, fixtures, build scripts and manifests all
+	// invalidate the cache. TypeScript is rebuilt and tested even on a hit.
+	return (
+		!(
+			/^packages\/js-sdk\/src\/.+\.ts$/.test(path) &&
+			!path.startsWith("packages/js-sdk/src/wasm/")
+		) &&
+		!/^\.changenotes\/[^/]+\.md$/.test(path) &&
+		path !== "CHANGELOG.md"
+	);
+}
+
+export function cacheKey(root, runtime, env = process.env) {
+	validateRuntime(runtime);
+	const hash = createHash("sha256");
+	const buildEnv = Object.fromEntries(
+		Object.entries(env)
+			.filter(([name]) =>
+				/^(CARGO_PROFILE_|CARGO_ENCODED_RUSTFLAGS$|CARGO_INCREMENTAL$|RUSTFLAGS$|LIX_.*PROFILE$|LIX_WASM_STORAGE_BENCH$|CC$|CXX$|CFLAGS$|CXXFLAGS$)/.test(
+					name,
+				),
+			)
+			.sort(([a], [b]) => a.localeCompare(b)),
+	);
+	hash.update(
+		JSON.stringify({
+			runtime,
+			platform: process.platform,
+			arch: process.arch,
+			node: process.versions.node.split(".")[0],
+			buildEnv,
+		}),
+	);
+	const paths = execFileSync("git", ["ls-files", "-z"], {
+		cwd: root,
+		encoding: "utf8",
+		maxBuffer: 16 * 1024 * 1024,
+	})
+		.split("\0")
+		.filter(Boolean)
+		.filter(isBuildInput)
+		.sort();
+	for (const path of paths) {
+		const file = join(root, path);
+		const info = lstatSync(file);
+		hash.update(`${path}\0${info.mode & 0o777}\0`);
+		hash.update(
+			info.isSymbolicLink() ? readlinkSync(file) : readFileSync(file),
+		);
+		hash.update("\0");
+	}
+	return `sdk-binaries-v1-${runtime}-${hash.digest("hex")}`;
+}
+
+function outputs(runtime) {
+	validateRuntime(runtime);
+	return [
+		"dist/wasm",
+		"dist/bundled-plugins",
+		...(runtime === "native" ? ["lix_js_sdk.node"] : []),
+	];
+}
+
+function files(root, relative) {
+	const info = lstatSync(join(root, relative));
+	if (info.isFile()) return [relative];
+	if (!info.isDirectory())
+		throw new Error(`Unexpected binary cache entry: ${relative}`);
+	return readdirSync(join(root, relative))
+		.sort()
+		.flatMap((name) => files(root, `${relative}/${name}`));
+}
+
+function manifest(root, runtime, key) {
+	const entries = outputs(runtime).flatMap((path) => files(root, path));
+	for (const path of [
+		"dist/wasm/lix_js_sdk.js",
+		"dist/wasm/lix_js_sdk.d.ts",
+		"dist/wasm/lix_js_sdk_bg.wasm",
+		"dist/bundled-plugins/plugin_csv.lixplugin",
+		"dist/bundled-plugins/plugin_markdown.lixplugin",
+	]) {
+		if (!entries.includes(path))
+			throw new Error(`Missing binary output: ${path}`);
+	}
+	return {
+		key,
+		files: Object.fromEntries(
+			entries.map((path) => [
+				path,
+				createHash("sha256")
+					.update(readFileSync(join(root, path)))
+					.digest("hex"),
+			]),
+		),
+	};
+}
+
+export function validCache(cache, runtime, key) {
+	try {
+		return (
+			JSON.stringify(manifest(cache, runtime, key)) ===
+			JSON.stringify(
+				JSON.parse(readFileSync(join(cache, "manifest.json"), "utf8")),
+			)
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function saveBinaries(sdk, cache, runtime, key) {
+	const description = manifest(sdk, runtime, key);
+	rmSync(cache, { recursive: true, force: true });
+	for (const path of outputs(runtime)) {
+		mkdirSync(dirname(join(cache, path)), { recursive: true });
+		cpSync(join(sdk, path), join(cache, path), { recursive: true });
+	}
+	writeFileSync(join(cache, "manifest.json"), JSON.stringify(description));
+}
+
+export function restoreBinaries(sdk, cache, runtime, key) {
+	if (!validCache(cache, runtime, key))
+		throw new Error("Binary cache validation failed");
+	for (const path of outputs(runtime)) {
+		rmSync(join(sdk, path), { recursive: true, force: true });
+		mkdirSync(dirname(join(sdk, path)), { recursive: true });
+		cpSync(join(cache, path), join(sdk, path), { recursive: true });
+	}
+	mkdirSync(join(sdk, "src"), { recursive: true });
+	rmSync(join(sdk, "src/wasm"), { recursive: true, force: true });
+	symlinkSync("../dist/wasm", join(sdk, "src/wasm"), "dir");
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	const [command, runtime, key] = process.argv.slice(2);
+	const root = process.cwd();
+	const cache = join(root, ".ci-sdk-cache", runtime ?? "");
+	const sdk = join(root, "packages/js-sdk");
+	validateRuntime(runtime);
+	if (command === "key")
+		appendFileSync(
+			process.env.GITHUB_OUTPUT,
+			`key=${cacheKey(root, runtime)}\n`,
+		);
+	else if (command === "check") {
+		const reuse = validCache(cache, runtime, key);
+		appendFileSync(process.env.GITHUB_OUTPUT, `reuse=${reuse}\n`);
+		console.log(
+			reuse
+				? "Validated exact-input binaries; skip Rust compilation."
+				: "No valid exact-input binaries; compile from source.",
+		);
+	} else if (command === "save") saveBinaries(sdk, cache, runtime, key);
+	else if (command === "restore") restoreBinaries(sdk, cache, runtime, key);
+	else throw new Error(`Unknown command: ${command}`);
+}

--- a/scripts/ci-sdk-cache.test.mjs
+++ b/scripts/ci-sdk-cache.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import {
+	cacheKey,
+	isBuildInput,
+	restoreBinaries,
+	saveBinaries,
+	validCache,
+} from "./ci-sdk-cache.mjs";
+
+function fixture(t) {
+	const root = mkdtempSync(join(tmpdir(), "lix-binaries-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const write = (path, content = path) => {
+		mkdirSync(dirname(join(root, path)), { recursive: true });
+		writeFileSync(join(root, path), content);
+	};
+	return { root, write };
+}
+
+test("handwritten SDK TypeScript and release prose do not invalidate binaries; unknown inputs do", () => {
+	for (const path of [
+		"packages/js-sdk/src/foo.ts",
+		".changenotes/fix.md",
+		"CHANGELOG.md",
+	])
+		assert.equal(isBuildInput(path), false, path);
+	for (const path of [
+		"Cargo.lock",
+		"rust-toolchain.toml",
+		".cargo/config.toml",
+		"packages/lix/src/lib.rs",
+		"packages/js-sdk/src/wasm/generated.d.ts",
+		"packages/js-sdk/build.rs",
+		"packages/js-sdk/scripts/build-wasm.js",
+		"plugins/csv/schema/csv_row.json",
+		"new-build-config.json",
+		".github/workflows/ci.yml",
+	])
+		assert.equal(isBuildInput(path), true, path);
+});
+
+test("keys track actual tracked bytes, filenames, runtime and build settings without depending on commit SHA", (t) => {
+	const { root, write } = fixture(t);
+	write("Cargo.lock", "one");
+	write("packages/js-sdk/src/foo.ts", "one");
+	execFileSync("git", ["init", "--quiet", root]);
+	execFileSync("git", ["add", "."], { cwd: root });
+	const key = cacheKey(root, "native", {});
+	write("packages/js-sdk/src/foo.ts", "two");
+	assert.equal(cacheKey(root, "native", {}), key);
+	assert.notEqual(cacheKey(root, "browser", {}), key);
+	assert.notEqual(
+		cacheKey(root, "native", { LIX_NATIVE_PROFILE: "release" }),
+		key,
+	);
+	assert.notEqual(
+		cacheKey(root, "native", { RUSTFLAGS: "-C opt-level=1" }),
+		key,
+	);
+	write("Cargo.lock", "two");
+	assert.notEqual(cacheKey(root, "native", {}), key);
+	write("Cargo.lock", "one");
+	write("new-build-input.txt");
+	execFileSync("git", ["add", "."], { cwd: root });
+	assert.notEqual(cacheKey(root, "native", {}), key);
+});
+
+for (const runtime of ["native", "browser"]) {
+	test(`${runtime} binary snapshots restore generated imports and reject incomplete, corrupt or mismatched outputs`, (t) => {
+		const { root, write } = fixture(t);
+		const sdk = join(root, "sdk");
+		const cache = join(root, "cache");
+		for (const path of [
+			"dist/wasm/lix_js_sdk.js",
+			"dist/wasm/lix_js_sdk.d.ts",
+			"dist/wasm/lix_js_sdk_bg.wasm",
+			"dist/bundled-plugins/plugin_csv.lixplugin",
+			"dist/bundled-plugins/plugin_markdown.lixplugin",
+			...(runtime === "native" ? ["lix_js_sdk.node"] : []),
+		])
+			write(`sdk/${path}`);
+		saveBinaries(sdk, cache, runtime, "key");
+		assert.equal(validCache(cache, runtime, "key"), true);
+		assert.equal(validCache(cache, runtime, "other-key"), false);
+		rmSync(sdk, { recursive: true });
+		restoreBinaries(sdk, cache, runtime, "key");
+		assert.equal(realpathSync(join(sdk, "src/wasm")), join(sdk, "dist/wasm"));
+		assert.equal(
+			readFileSync(join(sdk, "dist/wasm/lix_js_sdk.js"), "utf8"),
+			"sdk/dist/wasm/lix_js_sdk.js",
+		);
+		write("cache/dist/wasm/lix_js_sdk_bg.wasm", "corrupt");
+		assert.equal(validCache(cache, runtime, "key"), false);
+		assert.throws(
+			() => restoreBinaries(sdk, cache, runtime, "key"),
+			/validation failed/,
+		);
+		saveBinaries(sdk, cache, runtime, "key");
+		rmSync(join(cache, "dist/bundled-plugins/plugin_csv.lixplugin"));
+		assert.equal(validCache(cache, runtime, "key"), false);
+	});
+}
+
+test("symlinked binary payloads are rejected", (t) => {
+	const { root } = fixture(t);
+	mkdirSync(join(root, "dist"));
+	symlinkSync(root, join(root, "dist/wasm"));
+	assert.equal(validCache(root, "browser", "key"), false);
+});

--- a/scripts/ci-server-image.mjs
+++ b/scripts/ci-server-image.mjs
@@ -1,0 +1,75 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+// Keep this hash compatible with LixRay's content-tag lookup.
+export function serverInputHash(cwd = process.cwd()) {
+	const tree = (...args) => execFileSync("git", ["ls-tree", ...args], { cwd });
+	const input = Buffer.concat([
+		tree(
+			"HEAD",
+			"--",
+			".cargo",
+			".dockerignore",
+			"Cargo.lock",
+			"Cargo.toml",
+			"rust-toolchain.toml",
+		),
+		tree(
+			"-r",
+			"HEAD",
+			"--",
+			"packages/lix",
+			"packages/lix-schema",
+			"packages/server",
+			"packages/storage-slatedb",
+			"plugins",
+		),
+	]);
+	return execFileSync("git", ["hash-object", "--stdin"], {
+		cwd,
+		input,
+		encoding: "utf8",
+	}).trim();
+}
+
+export function existingDigest(image, run = spawnSync) {
+	const result = run(
+		"docker",
+		[
+			"buildx",
+			"imagetools",
+			"inspect",
+			image,
+			"--format",
+			"{{json .Manifest.Digest}}",
+		],
+		{ encoding: "utf8" },
+	);
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		// Authentication/registry failures are not cache misses. Avoid paying for
+		// a build that cannot be published when the registry is unavailable.
+		if (/manifest unknown|not found|name unknown/i.test(result.stderr ?? ""))
+			return "";
+		throw new Error(`Cannot inspect ${image}: ${result.stderr}`);
+	}
+	const digest = JSON.parse(result.stdout.trim());
+	if (!/^sha256:[a-f0-9]{64}$/.test(digest))
+		throw new Error("Invalid image digest");
+	return digest;
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+	const tag = `ghcr.io/opral/lix-server:content-${serverInputHash()}`;
+	const digest = existingDigest(tag);
+	appendFileSync(process.env.GITHUB_OUTPUT, `tag=${tag}\ndigest=${digest}\n`);
+	console.log(
+		digest
+			? `Reuse ${tag}@${digest}; no server compilation needed.`
+			: `No image for ${tag}; build from source.`,
+	);
+}

--- a/scripts/ci-server-image.test.mjs
+++ b/scripts/ci-server-image.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { existingDigest, serverInputHash } from "./ci-server-image.mjs";
+
+test("server tags are stable across CI/SDK-only commits and change with server source", (t) => {
+	const root = mkdtempSync(join(tmpdir(), "lix-server-tag-"));
+	t.after(() => rmSync(root, { recursive: true, force: true }));
+	const git = (...args) => execFileSync("git", args, { cwd: root });
+	const commit = (path, content) => {
+		mkdirSync(dirname(join(root, path)), { recursive: true });
+		writeFileSync(join(root, path), content);
+		git("add", ".");
+		git(
+			"-c",
+			"user.name=CI test",
+			"-c",
+			"user.email=ci@example.test",
+			"commit",
+			"--quiet",
+			"-m",
+			"fixture",
+		);
+	};
+	git("init", "--quiet");
+	commit("Cargo.toml", "workspace");
+	commit("packages/server/src/main.rs", "server");
+	const hash = serverInputHash(root);
+	commit(".github/workflows/ci.yml", "workflow");
+	commit("packages/js-sdk/src/api.ts", "typescript");
+	assert.equal(serverInputHash(root), hash);
+	commit("packages/server/src/main.rs", "updated server");
+	assert.notEqual(serverInputHash(root), hash);
+	const sourceHash = serverInputHash(root);
+	commit(".dockerignore", "build context exclusions");
+	assert.notEqual(serverInputHash(root), sourceHash);
+});
+
+test("image lookup distinguishes a cache miss from registry failures", () => {
+	const digest = `sha256:${"a".repeat(64)}`;
+	assert.equal(
+		existingDigest("image", () => ({
+			status: 0,
+			stdout: JSON.stringify(digest),
+		})),
+		digest,
+	);
+	assert.equal(
+		existingDigest("image", () => ({ status: 1, stderr: "manifest unknown" })),
+		"",
+	);
+	assert.throws(
+		() =>
+			existingDigest("image", () => ({ status: 1, stderr: "unauthorized" })),
+		/Cannot inspect/,
+	);
+	assert.throws(
+		() =>
+			existingDigest("image", () => ({
+				status: 1,
+				stderr: "connection timed out",
+			})),
+		/Cannot inspect/,
+	);
+	assert.throws(
+		() => existingDigest("image", () => ({ status: 0, stdout: '"invalid"' })),
+		/Invalid image digest/,
+	);
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -60,7 +60,7 @@ test("Rust scope gates only Rust jobs and keeps both SDK integration suites", ()
 	assert.match(cargo, /if: needs\.changelog\.outputs\.rust != 'false'/);
 	const sdk = workflow
 		.split("\n  js-sdk-test:\n")[1]
-		.split("\n  preview-artifact-changes:\n")[0];
+		.split("\n  opfs-benchmarks:\n")[0];
 	assert.doesNotMatch(sdk, /needs:|outputs\.rust/);
 	assert.match(workflow, /fetch-depth: 2/);
 	assert.match(workflow, /rust: \$\{\{ steps\.scope\.outputs\.rust \}\}/);
@@ -137,6 +137,32 @@ test("green SDK jobs retain exact-revision artifacts for submodule consumers", (
 	assert.match(workflow, /retention-days: 90/);
 	assert.doesNotMatch(workflow, /name: lix-native-sdk-/);
 	assert.doesNotMatch(workflow, /CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"/);
+});
+
+test("OPFS latency budgets reuse the tested SDK without compiling on Blacksmith", () => {
+	const sdk = workflow
+		.split("\n  js-sdk-test:\n")[1]
+		.split("\n  opfs-benchmarks:\n")[0];
+	const benchmarks = workflow
+		.split("\n  opfs-benchmarks:\n")[1]
+		.split("\n  preview-artifact-changes:\n")[0];
+	assert.match(sdk, /name: lix-browser-sdk-build-\$\{\{ env\.LIX_SOURCE_SHA \}\}/);
+	assert.doesNotMatch(sdk, /npm run benchmark/);
+	assert.match(benchmarks, /needs: js-sdk-test/);
+	assert.match(benchmarks, /runs-on: blacksmith-4vcpu-ubuntu-2404/);
+	assert.match(
+		benchmarks,
+		/uses: actions\/download-artifact@v4[\s\S]*?name: lix-browser-sdk-build-\$\{\{ env\.LIX_SOURCE_SHA \}\}/,
+	);
+	assert.match(benchmarks, /npm run benchmark\n\s+npm run benchmark:multi-tab/);
+	assert.doesNotMatch(
+		benchmarks,
+		/\brustup\b|\bcargo\b|\bbuild:(?:native|wasm|plugins|browser)\b/,
+	);
+	assert.ok(
+		benchmarks.indexOf("name: Upload tested browser SDK for submodule consumers") >
+			benchmarks.indexOf("npm run benchmark:multi-tab"),
+	);
 });
 
 test("server-changing pull requests retain one reusable preview image", () => {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -36,7 +36,7 @@ test("Rust test scopes run independently with workspace-specific caches", () => 
 		assert.match(
 			workflow,
 			new RegExp(
-				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}[\\s\\S]*?runner: ${runner}`,
+				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}[\\s\\S]*?blacksmith_runner: ${runner}`,
 			),
 		);
 	}
@@ -48,7 +48,7 @@ test("Rust test scopes run independently with workspace-specific caches", () => 
 	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
 	assert.match(
 		workflow,
-		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
+		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ inputs\.runner_provider == 'blacksmith' && matrix\.blacksmith_runner \|\| 'ubuntu-24\.04' \}\}/,
 	);
 });
 
@@ -109,18 +109,18 @@ test("short support jobs use free standard runners for the public repository", (
 	}
 });
 
-test("JS SDK native CI is right-sized without changing browser architecture coverage", () => {
+test("SDK CI defaults to free GitHub runners with an explicit Blacksmith fallback", () => {
 	assert.match(
 		workflow,
-		/- name: Native\n\s+runtime: native\n\s+runner: blacksmith-16vcpu-ubuntu-2404/,
+		/- name: Native\n\s+runtime: native\n\s+blacksmith_runner: blacksmith-16vcpu-ubuntu-2404/,
 	);
 	assert.match(
 		workflow,
-		/- name: Browser\n\s+runtime: browser\n\s+runner: blacksmith-32vcpu-ubuntu-2404/,
+		/- name: Browser\n\s+runtime: browser\n\s+blacksmith_runner: blacksmith-32vcpu-ubuntu-2404/,
 	);
 	assert.match(
 		workflow,
-		/name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
+		/name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ inputs\.runner_provider == 'blacksmith' && matrix\.blacksmith_runner \|\| 'ubuntu-24\.04' \}\}/,
 	);
 });
 
@@ -183,16 +183,20 @@ test("SDK binary reuse never skips TypeScript builds or integration tests", () =
 	}
 });
 
-test("server cache hits retag the immutable image on a small runner", () => {
+test("server publishing and SDK package tests use free GitHub runners", () => {
 	assert.match(
 		publishWorkflow,
-		/server_digest != '' && 'blacksmith-4vcpu-ubuntu-2404'/,
+		/name: Publish Lix reference server\n\s+runs-on: ubuntu-24\.04/,
 	);
 	assert.match(
 		publishWorkflow,
 		/id: publish\n\s+if: needs\.release-version\.outputs\.server_digest == ''/,
 	);
 	assert.match(publishWorkflow, /imagetools create --prefer-index=false/);
+	assert.match(
+		publishWorkflow,
+		/name: Test @lix-js\/sdk\n\s+runs-on: ubuntu-24\.04/,
+	);
 });
 
 test("nextest compiles test targets without building unused examples", () => {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -48,7 +48,11 @@ test("Rust test scopes run independently with workspace-specific caches", () => 
 	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
 	assert.match(
 		workflow,
-		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ inputs\.runner_provider == 'blacksmith' && matrix\.blacksmith_runner \|\| 'ubuntu-24\.04' \}\}/,
+		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ inputs\.runner_provider == 'blacksmith' && matrix\.blacksmith_runner \|\| matrix\.default_runner \|\| 'ubuntu-24\.04' \}\}/,
+	);
+	assert.match(
+		workflow,
+		/- name: Test\n\s+task: test[\s\S]*?default_runner: blacksmith-8vcpu-ubuntu-2404\n\s+blacksmith_runner: blacksmith-16vcpu-ubuntu-2404/,
 	);
 });
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -29,7 +29,7 @@ test("superseded CI runs are cancelled per pull request or branch", () => {
 test("Rust test scopes run independently with workspace-specific caches", () => {
 	for (const [name, task, workspace, runner] of [
 		["Clippy", "clippy", ".", "blacksmith-32vcpu-ubuntu-2404"],
-		["Test", "test", ".", "blacksmith-32vcpu-ubuntu-2404"],
+		["Test", "test", ".", "blacksmith-16vcpu-ubuntu-2404"],
 		["Tooling Test", "tooling", "tooling", "blacksmith-16vcpu-ubuntu-2404"],
 		["E2E Test", "e2e", "tooling", "blacksmith-16vcpu-ubuntu-2404"],
 	]) {
@@ -40,17 +40,27 @@ test("Rust test scopes run independently with workspace-specific caches", () => 
 			),
 		);
 	}
-	assert.match(workflow, /workspaces: \$\{\{ matrix\.cache_workspaces \|\| matrix\.workspace \}\}/);
+	assert.match(
+		workflow,
+		/workspaces: \$\{\{ matrix\.cache_workspaces \|\| matrix\.workspace \}\}/,
+	);
 	assert.match(workflow, /name: rust-nextest-junit-\$\{\{ matrix\.task \}\}/);
 	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
-	assert.match(workflow, /name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/);
+	assert.match(
+		workflow,
+		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
+	);
 });
 
 test("Rust scope gates only Rust jobs and keeps both SDK integration suites", () => {
-	const cargo = workflow.split("\n  cargo:\n")[1].split("\n  js-sdk-test:\n")[0];
+	const cargo = workflow
+		.split("\n  cargo:\n")[1]
+		.split("\n  js-sdk-test:\n")[0];
 	assert.match(cargo, /needs: changelog/);
 	assert.match(cargo, /if: needs\.changelog\.outputs\.rust != 'false'/);
-	const sdk = workflow.split("\n  js-sdk-test:\n")[1].split("\n  preview-artifact-changes:\n")[0];
+	const sdk = workflow
+		.split("\n  js-sdk-test:\n")[1]
+		.split("\n  preview-artifact-changes:\n")[0];
 	assert.doesNotMatch(sdk, /needs:|outputs\.rust/);
 	assert.match(workflow, /fetch-depth: 2/);
 	assert.match(workflow, /rust: \$\{\{ steps\.scope\.outputs\.rust \}\}/);
@@ -58,14 +68,29 @@ test("Rust scope gates only Rust jobs and keeps both SDK integration suites", ()
 });
 
 test("Clippy caches both workspaces and SDK build modes have separate main-seeded caches", () => {
-	assert.match(workflow, /cache_workspaces: \|\n\s+\. -> target\n\s+tooling -> target/);
-	assert.match(workflow, /shared-key: ci-js-\$\{\{ matrix\.runtime \}\}\n\s+save-if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/);
+	assert.match(
+		workflow,
+		/cache_workspaces: \|\n\s+\. -> target\n\s+tooling -> target/,
+	);
+	assert.match(
+		workflow,
+		/shared-key: ci-js-\$\{\{ matrix\.runtime \}\}\n\s+save-if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/,
+	);
 });
 
 test("Cargo output directories match the workspace caches and timing uploads", () => {
-	assert.match(workflow, /CARGO_TARGET_DIR: \$\{\{ github\.workspace \}\}\/\$\{\{ matrix\.workspace \}\}\/target/);
-	assert.match(workflow, /export CARGO_TARGET_DIR="\$GITHUB_WORKSPACE\/tooling\/target"\n\s+cargo clippy/);
-	assert.match(workflow, /path: \$\{\{ matrix\.workspace \}\}\/target\/cargo-timings\/\*\.html/);
+	assert.match(
+		workflow,
+		/CARGO_TARGET_DIR: \$\{\{ github\.workspace \}\}\/\$\{\{ matrix\.workspace \}\}\/target/,
+	);
+	assert.match(
+		workflow,
+		/export CARGO_TARGET_DIR="\$GITHUB_WORKSPACE\/tooling\/target"\n\s+cargo clippy/,
+	);
+	assert.match(
+		workflow,
+		/path: \$\{\{ matrix\.workspace \}\}\/target\/cargo-timings\/\*\.html/,
+	);
 });
 
 test("short support jobs use free standard runners for the public repository", () => {
@@ -77,7 +102,9 @@ test("short support jobs use free standard runners for the public repository", (
 	]) {
 		assert.match(
 			workflow,
-			new RegExp(`- name: ${name}\\n\\s+runner: ${runner.replaceAll(".", "\\.")}`),
+			new RegExp(
+				`- name: ${name}\\n\\s+runner: ${runner.replaceAll(".", "\\.")}`,
+			),
 		);
 	}
 });
@@ -91,7 +118,10 @@ test("JS SDK native CI is right-sized without changing browser architecture cove
 		workflow,
 		/- name: Browser\n\s+runtime: browser\n\s+runner: blacksmith-32vcpu-ubuntu-2404/,
 	);
-	assert.match(workflow, /name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/);
+	assert.match(
+		workflow,
+		/name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
+	);
 });
 
 test("green SDK jobs retain exact-revision artifacts for submodule consumers", () => {
@@ -100,7 +130,10 @@ test("green SDK jobs retain exact-revision artifacts for submodule consumers", (
 		/LIX_SOURCE_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/,
 	);
 	assert.match(workflow, /ref: \$\{\{ env\.LIX_SOURCE_SHA \}\}/);
-	assert.match(workflow, /name: lix-browser-sdk-\$\{\{ env\.LIX_SOURCE_SHA \}\}/);
+	assert.match(
+		workflow,
+		/name: lix-browser-sdk-\$\{\{ env\.LIX_SOURCE_SHA \}\}/,
+	);
 	assert.match(workflow, /retention-days: 90/);
 	assert.doesNotMatch(workflow, /name: lix-native-sdk-/);
 	assert.doesNotMatch(workflow, /CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"/);
@@ -115,20 +148,51 @@ test("server-changing pull requests retain one reusable preview image", () => {
 		/name: lix-server-image-linux-x64-\$\{\{ env\.LIX_SOURCE_SHA \}\}/,
 	);
 	assert.match(workflow, /retention-days: 14/);
-	assert.match(publishWorkflow, /lix-server:content-\$server_inputs/);
+	assert.match(publishWorkflow, /node scripts\/ci-server-image\.mjs/);
 });
 
-test("release PR automation reuses same-SHA pull request CI with a dispatch fallback", () => {
+test("release PR updates validate metadata and defer full CI until ready for review", () => {
+	assert.match(releasePrWorkflow, /draft: always-true/);
 	assert.match(
 		releasePrWorkflow,
-		/RELEASE_SHA: \$\{\{ steps\.release_pr\.outputs\.pull-request-head-sha \}\}/,
+		/node scripts\/validate-publish-surface\.mjs/,
 	);
-	assert.match(releasePrWorkflow, /--event pull_request/);
-	assert.match(releasePrWorkflow, /--commit "\$RELEASE_SHA"/);
-	for (const conclusion of ["action_required", "cancelled", "skipped", "stale"]) {
-		assert.match(releasePrWorkflow, new RegExp(`\\. == "${conclusion}"`));
+	assert.match(releasePrWorkflow, /node --test scripts\/release\.test\.mjs/);
+	assert.doesNotMatch(releasePrWorkflow, /gh workflow run|actions: write/);
+	assert.match(workflow, /ready_for_review/);
+});
+
+test("SDK binary reuse never skips TypeScript builds or integration tests", () => {
+	assert.match(workflow, /uses: actions\/cache\/restore@v4/);
+	assert.match(workflow, /uses: actions\/cache\/save@v4/);
+	assert.match(workflow, /node scripts\/ci-sdk-cache\.mjs check/);
+	assert.match(workflow, /fi\n\s+npm --prefix packages\/js-sdk run build:ts/);
+	assert.ok(
+		workflow.indexOf("name: Cache successfully tested SDK binaries") >
+			workflow.indexOf("name: Run OPFS storage browser tests"),
+	);
+	for (const name of [
+		"Run native JS SDK tests",
+		"Run browser JS SDK tests",
+		"Run OPFS storage browser tests",
+	]) {
+		const step = workflow
+			.split(`name: ${name}\n`)[1]
+			.split("\n      - name:")[0];
+		assert.doesNotMatch(step, /binary-cache|reuse/);
 	}
-	assert.match(releasePrWorkflow, /gh workflow run ci\.yml --ref "\$TARGET_BRANCH"/);
+});
+
+test("server cache hits retag the immutable image on a small runner", () => {
+	assert.match(
+		publishWorkflow,
+		/server_digest != '' && 'blacksmith-4vcpu-ubuntu-2404'/,
+	);
+	assert.match(
+		publishWorkflow,
+		/id: publish\n\s+if: needs\.release-version\.outputs\.server_digest == ''/,
+	);
+	assert.match(publishWorkflow, /imagetools create --prefer-index=false/);
 });
 
 test("nextest compiles test targets without building unused examples", () => {
@@ -152,7 +216,9 @@ test("tooling Clippy excludes the benchmark-only DuckDB feature", () => {
 	);
 	const e2eClippy = workflow
 		.split("\n")
-		.find((line) => line.includes("cargo clippy") && line.includes("-p lix_e2e"));
+		.find(
+			(line) => line.includes("cargo clippy") && line.includes("-p lix_e2e"),
+		);
 	assert.ok(e2eClippy);
 	assert.match(e2eClippy, /--all-targets --features /);
 	assert.doesNotMatch(e2eClippy, /\btpch\b|--all-features/);


### PR DESCRIPTION
CI spends large-runner minutes rebuilding unchanged SDK binaries and server images, and repeats the full suite for accumulating release-PR refreshes. Cut that work and move five of the six Rust/SDK jobs to free standard GitHub runners.

- Keep generated release PRs draft, validate metadata on refresh, and run full CI when marked ready for review.
- Reuse server images by content hash and build only on misses. Narrow Docker COPY inputs, include `.dockerignore` in the hash, and use `ubuntu-24.04` for server publishing/retagging.
- Reuse validated native/Wasm/plugin outputs by exact build inputs and runtime. Always rebuild handwritten TypeScript and run integration tests, including on binary-cache hits.
- Run Clippy, tooling, E2E and both SDK jobs on free `ubuntu-24.04`. Root Cargo Test uses 8-core/32-GB Blacksmith with four concurrent Cargo jobs; standard GitHub runners shut down during that compilation twice. Manual `runner_provider=blacksmith` retains larger compilation runners, including the previously tested 16-core root runner.
- Keep OPFS latency budgets on a short 4-core Blacksmith job. It downloads the functionally tested SDK, never recompiles Rust/Wasm, and publishes the consumer artifact only after the unchanged performance checks pass. The standard GitHub VM failed the existing 50 ms benchmark threshold, so only this short check stays on Blacksmith.
- Move release SDK package tests to GitHub. Reclaim unused preinstalled SDK space on disposable GitHub build VMs and use portable `grep` in the packaged-plugin assertion. Platform-specific release compilation and crates.io preflight retain Blacksmith pending separate qualification.

Validation: [all 13 CI jobs passed on this head](https://github.com/opral/lix/actions/runs/34060982942), including 4,081 root tests, doctests, packaged-Wasm plugin compilation and OPFS benchmarks. The root runner reported the intended 32-GB memory class. Local validation includes 41 tests, actionlint, publish-surface validation and diff checks.

A same-head browser SDK rerun restored the exact binary cache and passed in **74s versus 398s** when rebuilding (81.4% less job time), with Rust compilation/target setup skipped and functional/production tests preserved. Its dependent OPFS benchmark also passed. Native binary reuse was qualified earlier on Blacksmith; native functional tests passed on GitHub.

The full qualification used 758s on 8-core Blacksmith plus 71s on 4-core Blacksmith: approximately **$0.212 compute**, or **$0.224 with whole-minute job rounding**, at [published rates](https://www.blacksmith.sh/pricing), before credits and excluding storage/add-ons. Other job compute is free for public Lix. This is an estimate, not an invoice reconciliation.

Full Rust changes are slower on standard GitHub runners. Initial cold-cache jobs took 17–29 minutes; the final full run finished in about 13 minutes as caches warmed. Root Test's 8-core qualification had only 27% Rust compiler-cache hits, so its time is not a controlled warm-cache comparison with the earlier 16-core runner.

Companion [LixRay PR #322](https://github.com/opral/lixray/pull/322) passed full CI and deployed-preview sync on GitHub with both large compilation fallbacks skipped. Release/publishing-only paths execute after merge. Docker preview/web-image validation reused cached layers/images and did not force a cold image compilation.
