### PR TITLE
fix: align change identities with stored schema records

### DIFF
--- a/.changenotes/change-schema-row-pk.md
+++ b/.changenotes/change-schema-row-pk.md
@@ -1,0 +1,6 @@
+---
+type: minor
+---
+Restore `lix_change` record identities as `schema_key`, JSONB `row_pk`, and `file_id`, replacing its public `row_ref`.
+
+History `lixcol_source_changes` objects use the same record identity. Snapshots and identities describe the same underlying schema record. Public history rows and diff commands continue to use opaque row references.

--- a/docs/history.md
+++ b/docs/history.md
@@ -136,8 +136,9 @@ Filesystem history describes a composed projection. Renaming, moving,
 deleting, or restoring an ancestor directory creates a revision for every
 affected descendant even when the descendant's own descriptor did not change.
 Each row records all same-commit causes in the structured
-`lixcol_source_changes` JSON array. Each source object carries a `row_ref`
-instead of a JSON primary-key tuple. It deliberately does not expose singular
+`lixcol_source_changes` JSON array. Each source object carries the underlying record’s `schema_key`, JSON `row_pk`
+tuple, and `file_id`, matching `lix_change`. These identities describe the source
+snapshots, while `lixcol_row_ref` addresses the composed public history row. It deliberately does not expose singular
 `lixcol_change_id`, `lixcol_schema_key`, or `lixcol_origin_key` columns.
 
 Lix reconstructs rows through the anchor commit's ancestry. It does not treat
@@ -153,7 +154,7 @@ branch reachability. Ordinary untracked writes do not create change rows.
 | Column | What it is |
 | :-- | :-- |
 | `id` | Unique change ID. |
-| `row_ref` | Relation-qualified row reference, or `NULL` for private engine rows. |
+| `row_pk` | JSON primary-key tuple in the changed schema’s primary-key order. |
 | `schema_key` | Changed Schema v1 key. |
 | `file_id` | Owning file, or `NULL`. |
 | `metadata` | JSON change metadata. |
@@ -162,13 +163,16 @@ branch reachability. Ordinary untracked writes do not create change rows.
 | `origin_key` | Optional origin key attached to the change. |
 | `created_at` | Change timestamp. |
 
-Use `lix_row_ref()` to address a public logical row without reconstructing its
-primary-key encoding:
+Filter by the changed schema and its primary-key tuple; include `file_id` when
+the record is file-scoped. A change snapshot represents this underlying record,
+not a composed public view such as `lix_file` or `lix_branch`:
 
 ```sql
 SELECT created_at, id, snapshot_content
 FROM lix_change
-WHERE row_ref = lix_row_ref('acme_issue', 'launch', '7')
+WHERE schema_key = 'acme_issue'
+  AND row_pk = CAST('["launch", "7"]' AS JSONB)
+  AND file_id IS NULL
 ORDER BY created_at, id;
 ```
 

