### PR TITLE
ci: avoid repeating successful PR tests after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,76 @@ defaults:
     shell: bash --noprofile --norc -o errexit -o nounset -o pipefail -o xtrace -O nullglob -O dotglob {0}
 
 jobs:
+  merge-reuse:
+    name: Reuse tested merge
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    outputs:
+      reuse: ${{ steps.reuse.outputs.reuse }}
+      run_id: ${{ steps.reuse.outputs.run_id }}
+      revision: ${{ steps.reuse.outputs.revision }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find successful PR validation of the exact merged tree
+        id: reuse
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { selectMergeReuse } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/ci-merge-reuse.mjs`);
+            await selectMergeReuse({ github, context, core });
+
+  promote-browser-sdk:
+    name: Reuse tested browser SDK
+    needs: merge-reuse
+    if: needs.merge-reuse.outputs.reuse == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: lix-browser-sdk-${{ needs.merge-reuse.outputs.revision }}
+          run-id: ${{ needs.merge-reuse.outputs.run_id }}
+          github-token: ${{ github.token }}
+      - name: Record identical-tree artifact provenance
+        env:
+          SOURCE_REVISION: ${{ needs.merge-reuse.outputs.revision }}
+          SOURCE_RUN: ${{ needs.merge-reuse.outputs.run_id }}
+        run: |
+          node --input-type=module - <<'EOF'
+          import { readFileSync, writeFileSync } from 'node:fs';
+          const path = 'ci-artifact/browser.json';
+          const manifest = JSON.parse(readFileSync(path, 'utf8'));
+          if (manifest.schemaVersion !== 1 || manifest.kind !== 'lix-browser-sdk' ||
+              manifest.sourceRevision !== process.env.SOURCE_REVISION) {
+            throw new Error('Unexpected source artifact provenance');
+          }
+          manifest.reusedFromRevision = manifest.sourceRevision;
+          manifest.reusedFromRun = process.env.SOURCE_RUN;
+          manifest.sourceRevision = process.env.GITHUB_SHA;
+          writeFileSync(path, JSON.stringify(manifest, null, 2));
+          EOF
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lix-browser-sdk-${{ github.sha }}
+          path: |
+            packages/js-sdk/dist
+            packages/storage-opfs/dist
+            ci-artifact/browser.json
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+
   changelog:
     name: Changelog
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: merge-reuse
+    if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-24.04
     outputs:
       rust: ${{ steps.scope.outputs.rust }}
@@ -44,6 +111,29 @@ jobs:
         with:
           # Include both parents of the tested PR merge for scope detection.
           fetch-depth: 2
+
+      # Rust validates the checkout merge tree; SDK jobs validate the PR head.
+      # This evidence is reusable only after the entire workflow succeeds.
+      - name: Record tested source trees
+        env:
+          SOURCE_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          node --input-type=module - <<'EOF'
+          import { execFileSync } from 'node:child_process';
+          import { writeFileSync } from 'node:fs';
+          const tree = ref => execFileSync('git', ['rev-parse', `${ref}^{tree}`], { encoding: 'utf8' }).trim();
+          writeFileSync('tested-source.json', JSON.stringify({
+            schemaVersion: 1,
+            sourceRevision: process.env.SOURCE_REVISION,
+            sourceTree: tree(process.env.SOURCE_REVISION),
+            testedTree: tree('HEAD'),
+          }));
+          EOF
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ci-tested-source
+          path: tested-source.json
+          retention-days: 90
 
       - name: Select Rust CI scope
         id: scope
@@ -56,11 +146,12 @@ jobs:
         run: node scripts/validate-server-protocol-docs.mjs
 
       - name: Validate CI workflow invariants
-        run: node --test scripts/ci-workflow.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs
+        run: node --test scripts/ci-workflow.test.mjs scripts/ci-merge-reuse.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: merge-reuse
+    if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -338,7 +429,8 @@ jobs:
 
   js-sdk-test:
     name: JS SDK ${{ matrix.name }} Test
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: merge-reuse
+    if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || 'ubuntu-24.04' }}
     timeout-minutes: 45
     env:

--- a/scripts/ci-merge-reuse.mjs
+++ b/scripts/ci-merge-reuse.mjs
@@ -1,0 +1,72 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// A green head SHA alone is insufficient: Rust tests the PR merge tree, while
+// SDK jobs check out the PR head. Both must match the landed tree exactly.
+export function matchesTestedSource(evidence, { revision, tree }) {
+	return evidence.schemaVersion === 1 &&
+		evidence.sourceRevision === revision &&
+		evidence.sourceTree === tree && evidence.testedTree === tree;
+}
+
+export async function findReusableRun({ github, repository, sha, tree, readEvidence }) {
+	const [owner, repo] = repository.split("/");
+	const scope = { owner, repo };
+	const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({ ...scope, commit_sha: sha, per_page: 100 });
+	for (const pr of prs) {
+		if (!pr.merged_at || pr.merge_commit_sha !== sha || pr.head.repo?.full_name !== repository) continue;
+		const revision = pr.head.sha;
+		const { data } = await github.rest.actions.listWorkflowRuns({
+			...scope, workflow_id: "ci.yml", event: "pull_request",
+			head_sha: revision, status: "success", per_page: 100,
+		});
+		for (const run of data.workflow_runs) {
+			if (run.conclusion !== "success" || run.event !== "pull_request" ||
+				run.head_sha !== revision || run.head_repository?.full_name !== repository ||
+				run.path !== ".github/workflows/ci.yml") continue;
+			const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, { ...scope, run_id: run.id, per_page: 100 });
+			const evidenceArtifact = artifacts.find(a => a.name === "ci-tested-source" && !a.expired);
+			const browser = artifacts.find(a => a.name === `lix-browser-sdk-${revision}` && !a.expired);
+			if (!evidenceArtifact || !browser) continue;
+			const evidence = await readEvidence(evidenceArtifact);
+			if (matchesTestedSource(evidence, { revision, tree })) return { runId: run.id, revision };
+		}
+	}
+	return null;
+}
+
+export async function selectMergeReuse({ github, context, core }) {
+	core.setOutput("reuse", "false");
+	if (context.eventName !== "push") return;
+	try {
+		const tree = execFileSync("git", ["rev-parse", "HEAD^{tree}"], { encoding: "utf8" }).trim();
+		const result = await findReusableRun({
+			github, repository: `${context.repo.owner}/${context.repo.repo}`, sha: context.sha, tree,
+			readEvidence: async artifact => {
+				if (artifact.size_in_bytes > 65536) throw new Error("Oversized CI provenance");
+				const response = await github.rest.actions.downloadArtifact({ ...context.repo, artifact_id: artifact.id, archive_format: "zip" });
+				const download = await fetch(response.url);
+				if (!download.ok) throw new Error(`Provenance download: ${download.status}`);
+				const zip = Buffer.from(await download.arrayBuffer());
+				if (artifact.digest && artifact.digest !== `sha256:${createHash("sha256").update(zip).digest("hex")}`) throw new Error("CI provenance digest mismatch");
+				const directory = mkdtempSync(join(tmpdir(), "ci-provenance-"));
+				try {
+					const archive = join(directory, "source.zip");
+					writeFileSync(archive, zip);
+					return JSON.parse(execFileSync("unzip", ["-p", archive, "tested-source.json"], { encoding: "utf8", maxBuffer: 65536 }));
+				} finally { rmSync(directory, { recursive: true, force: true }); }
+			},
+		});
+		if (!result) { core.info("No successful PR run proves this exact tree; running full CI."); return; }
+		await core.summary.addRaw(`Reusing successful PR CI run ${result.runId}: both tested source trees match ${tree}. SDK artifacts are promoted to ${context.sha}; compilation and tests are not repeated.`).write();
+		core.setOutput("reuse", "true");
+		core.setOutput("run_id", result.runId);
+		core.setOutput("revision", result.revision);
+	} catch (error) {
+		// Lookup failures must never suppress validation.
+		core.warning(`Cannot prove prior CI coverage; running full CI: ${error.message}`);
+	}
+}

--- a/scripts/ci-merge-reuse.test.mjs
+++ b/scripts/ci-merge-reuse.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { findReusableRun, matchesTestedSource, selectMergeReuse } from './ci-merge-reuse.mjs';
+
+const evidence = { schemaVersion: 1, sourceRevision: 'head', sourceTree: 'tree', testedTree: 'tree' };
+test('reuse requires both the SDK head tree and Rust merge tree to match', () => {
+  assert.equal(matchesTestedSource(evidence, { revision: 'head', tree: 'tree' }), true);
+  for (const patch of [{ sourceTree: 'old' }, { testedTree: 'old' }, { sourceRevision: 'old' }, { schemaVersion: 2 }]) {
+    assert.equal(matchesTestedSource({ ...evidence, ...patch }, { revision: 'head', tree: 'tree' }), false);
+  }
+});
+function fixture() {
+  const pr = { merged_at: 'date', merge_commit_sha: 'merge', head: { sha: 'head', repo: { full_name: 'opral/lix' } } };
+  const run = { id: 42, conclusion: 'success', event: 'pull_request', head_sha: 'head', head_repository: { full_name: 'opral/lix' }, path: '.github/workflows/ci.yml' };
+  const artifacts = [{ name: 'ci-tested-source' }, { name: 'lix-browser-sdk-head' }];
+  const github = { rest: {
+    repos: { listPullRequestsAssociatedWithCommit: async () => ({ data: [pr] }) },
+    actions: { listWorkflowRuns: async () => ({ data: { workflow_runs: [run] } }), listWorkflowRunArtifacts() {} },
+  }, paginate: async () => artifacts };
+  return { pr, run, artifacts, args: { github, repository: 'opral/lix', sha: 'merge', tree: 'tree', readEvidence: async () => evidence } };
+}
+test('successful matching PR run retains a downstream SDK artifact without recompilation', async () => {
+  assert.deepEqual(await findReusableRun(fixture().args), { runId: 42, revision: 'head' });
+});
+for (const [name, mutate] of [
+  ['unmerged PR', f => f.pr.merged_at = null],
+  ['different merge', f => f.pr.merge_commit_sha = 'other'],
+  ['fork PR', f => f.pr.head.repo.full_name = 'fork/lix'],
+  ['failed CI', f => f.run.conclusion = 'failure'],
+  ['cancelled CI', f => f.run.conclusion = 'cancelled'],
+  ['push CI', f => f.run.event = 'push'],
+  ['different workflow', f => f.run.path = '.github/workflows/other.yml'],
+  ['different head', f => f.run.head_sha = 'old'],
+  ['fork run', f => f.run.head_repository.full_name = 'fork/lix'],
+  ['expired SDK', f => f.artifacts[1].expired = true],
+  ['missing provenance', f => f.artifacts.shift()],
+  ['changed merge tree', f => f.args.tree = 'new-tree'],
+]) {
+  test(`${name} requires full CI`, async () => {
+    const f = fixture(); mutate(f);
+    assert.equal(await findReusableRun(f.args), null);
+  });
+}
+test('manual dispatch and PR updates always validate', async () => {
+  for (const eventName of ['workflow_dispatch', 'pull_request']) {
+    const outputs = {};
+    await selectMergeReuse({ github: {}, context: { eventName }, core: { setOutput: (k, v) => outputs[k] = v } });
+    assert.deepEqual(outputs, { reuse: 'false' });
+  }
+});
+test('API failure falls back to full CI', async () => {
+  const outputs = {}; const warnings = [];
+  await selectMergeReuse({ github: {}, context: { eventName: 'push', repo: { owner: 'opral', repo: 'lix' } }, core: {
+    setOutput: (k, v) => outputs[k] = v, warning: message => warnings.push(message),
+  } });
+  assert.equal(outputs.reuse, 'false');
+  assert.equal(warnings.length, 1);
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -65,7 +65,8 @@ test("Rust scope gates only Rust jobs and keeps both SDK integration suites", ()
 	const sdk = workflow
 		.split("\n  js-sdk-test:\n")[1]
 		.split("\n  preview-artifact-changes:\n")[0];
-	assert.doesNotMatch(sdk, /needs:|outputs\.rust/);
+	assert.match(sdk, /needs: merge-reuse/);
+	assert.doesNotMatch(sdk, /outputs\.rust/);
 	assert.match(workflow, /fetch-depth: 2/);
 	assert.match(workflow, /rust: \$\{\{ steps\.scope\.outputs\.rust \}\}/);
 	assert.match(workflow, /run: node scripts\/ci-rust-scope\.mjs/);
@@ -261,4 +262,20 @@ test("tooling Clippy excludes the benchmark-only DuckDB feature", () => {
 	assert.ok(e2eClippy);
 	assert.match(e2eClippy, /--all-targets --features /);
 	assert.doesNotMatch(e2eClippy, /\btpch\b|--all-features/);
+});
+
+test("tested merges skip validation but retain SDK artifacts for the landed revision", () => {
+	for (const job of ["changelog", "cargo-config", "js-sdk-test"]) {
+		const definition = workflow.split(`\n  ${job}:\n`)[1].split("\n    steps:")[0];
+		assert.match(definition, /needs: merge-reuse/);
+		assert.match(definition, /needs\.merge-reuse\.outputs\.reuse != 'true'/);
+	}
+	assert.match(workflow, /name: ci-tested-source/);
+	assert.match(workflow, /sourceTree: tree\(process\.env\.SOURCE_REVISION\)/);
+	assert.match(workflow, /testedTree: tree\('HEAD'\)/);
+	const promotion = workflow.split("\n  promote-browser-sdk:\n")[1].split("\n  changelog:\n")[0];
+	assert.match(promotion, /if: needs\.merge-reuse\.outputs\.reuse == 'true'/);
+	assert.match(promotion, /run-id: \$\{\{ needs\.merge-reuse\.outputs\.run_id \}\}/);
+	assert.match(promotion, /name: lix-browser-sdk-\$\{\{ github\.sha \}\}/);
+	assert.doesNotMatch(promotion, /\bcargo\b|\bnpm\b/);
 });


### PR DESCRIPTION
Merging a green PR currently starts the entire CI suite again via the `push` trigger. For example, #1679 passed run 34070659177 and immediately started duplicate run 34071552283 after merge.

Add a short merge-reuse job that finds a successful same-repository PR CI run associated with the landed commit. PR CI records both the Rust checkout tree and the SDK head tree. Validation is skipped only when both exactly match the landed tree and the tested browser SDK artifact is available. The artifact is copied to the new commit's artifact name with its original provenance retained, so downstream LixRay consumers can still reuse it without compilation.

Direct pushes, changed merge trees, fork PRs, unavailable/expired evidence, failed runs and API errors retain full validation. Manual dispatch always runs validation. Existing release/publishing triggers remain unchanged. Older runs without the new provenance artifact cannot be reused.

Validation: 43 Node tests pass, including mismatched trees, unsuccessful/foreign runs, missing artifacts, API failures and workflow dependency checks; actionlint and git diff --check pass. GitHub execution and the first post-merge artifact promotion remain to be verified.
