### PR TITLE
ci: publish browser artifacts without OPFS benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,18 +553,18 @@ jobs:
           }, null, 2));
           EOF
 
-      - name: Share browser SDK with performance checks
+      - name: Upload tested browser SDK for submodule consumers
         if: matrix.runtime == 'browser'
         uses: actions/upload-artifact@v4
         with:
-          name: lix-browser-sdk-build-${{ env.LIX_SOURCE_SHA }}
+          name: lix-browser-sdk-${{ env.LIX_SOURCE_SHA }}
           path: |
             packages/js-sdk/dist
             packages/storage-opfs/dist
             ci-artifact/browser.json
           if-no-files-found: error
           compression-level: 0
-          retention-days: 1
+          retention-days: 90
 
       - name: Cache successfully tested SDK binaries
         if: steps.binary-cache.outputs.reuse != 'true' && steps.binaries.outputs.cache-hit != 'true'
@@ -578,63 +578,6 @@ jobs:
         run: |
           df -h "$GITHUB_WORKSPACE"
           free -h
-
-  opfs-benchmarks:
-    name: OPFS performance budgets
-    needs: js-sdk-test
-    # Preserve hardware-sensitive latency budgets on Blacksmith. This small
-    # job downloads the functional-test output and never recompiles Rust/Wasm.
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
-    env:
-      LIX_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.LIX_SOURCE_SHA }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: |
-            packages/js-sdk/package-lock.json
-            packages/storage-opfs/package-lock.json
-
-      - name: Install browser test dependencies
-        run: |
-          npm --prefix packages/js-sdk ci
-          npm --prefix packages/storage-opfs ci
-
-      - name: Download functionally tested browser SDK
-        uses: actions/download-artifact@v4
-        with:
-          name: lix-browser-sdk-build-${{ env.LIX_SOURCE_SHA }}
-
-      - name: Install Chromium
-        working-directory: packages/js-sdk
-        run: npx playwright install --with-deps chromium
-
-      - name: Check OPFS performance budgets with the existing SDK
-        working-directory: packages/storage-opfs
-        run: |
-          npm run benchmark
-          npm run benchmark:multi-tab
-
-      - name: Upload tested browser SDK for submodule consumers
-        uses: actions/upload-artifact@v4
-        with:
-          name: lix-browser-sdk-${{ env.LIX_SOURCE_SHA }}
-          path: |
-            packages/js-sdk/dist
-            packages/storage-opfs/dist
-            ci-artifact/browser.json
-          if-no-files-found: error
-          compression-level: 0
-          retention-days: 90
 
   preview-artifact-changes:
     name: Select preview artifacts

--- a/packages/storage-opfs/README.md
+++ b/packages/storage-opfs/README.md
@@ -55,3 +55,7 @@ application. `npm run benchmark` reports raw samples plus p50/p95 for warm Lix
 reopen, local execute-through-observer delivery, and the 10k/1M-row storage
 scorecards. `npm run benchmark:multi-tab` reports cross-tab observer delivery
 and owner-failover recovery from packed production artifacts.