--- a/packages/lix-schema/fixtures/current/lix_change.json
+++ b/packages/lix-schema/fixtures/current/lix_change.json
@@ -19,10 +19,10 @@
       ]
     },
     {
-      "name": "row_ref",
-      "type": "text",
-      "nullable": true,
-      "description": "Opaque reference to the public relation row this change applies to; NULL for private engine rows."
+      "name": "row_pk",
+      "type": "jsonb",
+      "nullable": false,
+      "description": "Canonical primary-key tuple of the changed schema record, in schema primary-key order and scoped by schema_key and file_id. Matches the record represented by snapshot_content."
     },
     {
       "name": "file_id",

--- a/packages/lix/src/schema/builtin/lix_change.json
+++ b/packages/lix/src/schema/builtin/lix_change.json
@@ -19,10 +19,10 @@
       ]
     },
     {
-      "name": "row_ref",
-      "type": "text",
-      "nullable": true,
-      "description": "Opaque reference to the public relation row this change applies to; NULL for private engine rows."
+      "name": "row_pk",
+      "type": "jsonb",
+      "nullable": false,
+      "description": "Canonical primary-key tuple of the changed schema record, in schema primary-key order and scoped by schema_key and file_id. Matches the record represented by snapshot_content."
     },
     {
       "name": "file_id",

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -11739,9 +11739,9 @@ mod tests {
                  FROM files AS file_a \
                  JOIN files AS file_b ON file_a.id = file_b.id \
                  LEFT JOIN (\
-                     SELECT row_ref FROM lix_change \
+                     SELECT row_pk FROM lix_change \
                      UNION ALL \
-                     SELECT row_ref FROM lix_change\
+                     SELECT row_pk FROM lix_change\
                  ) AS changes ON false",
                 &[],
             )

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -169,7 +169,7 @@ impl PublicCatalog {
             PublicSurfaceKind::Change => Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Utf8, false),
                 Field::new("account_id", DataType::Utf8, false),
-                row_ref_field("row_ref", true),
+                json_field("row_pk", false),
                 Field::new("schema_key", DataType::Utf8, false),
                 Field::new("file_id", DataType::Utf8, true),
                 json_field("metadata", true),
@@ -262,7 +262,7 @@ impl PublicCatalog {
             public_columns([
                 ("id", false),
                 ("account_id", false),
-                ("row_ref", true),
+                ("row_pk", false),
                 ("schema_key", false),
                 ("file_id", true),
                 ("metadata", true),

--- a/packages/lix/src/sql2/change_materialization.rs
+++ b/packages/lix/src/sql2/change_materialization.rs
@@ -26,33 +26,6 @@ pub(crate) struct MaterializedChange {
     pub(crate) origin_key: Option<String>,
 }
 
-/// Returns the stable public identity for a materialized change.
-///
-/// A change's physical schema and ownership scope are storage details. Public
-/// semantic relations retain their own primary key; filesystem implementation
-/// rows collapse to the logical file or directory identity.
-pub(crate) fn public_change_row_ref(
-    change: &MaterializedChange,
-) -> Result<Option<crate::RowRef>, LixError> {
-    let (relation, row_pk) =
-        if crate::sql2::catalog::schema_exposed_as_schema_surface(&change.schema_key) {
-            (change.schema_key.as_str(), change.row_pk.clone())
-        } else if change.schema_key == "lix_directory_descriptor" {
-            ("lix_directory", change.row_pk.clone())
-        } else if let Some(file_id) = change.file_id.as_deref() {
-            let row_pk = RowPk::uuid_from_canonical(file_id).map_err(|error| {
-                LixError::new(
-                    LixError::CODE_TYPE_MISMATCH,
-                    format!("lix_change file identity is invalid: {error}"),
-                )
-            })?;
-            ("lix_file", row_pk)
-        } else {
-            return Ok(None);
-        };
-    crate::row_ref::encode(relation, &row_pk).map(Some)
-}
-
 /// Payloads that a change scan must project for its output or filters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ChangePayloadProjection {

--- a/packages/lix/src/sql2/history_route.rs
+++ b/packages/lix/src/sql2/history_route.rs
@@ -14,7 +14,7 @@ use crate::row_pk::RowPk;
 
 use super::SqlHistoryQuerySource;
 use crate::sql2::change_materialization::{
-    MaterializedChange, materialize_located_history_change, public_change_row_ref,
+    MaterializedChange, materialize_located_history_change,
 };
 use crate::storage_adapter::StorageAdapterRead;
 
@@ -202,7 +202,7 @@ pub(crate) fn serialize_history_source_changes(
     let source_changes = ordered_changes
         .into_iter()
         .map(|change| {
-            let row_ref = public_change_row_ref(change)?.map(|value| value.to_string());
+            let row_pk = change.row_pk.as_json_array_value()?;
             let snapshot_content = parse_optional_source_json(
                 change.snapshot_content.as_deref(),
                 surface_name,
@@ -212,7 +212,7 @@ pub(crate) fn serialize_history_source_changes(
                 parse_optional_source_json(change.metadata.as_deref(), surface_name, "metadata")?;
             Ok(serde_json::json!({
                 "id": change.id,
-                "row_ref": row_ref,
+                "row_pk": row_pk,
                 "schema_key": change.schema_key,
                 "file_id": change.file_id,
                 "snapshot_content": snapshot_content,
@@ -837,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    fn source_change_row_ref_uses_public_filesystem_relation() {
+    fn source_change_identity_matches_underlying_schema() {
         let file_id = "018f6f7e-7cb2-7d45-8e1f-0a2b3c4d5e6f";
         let row_pk = RowPk::uuid_from_canonical(file_id).expect("test UUID should be canonical");
         let change = MaterializedChange {
@@ -857,14 +857,10 @@ mod tests {
             .expect("source changes should serialize");
         let value: serde_json::Value =
             serde_json::from_str(&json).expect("source changes should be JSON");
-        let encoded = value[0]["row_ref"]
-            .as_str()
-            .expect("public change should have a row reference");
-        let decoded = crate::row_ref::decode_str(encoded).expect("row reference should decode");
-
         assert_eq!(value[0]["schema_key"], "lix_file_descriptor");
-        assert_eq!(decoded.relation, "lix_file");
-        assert_eq!(decoded.row_pk, row_pk);
+        assert_eq!(value[0]["row_pk"], row_pk.as_json_array_value().unwrap());
+        assert_eq!(value[0]["file_id"], file_id);
+        assert!(value[0].get("row_ref").is_none());
     }
 
     #[test]

--- a/packages/lix/src/sql2/providers/change.rs
+++ b/packages/lix/src/sql2/providers/change.rs
@@ -17,10 +17,10 @@ use crate::sql2::SqlChangelogQuerySource;
 use crate::sql2::WriteAccess;
 use crate::sql2::change_materialization::{
     ChangePayloadProjection, MaterializedChange, materialize_changelog_change_record,
-    materialize_commit_graph_change, public_change_row_ref,
+    materialize_commit_graph_change,
 };
 use crate::sql2::error::lix_error_to_datafusion_error;
-use crate::sql2::result_metadata::{json_field, row_ref_field};
+use crate::sql2::result_metadata::json_field;
 use crate::storage_adapter::StorageAdapterRead;
 
 use super::columns::{Col, ColumnTable, ColumnTableError};
@@ -304,7 +304,7 @@ pub(super) fn lix_change_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("id", DataType::Utf8, false),
         Field::new("account_id", DataType::Utf8, false),
-        row_ref_field("row_ref", true),
+        json_field("row_pk", false),
         Field::new("schema_key", DataType::Utf8, false),
         Field::new("file_id", DataType::Utf8, true),
         json_field("metadata", true),
@@ -319,8 +319,8 @@ static LIX_CHANGE_COLS: ColumnTable<MaterializedChange> = ColumnTable {
         ("id", Col::Utf8(|row| Some(row.id.as_str()))),
         ("account_id", Col::Utf8(|row| Some(row.account_id.as_str()))),
         (
-            "row_ref",
-            Col::Utf8Fallible(change_public_row_ref),
+            "row_pk",
+            Col::Utf8Fallible(|row| row.row_pk.as_json_array_text().map(Some)),
         ),
         ("schema_key", Col::Utf8(|row| Some(row.schema_key.as_str()))),
         ("file_id", Col::Utf8(|row| row.file_id.as_deref())),
@@ -336,10 +336,6 @@ static LIX_CHANGE_COLS: ColumnTable<MaterializedChange> = ColumnTable {
         ),
     ],
 };
-
-fn change_public_row_ref(row: &MaterializedChange) -> Result<Option<String>, LixError> {
-    public_change_row_ref(row).map(|row_ref| row_ref.map(|value| value.to_string()))
-}
 
 fn change_batch_error(error: ColumnTableError) -> DataFusionError {
     match error {

--- a/packages/lix/src/sql2/providers/mod.rs
+++ b/packages/lix/src/sql2/providers/mod.rs
@@ -871,9 +871,9 @@ mod tests {
              SELECT left_side.id \
              FROM shadowed AS left_side \
              JOIN (\
-                 SELECT row_ref FROM lix_change \
+                 SELECT row_pk FROM lix_change \
                  UNION ALL \
-                 SELECT row_ref FROM lix_change\
+                 SELECT row_pk FROM lix_change\
                ) AS right_side \
                ON false \
              JOIN public.\"lix_directory\" AS directory_a ON true \

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -1235,7 +1235,7 @@ simulation_test!(
             "SELECT count(*) \
 	     FROM lix_change \
 	     WHERE schema_key = 'lix_key_value' \
-	       AND row_ref = lix_row_ref('lix_key_value', 'merge-select-change') \
+	       AND row_pk = CAST('[\"merge-select-change\"]' AS JSONB) \
 	       AND snapshot_content = CAST('{\"key\":\"merge-select-change\",\"value\":\"source\"}' AS JSONB)",
         )
         .await;

--- a/packages/lix/tests/integration/sql/checkpoint.rs
+++ b/packages/lix/tests/integration/sql/checkpoint.rs
@@ -236,15 +236,15 @@ simulation_test!(
             select_rows(
                 &session,
                 &format!(
-                    "SELECT schema_key, row_ref = lix_row_ref('lix_checkpoint', '{}') \
+                    "SELECT schema_key, row_pk \
                      FROM lix_change WHERE id = '{}'",
-                    receipt.commit_id, receipt.change_id
+                    receipt.change_id
                 ),
             )
             .await,
             vec![vec![
                 Value::Text("lix_checkpoint".to_string()),
-                Value::Boolean(true),
+                Value::Jsonb(json!([receipt.commit_id.to_string()]).into()),
             ]],
             "checkpoint publication must be a normal logical change"
         );

--- a/packages/lix/tests/integration/sql/lix_change.rs
+++ b/packages/lix/tests/integration/sql/lix_change.rs
@@ -25,16 +25,19 @@ simulation_test!(lix_change_queries_durable_change_facts, |sim| async move {
 
     let result = session
         .execute(
-            "SELECT row_ref, schema_key, snapshot_content \
+            "SELECT row_pk, schema_key, snapshot_content \
              FROM lix_change \
-             WHERE row_ref = lix_row_ref('lix_key_value', 'change-query')",
+             WHERE schema_key = 'lix_key_value' AND row_pk = CAST('[\"change-query\"]' AS JSONB)",
             &[],
         )
         .await
         .expect("lix_change should read");
     let rows = result;
     assert_eq!(rows.len(), 1);
-    assert!(matches!(rows.rows()[0].values()[0], Value::RowRef(_)));
+    assert_eq!(
+        rows.rows()[0].values()[0],
+        Value::Jsonb(json!(["change-query"]).into())
+    );
     assert_eq!(
         &rows.rows()[0].values()[1..],
         &[
@@ -43,6 +46,80 @@ simulation_test!(lix_change_queries_durable_change_facts, |sim| async move {
         ]
     );
 });
+
+simulation_test!(
+    lix_change_exposes_tracked_schema_identity_and_not_public_row_refs,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+        // Bootstrap may retain ref facts; ordinary writes must not append head movements.
+        let initial_ref_changes = session.execute(
+            "SELECT count(*) AS n FROM lix_change WHERE schema_key = 'lix_branch_ref'", &[],
+        ).await.unwrap().rows()[0].get::<i64>("n").unwrap();
+        let file_id = "01950000-0000-7000-8000-000000000041";
+        session.execute(
+        "INSERT INTO lix_file (id, path, content) VALUES ($1, '/record.txt', CAST('hello' AS BYTEA))",
+        &[Value::Text(file_id.into())],
+    ).await.unwrap();
+        let changes = session.execute(
+        "SELECT schema_key, row_pk, file_id, snapshot_content FROM lix_change WHERE file_id = $1",
+        &[Value::Text(file_id.into())],
+    ).await.unwrap();
+        assert_eq!(changes.column_types()[1], lix::ResultColumnType::Jsonb);
+        let descriptor = changes
+            .rows()
+            .iter()
+            .find(|row| row.get::<String>("schema_key").unwrap() == "lix_file_descriptor")
+            .expect("descriptor change should remain visible");
+        assert_eq!(
+            descriptor.values()[1],
+            Value::Jsonb(json!([file_id]).into())
+        );
+        assert_eq!(descriptor.values()[2], Value::Text(file_id.into()));
+        let Value::Jsonb(snapshot) = &descriptor.values()[3] else {
+            panic!("expected snapshot");
+        };
+        assert_eq!(snapshot.to_value()["id"], file_id);
+        assert_eq!(snapshot.to_value()["name"], "record.txt");
+
+        let columns = session.execute(
+        "SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = 'lix_change' AND column_name IN ('row_pk', 'row_ref')",
+        &[],
+    ).await.unwrap();
+        assert_eq!(columns.len(), 1);
+        assert_eq!(
+            columns.rows()[0].get::<String>("column_name").unwrap(),
+            "row_pk"
+        );
+        assert!(
+            session
+                .execute("SELECT row_ref FROM lix_change", &[])
+                .await
+                .is_err()
+        );
+        let refs = session
+            .execute(
+                "SELECT row_ref FROM lix_diff('lix_file') WHERE id = $1",
+                &[Value::Text(file_id.into())],
+            )
+            .await
+            .unwrap();
+        assert_eq!(refs.column_types()[0], lix::ResultColumnType::RowRef);
+        assert_eq!(
+            session
+                .execute(
+                    "SELECT count(*) AS n FROM lix_change WHERE schema_key = 'lix_branch_ref'",
+                    &[]
+                )
+                .await
+                .unwrap()
+                .rows()[0]
+                .get::<i64>("n")
+                .unwrap(),
+            initial_ref_changes
+        );
+    }
+);
 
 simulation_test!(lix_change_includes_commit_changes, |sim| async move {
     let engine = sim.boot_engine().await;
@@ -78,7 +155,7 @@ simulation_test!(lix_change_includes_commit_changes, |sim| async move {
 });
 
 simulation_test!(
-    lix_change_row_ref_is_lossless_for_composite_primary_keys,
+    lix_change_row_pk_is_lossless_for_composite_primary_keys,
     |sim| async move {
         let engine = sim.boot_engine().await;
         let session = sim.wrap_session(
@@ -120,18 +197,23 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT row_ref, \
-                        row_ref = lix_row_ref('engine_composite_message', 'welcome.title', 'en') AS expected_ref \
+                "SELECT row_pk, file_id \
                  FROM lix_change \
                  WHERE schema_key = 'engine_composite_message'",
                 &[],
             )
             .await
-            .expect("lix_change should expose the semantic composite row_ref");
+            .expect("lix_change should expose the schema record identity");
 
         assert_eq!(result.len(), 1);
-        assert!(matches!(result.rows()[0].values()[0], Value::RowRef(_)));
-        assert_eq!(result.rows()[0].values()[1], Value::Boolean(true));
+        assert_eq!(
+            result.rows()[0].values()[0],
+            Value::Jsonb(json!(["welcome.title", "en"]).into())
+        );
+        assert_eq!(
+            result.rows()[0].values()[1],
+            Value::Text("01950000-0000-7000-8000-000000000031".into())
+        );
     }
 );
 
@@ -162,9 +244,7 @@ simulation_test!(
 
         assert_eq!(error.code, lix::LixError::CODE_SCHEMA_DEFINITION);
         assert!(
-            error
-                .message
-                .contains("must use text, uuid, or int8"),
+            error.message.contains("must use text, uuid, or int8"),
             "error should explain unsupported primary-key schema: {error:?}"
         );
     }

--- a/packages/lix/tests/integration/sql/lix_directory_history.rs
+++ b/packages/lix/tests/integration/sql/lix_directory_history.rs
@@ -100,7 +100,7 @@ simulation_test!(
         };
         let source_changes = source_changes.to_value();
         assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
-        assert!(source_changes[0]["row_ref"].as_str().is_some());
+        assert!(source_changes[0]["row_pk"].as_array().is_some());
         assert_eq!(
             source_changes[0]["snapshot_content"]["parent_id"],
             json!("68697374-6f72-892d-8469-722d646f6300")
@@ -122,7 +122,7 @@ simulation_test!(
                 "id",
                 "metadata",
                 "origin_key",
-                "row_ref",
+                "row_pk",
                 "schema_key",
                 "snapshot_content",
             ]
@@ -367,9 +367,7 @@ simulation_test!(
                 .iter()
                 .map(|source| {
                     assert_eq!(source["snapshot_content"], serde_json::Value::Null);
-                    source["row_ref"]
-                        .as_str()
-                        .expect("directory source row_ref should be text")
+                    (source["schema_key"].to_string(), source["row_pk"].to_string())
                 })
                 .collect::<BTreeSet<_>>();
             assert_eq!(actual_source_refs.len(), expected_source_count);

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -215,7 +215,7 @@ simulation_test!(
                     "SELECT file_id \
                      FROM lix_change \
                      WHERE schema_key = 'lix_directory_descriptor' \
-                       AND row_ref = lix_row_ref('lix_directory', '{directory_id}') \
+                       AND row_pk = CAST('[\"{directory_id}\"]' AS JSONB) \
                      ORDER BY created_at"
                 ),
             )
@@ -1040,7 +1040,7 @@ simulation_test!(
             .execute(
                 "SELECT schema_key \
              FROM lix_change \
-             WHERE row_ref = lix_row_ref('lix_file', '66696c65-2d72-8561-846d-650000000000') \
+             WHERE file_id = '66696c65-2d72-8561-846d-650000000000' \
                AND schema_key IN ('lix_file_descriptor', 'lix_binary_blob_ref') \
              ORDER BY schema_key",
                 &[],
@@ -1636,7 +1636,7 @@ simulation_test!(
                 "SELECT id \
              FROM lix_change \
              WHERE schema_key = 'lix_binary_blob_ref' \
-               AND row_ref = lix_row_ref('lix_file', '656d7074-792d-8461-8461-2d66696c6500')",
+               AND file_id = '656d7074-792d-8461-8461-2d66696c6500'",
                 &[],
             )
             .await
@@ -2954,7 +2954,7 @@ async fn file_descriptor_event_count(
         .expect("file history source changes should be an array")
         .iter()
         .filter(|source| {
-            source["row_ref"].as_str().is_some()
+            source["row_pk"].as_array().is_some()
                 && source["snapshot_content"]["id"] == json!(file_id)
                 && source["snapshot_content"].get("name").is_some()
         })
@@ -2994,7 +2994,7 @@ simulation_test!(
                 "SELECT id \
                  FROM lix_change \
                  WHERE schema_key = 'lix_binary_blob_ref' \
-                   AND row_ref = lix_row_ref('lix_file', '616c7265-6164-892d-856d-7074792d6600')",
+                   AND file_id = '616c7265-6164-892d-856d-7074792d6600'",
                 &[],
             )
             .await

--- a/packages/lix/tests/integration/sql/lix_file_history.rs
+++ b/packages/lix/tests/integration/sql/lix_file_history.rs
@@ -618,7 +618,7 @@ async fn lix_file_history_ancestor_point_lookup_keeps_parent_evidence_bounded() 
         panic!("ancestor source changes should be JSON");
     };
     let sources = sources.to_value();
-    assert!(sources[0]["row_ref"].as_str().is_some());
+    assert!(sources[0]["row_pk"].as_array().is_some());
 
     let (requested_keys, scan_calls, scanned_rows) = storage.counters();
     assert!(
@@ -712,7 +712,7 @@ simulation_test!(
         };
         let rename_sources = rename_sources.to_value();
         assert_eq!(rename_sources.as_array().map(Vec::len), Some(1));
-        assert!(rename_sources[0]["row_ref"].as_str().is_some());
+        assert!(rename_sources[0]["row_pk"].as_array().is_some());
 
         crate::sql2::reset_file_history_anchor_probe_census();
         let bounded_renamed_file = session
@@ -883,7 +883,7 @@ simulation_test!(
             .as_array()
             .expect("grouped file sources should be an array")
             .iter()
-            .map(|source| source["row_ref"].as_str().unwrap())
+            .map(|source| (source["schema_key"].to_string(), source["row_pk"].to_string()))
             .collect::<BTreeSet<_>>();
         assert_eq!(source_refs.len(), 3);
 
@@ -1087,7 +1087,7 @@ simulation_test!(
             .as_array()
             .expect("delete sources should be an array")
             .iter()
-            .filter_map(|source| source["row_ref"].as_str())
+            .map(|source| (source["schema_key"].to_string(), source["row_pk"].to_string()))
             .collect::<BTreeSet<_>>();
         assert!(deleted_directory_refs.len() >= 2);
 
@@ -1153,7 +1153,7 @@ simulation_test!(
             .as_array()
             .expect("restore sources should be an array")
             .iter()
-            .filter_map(|source| source["row_ref"].as_str())
+            .map(|source| (source["schema_key"].to_string(), source["row_pk"].to_string()))
             .collect::<BTreeSet<_>>();
         assert!(restored_directory_refs.len() >= 2);
     }
@@ -1281,7 +1281,7 @@ simulation_test!(
         };
         let source_changes = source_changes.to_value();
         assert_eq!(source_changes.as_array().map(Vec::len), Some(1));
-        assert!(source_changes[0]["row_ref"].as_str().is_some());
+        assert!(source_changes[0]["row_pk"].as_array().is_some());
         assert_eq!(
             source_changes[0]["snapshot_content"]["name"],
             json!("readme-renamed.md")
@@ -2201,7 +2201,7 @@ simulation_test!(
         };
         let latest_sources = latest_sources.to_value();
         assert_eq!(latest_sources.as_array().map(Vec::len), Some(1));
-        assert!(latest_sources[0]["row_ref"].as_str().is_some());
+        assert!(latest_sources[0]["row_pk"].as_array().is_some());
 
         let Value::Jsonb(initial_sources) = &result.rows()[1].values()[3] else {
             panic!(
@@ -2211,27 +2211,14 @@ simulation_test!(
         };
         let initial_sources = initial_sources.to_value();
         assert_eq!(initial_sources.as_array().map(Vec::len), Some(2));
-        let source_row_refs = initial_sources
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|source| source["row_ref"].as_str().unwrap().to_owned())
+        let source_schema_keys = initial_sources.as_array().unwrap().iter()
+            .map(|source| source["schema_key"].as_str().unwrap())
             .collect::<BTreeSet<_>>();
-        let expected_row_ref = session
-            .execute(
-                "SELECT lix_row_ref('lix_file', '68697374-6f72-892d-8669-6c652d626c00')",
-                &[],
-            )
-            .await
-            .expect("public file row reference should be constructible");
-        let Value::RowRef(expected_row_ref) = &expected_row_ref.rows()[0].values()[0] else {
-            panic!("lix_row_ref should return the opaque row-reference type");
-        };
-        assert_eq!(
-            source_row_refs,
-            BTreeSet::from([expected_row_ref.as_str().to_owned()]),
-            "descriptor and blob provenance must address the same public file row"
-        );
+        assert_eq!(source_schema_keys, BTreeSet::from(["lix_binary_blob_ref", "lix_file_descriptor"]));
+        for source in initial_sources.as_array().unwrap() {
+            assert!(source["row_pk"].as_array().is_some());
+            assert!(source.get("row_ref").is_none());
+        }
         let source_ids = initial_sources
             .as_array()
             .unwrap()
@@ -2256,7 +2243,7 @@ simulation_test!(
                     "id",
                     "metadata",
                     "origin_key",
-                    "row_ref",
+                    "row_pk",
                     "schema_key",
                     "snapshot_content",
                 ],

--- a/packages/lix/tests/integration/sql/metadata.rs
+++ b/packages/lix/tests/integration/sql/metadata.rs
@@ -555,7 +555,7 @@ simulation_test!(
                 .execute(
                     "SELECT metadata \
                      FROM lix_change \
-                     WHERE row_ref = lix_row_ref('lix_key_value', 'metadata-valid-object') \
+                     WHERE row_pk = CAST('[\"metadata-valid-object\"]' AS JSONB) \
                        AND schema_key = 'lix_key_value'",
                     &[],
                 )

--- a/packages/lix/tests/integration/sql/untracked_current_state.rs
+++ b/packages/lix/tests/integration/sql/untracked_current_state.rs
@@ -530,7 +530,7 @@ async fn change_count_for_key(
         .execute(
             &format!(
                 "SELECT id FROM lix_change WHERE schema_key = 'lix_key_value' \
-                 AND row_ref = lix_row_ref('lix_key_value', '{key}')"
+                 AND row_pk = CAST('[\"{key}\"]' AS JSONB)"
             ),
             &[],
         )


### PR DESCRIPTION
`lix_change` paired a public row reference with an underlying schema snapshot. For merged relations such as `lix_file` and `lix_branch`, those described different rows. Expose `schema_key`, JSONB `row_pk`, and `file_id` so identity and snapshot describe the same stored schema record.

History `lixcol_source_changes` uses the same identity. Public history rows, `lix_diff`, checkpoint selection, and restore/revert continue to use opaque row references. Update the schema fixture, docs, release note, and regression tests, including composite keys and file scope.

Validation:
- GitHub CI Rust workspace tests and doctests passed in the normal test profile; native SDK: 202 passed.
- SQL suite: 870 passed, 3 ignored; branching: 44 passed; schema package: 50 passed.
- All-simulations nextest (release profile): 3,438 passed, 76 skipped; two existing integrity tests fail because they expect verification guarded by `cfg!(debug_assertions)`, which is off in release.
- Doctests: 10 passed. Rust formatting and diff checks pass.
- Rebuilt native/browser SDK; browser verified JSONB row_pk and interactive diff row_ref.
