### PR TITLE
fix(js-sdk): release native storage before resolving close

### DIFF
--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -767,7 +767,7 @@ impl NativeLixActor {
             return;
         };
         if self.closed.load(Ordering::SeqCst) {
-            settle_deferred(deferred, Err(lix_closed_error()));
+            settle_command_after_close(command(deferred));
             return;
         }
         let queued = QueuedLixCommand {
@@ -872,14 +872,15 @@ fn run_lix_actor(
             drain_commands_after_close(&receiver, &send_lock);
             break;
         }
-        if handle_lix_command(
-            &rt,
-            open_state,
-            &closed,
-            queued.command,
-            queued.telemetry_parent,
-        ) {
+        if let Some(deferred) =
+            handle_lix_command(&rt, open_state, queued.command, queued.telemetry_parent)
+        {
+            // Closing the session does not drop its storage ownership. Release
+            // the actor state before publishing completion, including the flag
+            // used by repeated close calls to resolve without queueing.
             drop(state.take());
+            closed.store(true, Ordering::SeqCst);
+            settle_deferred(deferred, Ok(()));
             drain_commands_after_close(&receiver, &send_lock);
             break;
         }
@@ -940,10 +941,9 @@ fn reject_pending_lix_commands(receiver: mpsc::Receiver<QueuedLixCommand>, error
 fn handle_lix_command(
     rt: &Runtime,
     state: &mut NativeLixActorState,
-    closed: &AtomicBool,
     command: LixCommand,
     telemetry_parent: Option<SpanContext>,
-) -> bool {
+) -> Option<NativeUnitDeferred> {
     macro_rules! block_on {
         ($future:expr) => {
             rt.block_on(instrument_remote_parent(telemetry_parent.clone(), $future))
@@ -958,7 +958,7 @@ fn handle_lix_command(
             let result = block_on!(state.lix.open_another_session(options))
                 .and_then(|lix| NativeLix::new(lix, telemetry_parent));
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::Execute {
             sql,
@@ -969,7 +969,7 @@ fn handle_lix_command(
             let result = block_on!(state.lix.execute(&sql, &params, options))
                 .and_then(ExecuteResult::try_from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::ExecuteBatch {
             statements,
@@ -984,7 +984,7 @@ fn handle_lix_command(
                         .collect::<std::result::Result<Vec<_>, _>>()
                 });
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::BeginTransaction {
             transaction_id,
@@ -996,60 +996,60 @@ fn handle_lix_command(
                 NativeLixTransaction::new(actor, transaction_id)
             });
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::ActiveBranchId(deferred) => {
             let result = block_on!(state.lix.active_branch_id());
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::ActiveAccountId(deferred) => {
             settle_deferred(deferred, Ok(state.lix.active_account_id().to_string()));
-            false
+            None
         }
         LixCommand::CreateBranch { options, deferred } => {
             let result =
                 block_on!(state.lix.create_branch(options)).map(CreateBranchReceiptDto::from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::Undo(deferred) => {
             let result = block_on!(state.lix.undo()).map(UndoReceiptDto::from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::Redo(deferred) => {
             let result = block_on!(state.lix.redo()).map(RedoReceiptDto::from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::SwitchBranch { options, deferred } => {
             let result =
                 block_on!(state.lix.switch_branch(options)).map(SwitchBranchReceiptDto::from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::ImportFilesystemPaths { paths, deferred } => {
             let result = block_on!(state.lix.import_filesystem_paths(paths));
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::MergeBranchPreview { options, deferred } => {
             let result =
                 block_on!(state.lix.merge_branch_preview(options)).map(MergeBranchPreviewDto::from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::MergeBranch { options, deferred } => {
             let result =
                 block_on!(state.lix.merge_branch(options)).map(MergeBranchReceiptDto::from);
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::SyncDiskToLix(deferred) => {
             let result = block_on!(state.lix.sync_disk_to_lix());
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::ExportSnapshot { sender, completion } => {
             if state.snapshot_export_active.swap(true, Ordering::SeqCst) {
@@ -1061,7 +1061,7 @@ fn handle_lix_command(
                         "a native snapshot export is already active; finish or cancel it before starting another",
                     )),
                 );
-                return false;
+                return None;
             }
             let job = NativeSnapshotExportJob {
                 builder: state.lix.snapshot_export_builder(),
@@ -1083,16 +1083,17 @@ fn handle_lix_command(
                     );
                 }
             }
-            false
+            None
         }
         LixCommand::Close(deferred) => {
             let result = block_on!(state.lix.close());
-            let should_drop_state = result.is_ok();
-            if result.is_ok() {
-                closed.store(true, Ordering::SeqCst);
+            match result {
+                Ok(()) => Some(deferred),
+                Err(error) => {
+                    settle_deferred(deferred, Err(error));
+                    None
+                }
             }
-            settle_deferred(deferred, result);
-            should_drop_state
         }
         LixCommand::Observe {
             sql,
@@ -1108,7 +1109,7 @@ fn handle_lix_command(
                 })
             });
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::TransactionExecute {
             transaction_id,
@@ -1125,7 +1126,7 @@ fn handle_lix_command(
                 },
             );
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::TransactionCommit {
             transaction_id,
@@ -1136,7 +1137,7 @@ fn handle_lix_command(
                 |transaction| block_on!(transaction.commit()),
             );
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::TransactionRollback {
             transaction_id,
@@ -1147,13 +1148,13 @@ fn handle_lix_command(
                 |transaction| block_on!(transaction.rollback()),
             );
             settle_deferred(deferred, result);
-            false
+            None
         }
         LixCommand::TransactionAbandon { transaction_id } => {
             if let Some(transaction) = state.transactions.remove(&transaction_id) {
                 let _ = block_on!(transaction.rollback());
             }
-            false
+            None
         }
     }
 }

--- a/packages/js-sdk/src/binding.node.test.ts
+++ b/packages/js-sdk/src/binding.node.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { openNativeLixBinding } from "./binding.node.js";
+
+test.each([false, true])(
+	"native close releases filesystem ownership before resolving (syncAllFiles=%s)",
+	async (syncAllFiles) => {
+		const path = mkdtempSync(join(tmpdir(), "lix-native-close-"));
+		const storage = { kind: "filesystem" as const, path, syncAllFiles };
+		let binding = await openNativeLixBinding(storage);
+		try {
+			// Exercise the native promises directly: the public Lix wrapper
+			// coalesces close calls and would hide races between native closes.
+			for (let iteration = 0; iteration < 32; iteration++) {
+				const previous = binding;
+				await previous.execute(
+					`INSERT INTO lix_key_value (key, value) VALUES ('close-${iteration}', 'persisted')`,
+					[],
+				);
+				const closing = [previous.close(), previous.close(), previous.close()];
+				// Every successful close is a release boundary, including the first
+				// one to finish. Do not wait for all closes before reopening.
+				await Promise.race(closing);
+				binding = await openNativeLixBinding(storage);
+				await Promise.all(closing);
+				await previous.close();
+				const persisted = await binding.execute(
+					`SELECT value FROM lix_key_value WHERE key = 'close-${iteration}'`,
+					[],
+				);
+				expect(persisted.rows).toHaveLength(1);
+			}
+		} finally {
+			await binding.close();
+			rmSync(path, { recursive: true, force: true });
+		}
+	},
+	20_000,
+);
+
+test("a rejected native close preserves the actor for rollback and retry", async () => {
+	const binding = await openNativeLixBinding({ kind: "memory" });
+	try {
+		const transaction = await binding.beginTransaction();
+		try {
+			await expect(binding.close()).rejects.toMatchObject({
+				code: "LIX_INVALID_TRANSACTION_STATE",
+			});
+		} finally {
+			await transaction.rollback();
+		}
+		expect((await binding.execute("SELECT 42 AS answer", [])).rows).toHaveLength(1);
+	} finally {
+		await binding.close();
+	}
+});


### PR DESCRIPTION
Immediately reopening a filesystem-backed Lix after awaiting `close()` could fail with a RocksDB lock error. The native actor resolved the close promise and marked itself closed before dropping the state that still owned storage.

Return the successful close deferred to the owning actor, drop its state, and only then publish completion. Preserve idempotent close when a caller races the completed-state check, and keep the actor available after a rejected close.

Validation:
- Native SDK build and TypeScript build/typecheck passed.
- All 202 native SDK tests passed, including the test that failed in CI.
- Added repeated write/close/reopen coverage with concurrent native closes, filesystem sync enabled and disabled, and rejected-close rollback/retry coverage.
- Rust formatting and diff checks passed.

The original timing failure did not reproduce locally on macOS; the completion ordering defect is established by code inspection and the failing Linux CI log.

Addresses the failure in https://github.com/opral/lix/actions/runs/34068085409/job/101580299604.