+
+Run these benchmarks manually when investigating performance. CI/CD runs the
+functional browser tests and publishes the tested SDK artifact without running
+the OPFS performance budgets.

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -64,7 +64,7 @@ test("Rust scope gates only Rust jobs and keeps both SDK integration suites", ()
 	assert.match(cargo, /if: needs\.changelog\.outputs\.rust != 'false'/);
 	const sdk = workflow
 		.split("\n  js-sdk-test:\n")[1]
-		.split("\n  opfs-benchmarks:\n")[0];
+		.split("\n  preview-artifact-changes:\n")[0];
 	assert.doesNotMatch(sdk, /needs:|outputs\.rust/);
 	assert.match(workflow, /fetch-depth: 2/);
 	assert.match(workflow, /rust: \$\{\{ steps\.scope\.outputs\.rust \}\}/);
@@ -143,30 +143,35 @@ test("green SDK jobs retain exact-revision artifacts for submodule consumers", (
 	assert.doesNotMatch(workflow, /CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"/);
 });
 
-test("OPFS latency budgets reuse the tested SDK without compiling on Blacksmith", () => {
+test("browser artifacts publish after functional tests without OPFS benchmarks", () => {
 	const sdk = workflow
 		.split("\n  js-sdk-test:\n")[1]
-		.split("\n  opfs-benchmarks:\n")[0];
-	const benchmarks = workflow
-		.split("\n  opfs-benchmarks:\n")[1]
 		.split("\n  preview-artifact-changes:\n")[0];
-	assert.match(sdk, /name: lix-browser-sdk-build-\$\{\{ env\.LIX_SOURCE_SHA \}\}/);
-	assert.doesNotMatch(sdk, /npm run benchmark/);
-	assert.match(benchmarks, /needs: js-sdk-test/);
-	assert.match(benchmarks, /runs-on: blacksmith-4vcpu-ubuntu-2404/);
-	assert.match(
-		benchmarks,
-		/uses: actions\/download-artifact@v4[\s\S]*?name: lix-browser-sdk-build-\$\{\{ env\.LIX_SOURCE_SHA \}\}/,
-	);
-	assert.match(benchmarks, /npm run benchmark\n\s+npm run benchmark:multi-tab/);
-	assert.doesNotMatch(
-		benchmarks,
-		/\brustup\b|\bcargo\b|\bbuild:(?:native|wasm|plugins|browser)\b/,
-	);
+	const upload = sdk
+		.split("name: Upload tested browser SDK for submodule consumers\n")[1]
+		.split("\n      - name:")[0];
+	assert.match(upload, /if: matrix\.runtime == 'browser'/);
+	assert.match(upload, /uses: actions\/upload-artifact@v4/);
+	assert.match(upload, /name: lix-browser-sdk-\$\{\{ env\.LIX_SOURCE_SHA \}\}/);
+	for (const path of [
+		"packages/js-sdk/dist",
+		"packages/storage-opfs/dist",
+		"ci-artifact/browser.json",
+	]) {
+		assert.ok(upload.includes(path));
+	}
+	assert.match(upload, /retention-days: 90/);
 	assert.ok(
-		benchmarks.indexOf("name: Upload tested browser SDK for submodule consumers") >
-			benchmarks.indexOf("npm run benchmark:multi-tab"),
+		sdk.indexOf("name: Upload tested browser SDK for submodule consumers") >
+			sdk.indexOf("name: Run OPFS storage browser tests"),
 	);
+	for (const source of [workflow, publishWorkflow]) {
+		assert.doesNotMatch(
+			source,
+			/opfs-benchmarks:|OPFS performance budgets|npm run benchmark/,
+		);
+		assert.doesNotMatch(source, /lix-browser-sdk-build-/);
+	}
 });
 
 test("server-changing pull requests retain one reusable preview image", () => {


### PR DESCRIPTION
Browser SDK artifact publishing currently waits for the OPFS performance-budget job, making downstream artifact availability depend on hardware-sensitive benchmarks.

Publish the existing `lix-browser-sdk-<sha>` artifact directly from the browser SDK test job after functional tests pass, preserving its payload, revision metadata, and 90-day retention. Remove the OPFS benchmark job from CI/CD. Browser storage correctness tests remain in CI; performance benchmarks remain available through the existing manual npm commands.

Fix the existing storage-watch coalescing test's notification-delivery race. Awaiting commits on the writer does not synchronize a separate watching client. Round-trip to the owner on the watching client's channel before asserting coalescing, so both preceding notifications have arrived. The test still checks that the next waiter stays pending and rejects on close.

Validation:
- `actionlint .github/workflows/ci.yml` passed.
- All 26 CI workflow, scope, binary-cache, and server-image tests passed with `TMPDIR=/private/tmp` (avoids macOS temporary-path alias differences in the cache tests).
- OPFS package build and TypeScript checks passed.
- All 39 OPFS browser correctness tests passed, including all 11 storage-watch tests.
- `git diff --check` passed.

Follow-up to #1679. Also addresses the flaky main-branch test in https://github.com/opral/lix/actions/runs/34071552283/job/101589725699.
