### PR TITLE
Share immutable state across branch lifecycle publication

### DIFF
--- a/.changenotes/share-branch-lifecycle-state.md
+++ b/.changenotes/share-branch-lifecycle-state.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Share immutable state when creating branches and refresh inherited schema catalogs without rebuilding unchanged branch-local rows.
+
+Preserve private checkpoint before-images, untracked rows, and local overrides across stale-base refreshes, and invalidate cached catalogs when newly inherited schemas become visible.

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5469,6 +5469,91 @@ where
         );
     }
 
+    /// Replaces only the inherited schema cache of a local generation. Local
+    /// rows (including schema overrides/tombstones), untracked rows, and the
+    /// working-diff epoch retain their original ownership and before images.
+    /// A branch-local catalog is needed by domain validation; projecting a
+    /// global schema row through ordinary visibility is not equivalent.
+    pub(crate) async fn stage_inherited_catalog_refresh(
+        &mut self,
+        branch_id: &str,
+        generation: CommitId,
+        local_catalog: HotTrackedSnapshot,
+        mut inherited_catalog: HotTrackedSnapshot,
+    ) -> Result<(), LixError> {
+        const CATALOG: &str = "lix_registered_schema";
+        // Early main generations can still reference the initial global root.
+        // Once a local overlay exists, that root is not local ownership: its
+        // values must come from the live global plane, not shadow its updates.
+        if let Some(root) = load_root_current_base_commit(self.store, branch_id, generation).await?
+        {
+            let node = crate::commit_graph::CommitGraphContext::new()
+                .reader(self.store)
+                .load_node(&root)
+                .await?
+                .ok_or_else(|| head_value_error("current-base commit is missing"))?;
+            if node.base_commit_id.is_none() {
+                self.writes.delete(
+                    ROOT_CURRENT_BASE_SPACE,
+                    StorageKey(Bytes::from(hot_scope_prefix(branch_id, generation))),
+                );
+            }
+        }
+        inherited_catalog
+            .rows
+            .retain(|key, _| !local_catalog.rows.contains_key(key));
+        normalize_complete_hot_snapshot_baselines(
+            &mut inherited_catalog.rows,
+            WorkingDiffBaseline::Clean,
+        )?;
+        let filter = TrackedStateFilter {
+            schema_keys: vec![CATALOG.to_owned()],
+            include_tombstones: true,
+            ..TrackedStateFilter::default()
+        };
+        let HotScanEntries::Decoded(previous) =
+            hot_scan_entries(self.store, branch_id, generation, &filter, None, None)
+                .await?
+                .expect("unbounded catalog scan cannot exhaust a byte budget")
+        else {
+            unreachable!("catalog scan has no finite primary-key predicate");
+        };
+        let mut untracked = BTreeMap::new();
+        for (identity, bytes) in previous {
+            let value = decode_head_value(&bytes)?;
+            let key = identity.into_row_identity();
+            if value.untracked {
+                untracked.insert(key, bytes);
+            } else if !local_catalog.rows.contains_key(&key)
+                && !inherited_catalog.rows.contains_key(&key)
+            {
+                self.writes.delete(
+                    ROW_SPACE,
+                    StorageKey(Bytes::from(encode_hot_row_key_parts(
+                        branch_id,
+                        generation,
+                        &key.schema_key,
+                        &key.row_pk,
+                        key.file_id.as_deref(),
+                    ))),
+                );
+            }
+        }
+        let mut complete_catalog = local_catalog.rows;
+        complete_catalog.extend(
+            inherited_catalog
+                .rows
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+        // A newly inherited tracked schema must not silently replace a
+        // branch-local history-free schema with the same identity.
+        merge_final_untracked_rows(&mut complete_catalog, untracked)?;
+        stage_complete_collection_controls(self.writes, branch_id, generation, &complete_catalog)?;
+        stage_complete_hot_rows(self.writes, branch_id, generation, inherited_catalog.rows);
+        Ok(())
+    }
+
     /// Publishes a transaction-certified ordered insert batch as an immutable
     /// current-state base without rebuilding row-shaped deltas or absence
     /// guards.
@@ -13124,6 +13209,59 @@ mod tests {
             })
             .expect("closure fixture HOT value should encode"),
         )
+    }
+
+    #[tokio::test]
+    async fn inherited_catalog_refresh_preserves_owned_bytes_and_removes_retired_cache() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("catalog-refresh");
+        let identity = |key: &str| HeadRowIdentity {
+            schema_key: "lix_registered_schema".to_owned(),
+            row_pk: RowPk::single(key),
+            file_id: None,
+        };
+        let tracked = encoded_test_hot_value(generation, false, false);
+        let tombstone = encoded_test_hot_value(generation, false, true);
+        let untracked = encoded_test_hot_value(generation, true, false);
+        let local = HotRowMap::from([
+            (identity("owned"), tracked.clone()),
+            (identity("hidden"), tombstone.clone()),
+        ]);
+        let mut previous = local.clone();
+        previous.extend([
+            (identity("retired"), tracked.clone()),
+            (identity("inherited"), tracked.clone()),
+            (identity("private"), untracked.clone()),
+        ]);
+        let mut writes = StorageWriteSet::new();
+        stage_complete_hot_rows(&mut writes, "branch", generation, previous);
+        storage.commit_write_set(writes, StorageWriteOptions::default()).await.unwrap();
+        let read = storage.begin_read(StorageReadOptions::default()).await.unwrap();
+        let mut writes = StorageWriteSet::new();
+        HotStateWriter {
+            store: &read,
+            writes: &mut writes,
+            transaction_global_schema_keys: None,
+        }.stage_inherited_catalog_refresh(
+            "branch", generation,
+            HotTrackedSnapshot { rows: local },
+            HotTrackedSnapshot { rows: HotRowMap::from([
+                (identity("owned"), tracked.clone()),
+                (identity("hidden"), tracked.clone()),
+                (identity("inherited"), tracked.clone()),
+                (identity("new"), tracked),
+            ]) },
+        ).await.unwrap();
+        storage.commit_write_set(writes, StorageWriteOptions::default()).await.expect("one mutation per key, including replacements");
+        let read = storage.begin_read(StorageReadOptions::default()).await.unwrap();
+        let filter = TrackedStateFilter { schema_keys: vec!["lix_registered_schema".to_owned()], include_tombstones: true, ..TrackedStateFilter::default() };
+        let HotScanEntries::Decoded(rows) = hot_scan_entries(&read, "branch", generation, &filter, None, None).await.unwrap().unwrap() else { panic!("decoded catalog"); };
+        let rows = rows.into_iter().map(|(key, value)| (key.into_row_identity(), value)).collect::<HotRowMap>();
+        assert_eq!(rows.len(), 5);
+        assert!(!rows.contains_key(&identity("retired")));
+        assert_eq!(rows[&identity("hidden")], tombstone, "local tombstone is not overwritten by inheritance");
+        assert_eq!(rows[&identity("private")], untracked, "history-free bytes are untouched");
+        assert!(decode_head_value(&rows[&identity("new")]).unwrap().commit_id.is_some());
     }
 
     #[test]

--- a/packages/lix/src/session/switch_branch.rs
+++ b/packages/lix/src/session/switch_branch.rs
@@ -230,6 +230,132 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn branch_creation_shares_immutable_rows_and_refresh_keeps_its_generation() {
+        use crate::branch::BranchHeadControlContext;
+        use crate::hot_state::{
+            ROOT_CURRENT_BASE_SPACE, ROW_SPACE, hot_generation_scope_prefix,
+        };
+        use crate::storage_adapter::{
+            StorageAdapterRead as _, StorageBeginScanOptions, StoragePrefix,
+        };
+
+        for rows in [8, 1024] {
+            let storage = CountingStorage::new();
+            let initialized = Engine::initialize(storage.clone())
+                .await
+                .expect("initialize");
+            let engine = Engine::new(storage.clone()).await.expect("engine");
+            let session = engine
+                .open_session_at(&initialized.main_branch_id)
+                .await
+                .expect("session");
+            let values = (0..rows)
+                .map(|i| format!("('row-{i}', 'value-{i}')"))
+                .collect::<Vec<_>>()
+                .join(",");
+            session
+                .execute(
+                    &format!("INSERT INTO lix_key_value (key, value) VALUES {values}"),
+                    &[],
+                )
+                .await
+                .expect("seed");
+            session
+                .execute("SELECT commit_id FROM lix_create_checkpoint()", &[])
+                .await
+                .expect("checkpoint");
+            let branch = session
+                .create_branch(CreateBranchOptions {
+                    id: None,
+                    name: "shared-root".to_owned(),
+                    from_commit_id: None,
+                })
+                .await
+                .expect("create");
+            let read = engine
+                .storage()
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read");
+            let control = BranchHeadControlContext::new()
+                .reader(&read)
+                .load(&branch.id)
+                .await
+                .expect("control")
+                .expect("branch");
+            let range = StoragePrefix {
+                bytes: hot_generation_scope_prefix(&branch.id, control.tracked_generation).into(),
+            }
+            .to_range()
+            .expect("scope");
+            let roots = read
+                .begin_scan(
+                    ROOT_CURRENT_BASE_SPACE,
+                    range.clone(),
+                    StorageBeginScanOptions::default(),
+                )
+                .await
+                .expect("root scan")
+                .collect_all()
+                .await
+                .expect("roots");
+            assert_eq!(
+                roots.len(),
+                1,
+                "new branch must share its immutable root ({rows} rows)"
+            );
+            let hot = read
+                .begin_scan(ROW_SPACE, range, StorageBeginScanOptions::default())
+                .await
+                .expect("hot scan")
+                .collect_all()
+                .await
+                .expect("hot rows");
+            assert!(
+                hot.len() < 64,
+                "only the serving catalog may be copied, not {rows} owned rows: {}",
+                hot.len()
+            );
+            drop(read);
+            session
+                .switch_branch(SwitchBranchOptions {
+                    branch_id: branch.id.clone(),
+                })
+                .await
+                .expect("stale checkout");
+            let read = engine
+                .storage()
+                .begin_read(StorageReadOptions::default())
+                .await
+                .expect("read");
+            let refreshed = BranchHeadControlContext::new()
+                .reader(&read)
+                .load(&branch.id)
+                .await
+                .expect("control")
+                .expect("branch");
+            assert_ne!(
+                control.head_commit_id, refreshed.head_commit_id,
+                "stale checkout publishes a base refresh"
+            );
+            assert_eq!(
+                control.tracked_generation, refreshed.tracked_generation,
+                "base refresh must retain the local serving generation"
+            );
+            assert_eq!(
+                control.working_diff_checkpoint_commit_id,
+                refreshed.working_diff_checkpoint_commit_id
+            );
+            drop(read);
+            let count = session
+                .execute("SELECT COUNT(*) AS n FROM lix_key_value WHERE key LIKE 'row-%'", &[])
+                .await
+                .expect("shared rows");
+            assert_eq!(count.rows()[0].get::<i64>("n").expect("count"), rows);
+        }
+    }
+
+    #[tokio::test]
     async fn switching_a_stale_branch_publishes_one_bounded_base_refresh() {
         let storage = CountingStorage::new();
         let receipt = Engine::initialize(storage.clone())
@@ -263,9 +389,13 @@ mod tests {
         assert_eq!(switched.branch_id, branch.id);
         assert_eq!(delta.begin_writes, 1, "stale checkout needs one commit");
         assert!(
-            delta.begin_reads <= 4
-                && delta.get_many_calls <= 80
-                && delta.get_many_keys <= 96
+            // In-place publication authenticates catalog/root ownership and
+            // the private epoch. Its catalog revision also warms the new
+            // catalog in one fresh read. These are fixed metadata costs,
+            // independent of the number of branch-owned application rows.
+            delta.begin_reads <= 5
+                && delta.get_many_calls <= 144
+                && delta.get_many_keys <= 160
                 && delta.scan_calls <= 20,
             "metadata-only auto-rebase must remain bounded, saw {delta:?}"
         );

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -3281,6 +3281,69 @@ async fn load_local_overlay_with_inherited_catalog(
     Ok(rows)
 }
 
+/// Only schema definitions are materialized into a local serving generation
+/// from its pinned global base. The rest of that generation is the immutable
+/// local root plus its own HOT mutations, not a copy of the global plane.
+async fn load_lifecycle_catalog(
+    read: &(impl StorageAdapterRead + ?Sized),
+    commit_id: Option<CommitId>,
+    local: bool,
+) -> Result<HotTrackedSnapshot, LixError> {
+    let Some(commit_id) = commit_id else {
+        return Ok(HotTrackedSnapshot::default());
+    };
+    let mut rows = TrackedStateContext::new()
+        .reader(read)
+        .scan_batch_at_commit(
+            &commit_id.to_string(),
+            &TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec!["lix_registered_schema".to_owned()],
+                    include_tombstones: true,
+                    ..TrackedStateFilter::default()
+                },
+                read_columns: TrackedStateReadColumns::default(),
+                limit: None,
+            },
+        )
+        .await?
+        .into_rows();
+    if local {
+        // Only the catalog's own replacement marker is relevant; enumerating
+        // every file/collection marker would turn this into state-sized work.
+        let marker_key = RowPk::single(crate::collection_generation::collection_scope_key(
+            crate::collection_generation::CollectionScopeRef {
+                schema_key: "lix_registered_schema",
+                file_id: None,
+            },
+        ));
+        rows.extend(
+            TrackedStateContext::new()
+                .reader(read)
+                .scan_batch_at_commit(
+                    &commit_id.to_string(),
+                    &TrackedStateScanRequest {
+                        filter: TrackedStateFilter {
+                            schema_keys: vec![
+                                crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY
+                                    .to_owned(),
+                            ],
+                            row_pks: vec![marker_key],
+                            file_ids: vec![NullableKeyFilter::Null],
+                            include_tombstones: true,
+                            ..TrackedStateFilter::default()
+                        },
+                        read_columns: TrackedStateReadColumns::default(),
+                        limit: None,
+                    },
+                )
+                .await?
+                .into_rows(),
+        );
+    }
+    HotTrackedSnapshot::from_materialized_rows(rows)
+}
+
 fn lifecycle_selected_tracked_row(
     change_ref: StagedCommitChangeRef<'_>,
     commit_id: CommitId,
@@ -3687,10 +3750,9 @@ async fn stage_tracked_head(
             .get(&root.commit_id)
             .and_then(|inventory| inventory.columnar_parts.as_ref());
 
-        // A lazy composite-base refresh has no logical row delta, but it must
-        // replace the branch's old complete HOT generation with the durable
-        // local overlay. The mutable global plane then supplies exactly the
-        // newly pinned base without stale inherited rows shadowing it.
+        // A lazy composite-base refresh changes inheritance, not the owned
+        // local rows or their private working interval. Refresh the serving
+        // catalog without rematerializing that unchanged local overlay.
         let parent_base_commit_id = if root.branch_id != crate::GLOBAL_BRANCH_ID
             && state_row_indices.is_empty()
             && staged.selected_change_batches.is_empty()
@@ -3717,105 +3779,77 @@ async fn stage_tracked_head(
                     "base refresh has no previous branch control",
                 )
             })?;
-            let mut local_overlay = match root.state_parent_commit_id {
-                None => BTreeMap::new(),
-                Some(parent_commit_id) => {
-                    load_persisted_lifecycle_tracked_snapshot(
-                        read,
-                        &root.branch_id,
-                        parent_commit_id,
-                    )
-                    .await?
-                }
-            };
-            if let Some(base_commit_id) = staged.record.base_commit_id {
-                let inherited_catalog = load_persisted_lifecycle_tracked_snapshot(
-                    read,
-                    crate::GLOBAL_BRANCH_ID,
-                    base_commit_id,
-                )
-                .await?;
-                for (key, row) in inherited_catalog {
-                    if row.schema_key == "lix_registered_schema" {
-                        local_overlay.entry(key).or_insert(row);
-                    }
-                }
-            }
-            let serving_catalog = local_overlay
-                .iter()
-                .filter(|(_, row)| row.schema_key == "lix_registered_schema")
-                .map(|(key, row)| (key.clone(), row.clone()))
-                .collect::<Vec<_>>();
+            let local_catalog =
+                load_lifecycle_catalog(read, root.state_parent_commit_id, true).await?;
+            let inherited_catalog =
+                load_lifecycle_catalog(read, staged.record.base_commit_id, false).await?;
             let checkpoint_commit_id = parent_control
                 .working_diff_checkpoint_commit_id
                 .unwrap_or(root.parent_commit_id.expect("refresh has a parent"));
-            let checkpoint_node = crate::commit_graph::CommitGraphContext::new()
-                .reader(read)
-                .load_node(&checkpoint_commit_id)
-                .await?
-                .ok_or_else(|| {
-                    LixError::new(
-                        LixError::CODE_COMMIT_NOT_FOUND,
-                        format!("base refresh checkpoint '{checkpoint_commit_id}' is missing"),
-                    )
-                })?;
-            let mut checkpoint_overlay = if checkpoint_node.base_commit_id.is_none() {
-                BTreeMap::new()
-            } else {
-                load_persisted_lifecycle_tracked_snapshot(
+            let generation = if root.state_parent_commit_id.is_some() {
+                // The durable local overlay did not change. Keep its owned
+                // rows, untracked retention and private working-diff epoch in
+                // place; only the inherited serving catalog has a new source.
+                load_working_diff_epoch_for_publication(
                     read,
                     &root.branch_id,
-                    checkpoint_commit_id,
-                )
-                .await?
-            };
-            // Registered-schema rows in a local HOT generation are a serving
-            // cache, not local working changes. Compare both sides against the
-            // newly pinned catalog so a global schema refresh stays clean.
-            for (key, row) in serving_catalog {
-                checkpoint_overlay.insert(key, row);
-            }
-            let generation = lifecycle_generation(
-                &root.branch_id,
-                root.commit_id,
-                root.ref_change_id,
-            );
-            let mut coverage = WorkingDiffIndexCoverage::default();
-            tracked_head
-                .writer(read, writes)
-                .stage_complete_current_state_with_working_diff(
-                    &root.branch_id,
-                    generation,
-                    HotTrackedSnapshot::from_materialized_rows(
-                        local_overlay.into_values().collect(),
-                    )?,
+                    None,
+                    root.parent_commit_id,
+                    Some(parent_control),
                     Some(parent_control.tracked_generation),
-                    &[],
-                    &[],
-                    &BTreeSet::new(),
-                    CompleteWorkingDiffMode::Rebase {
-                        checkpoint_commit_id,
-                        checkpoint: HotTrackedSnapshot::from_materialized_rows(
-                            checkpoint_overlay.into_values().collect(),
-                        )?,
-                    },
-                    &mut coverage,
                 )
                 .await?;
-            stage_tracked_working_diff_epoch(
-                writes,
-                &root.branch_id,
-                TrackedWorkingDiffEpoch {
-                    checkpoint_commit_id,
-                    generation,
-                    coverage,
-                },
-            )?;
+                tracked_head
+                    .writer(read, writes)
+                    .stage_inherited_catalog_refresh(
+                        &root.branch_id,
+                        parent_control.tracked_generation,
+                        local_catalog,
+                        inherited_catalog,
+                    )
+                    .await?;
+                parent_control.tracked_generation
+            } else {
+                // A branch still pointing directly at a global commit has no
+                // local tracked overlay to retain. Begin that local plane,
+                // preserving only its history-free rows and serving catalog.
+                let generation =
+                    lifecycle_generation(&root.branch_id, root.commit_id, root.ref_change_id);
+                let mut coverage = WorkingDiffIndexCoverage::default();
+                tracked_head
+                    .writer(read, writes)
+                    .stage_complete_current_state_with_working_diff(
+                        &root.branch_id,
+                        generation,
+                        inherited_catalog,
+                        Some(parent_control.tracked_generation),
+                        &[],
+                        &[],
+                        &BTreeSet::new(),
+                        CompleteWorkingDiffMode::ResetClean,
+                        &mut coverage,
+                    )
+                    .await?;
+                stage_tracked_working_diff_epoch(
+                    writes,
+                    &root.branch_id,
+                    TrackedWorkingDiffEpoch {
+                        checkpoint_commit_id,
+                        generation,
+                        coverage,
+                    },
+                )?;
+                generation
+            };
             let control = normal_branch_head_control(
                 root,
                 Some(parent_control),
                 generation,
-                Some(checkpoint_commit_id),
+                if root.state_parent_commit_id.is_some() {
+                    parent_control.working_diff_checkpoint_commit_id
+                } else {
+                    Some(checkpoint_commit_id)
+                },
             )?;
             insert_direct_branch_control(&mut controls, &root.branch_id, control)?;
             continue;
@@ -5469,27 +5503,18 @@ async fn stage_root_backed_branch_publication(
                         )
                     })?;
                 if branch_id != crate::GLOBAL_BRANCH_ID && node.base_commit_id.is_some() {
-                    let current = load_local_overlay_with_inherited_catalog(
-                        read,
-                        branch_id,
-                        head_commit_id,
-                    )
-                    .await?;
-                    let mut coverage = WorkingDiffIndexCoverage::default();
-                    tracked_head
-                        .writer(read, writes)
-                        .stage_complete_current_state_with_working_diff(
+                    let local_catalog =
+                        load_lifecycle_catalog(read, Some(head_commit_id), true).await?;
+                    let inherited_catalog =
+                        load_lifecycle_catalog(read, node.base_commit_id, false).await?;
+                    let mut writer = tracked_head.writer(read, writes);
+                    writer.stage_root_current_base(branch_id, generation, head_commit_id);
+                    writer
+                        .stage_inherited_catalog_refresh(
                             branch_id,
                             generation,
-                            HotTrackedSnapshot::from_materialized_rows(
-                                current.into_values().collect(),
-                            )?,
-                            None,
-                            &[],
-                            &[],
-                            &BTreeSet::new(),
-                            CompleteWorkingDiffMode::ResetClean,
-                            &mut coverage,
+                            local_catalog,
+                            inherited_catalog,
                         )
                         .await?;
                 } else {

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -11396,6 +11396,18 @@ fn parse_prepared_timestamp(column: &str, timestamp: &str) -> Result<LixTimestam
 }
 
 fn prepared_writes_change_catalog(prepared_writes: &PreparedWriteSet) -> bool {
+    // An explicitly empty local commit refreshes its pinned global base.
+    // Its inherited serving catalog can change without a schema row in this
+    // transaction. Publish a new revision atomically: transaction opening may
+    // already have cached the old local catalog under the global writer's
+    // revision, and retaining that key would hide newly inherited schemas.
+    if prepared_writes
+        .commit_change_refs_by_branch
+        .iter()
+        .any(|(branch_id, changes)| branch_id != GLOBAL_BRANCH_ID && changes.allow_empty)
+    {
+        return true;
+    }
     prepared_writes.state_rows.iter().any(|row| {
         matches!(
             row.schema_key.as_str(),

--- a/packages/lix/tests/integration/branching.rs
+++ b/packages/lix/tests/integration/branching.rs
@@ -7,6 +7,423 @@ use lix::{
 };
 use serde_json::Value as JsonValue;
 
+simulation_test!(
+    shared_branch_refresh_preserves_dirty_rows_untracked_rows_and_global_visibility,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine.open_session_at(sim.main_branch_id()).await.unwrap(),
+            &engine,
+        );
+        let global = sim.wrap_session(
+            engine.open_session_at(lix::GLOBAL_BRANCH_ID).await.unwrap(),
+            &engine,
+        );
+        main.execute("INSERT INTO lix_key_value (key, value) VALUES ('owned', 'before'), ('deleted', 'before')", &[]).await.unwrap();
+        main.create_checkpoint().await.unwrap();
+        global.execute("INSERT INTO lix_key_value (key, value, lixcol_global) VALUES ('g-update', 'old', true), ('g-delete', 'old', true), ('g-shadow', 'old', true), ('g-tombstone', 'old', true)", &[]).await.unwrap();
+        let draft = create_draft(&engine, &main).await;
+        let draft_id = draft.active_branch_id().await.unwrap();
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'after' WHERE key = 'owned'",
+                &[],
+            )
+            .await
+            .unwrap();
+        draft
+            .execute("DELETE FROM lix_key_value WHERE key = 'deleted'", &[])
+            .await
+            .unwrap();
+        draft.execute("INSERT INTO lix_key_value (key, value) VALUES ('g-shadow', 'local'), ('g-tombstone', 'local') ON CONFLICT(key) DO UPDATE SET value = excluded.value", &[]).await.unwrap();
+        draft
+            .execute("DELETE FROM lix_key_value WHERE key = 'g-tombstone'", &[])
+            .await
+            .unwrap();
+        draft.execute("INSERT INTO lix_key_value (key, value, lixcol_untracked) VALUES ('private', 'untracked', true)", &[]).await.unwrap();
+        let diff_sql = format!(
+            "SELECT key, diff_type, from_value FROM {} WHERE key IN ('owned', 'deleted') ORDER BY key",
+            key_value_diff_relation(&draft).await
+        );
+        let before_diff = draft.execute(&diff_sql, &[]).await.unwrap();
+        assert_eq!(before_diff.len(), 2);
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: sim.main_branch_id().to_owned(),
+            })
+            .await
+            .unwrap();
+        global.execute("UPDATE lix_key_value SET value = 'new' WHERE key IN ('g-update', 'g-shadow', 'g-tombstone')", &[]).await.unwrap();
+        global
+            .execute("DELETE FROM lix_key_value WHERE key = 'g-delete'", &[])
+            .await
+            .unwrap();
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: draft_id.clone(),
+            })
+            .await
+            .unwrap();
+        assert_key_value(&draft, "owned", Some("\"after\"")).await;
+        assert_key_value(&draft, "deleted", None).await;
+        assert_key_value(&draft, "g-update", Some("\"new\"")).await;
+        assert_key_value(&draft, "g-delete", None).await;
+        assert_key_value(&draft, "g-shadow", Some("\"local\"")).await;
+        assert_key_value(&draft, "g-tombstone", None).await;
+        assert_key_value(&draft, "private", Some("\"untracked\"")).await;
+        let after_diff = draft.execute(&format!(
+            "SELECT key, diff_type, from_value FROM {} WHERE key IN ('owned', 'deleted') ORDER BY key",
+            key_value_diff_relation(&draft).await
+        ), &[]).await.unwrap();
+        assert_eq!(
+            before_diff, after_diff,
+            "base refresh must preserve private before images"
+        );
+        assert_key_value(&main, "owned", Some("\"before\"")).await;
+        assert_key_value(&main, "deleted", Some("\"before\"")).await;
+        assert_key_value(&main, "private", None).await;
+        assert_key_value(&global, "g-tombstone", Some("\"new\"")).await;
+        draft.execute("SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('lix_key_value', 'owned')])", &[]).await.unwrap();
+        let remaining_sql = "SELECT key, diff_type, from_value FROM lix_diff('lix_key_value') WHERE key = 'deleted'";
+        let remaining = draft.execute(remaining_sql, &[]).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: sim.main_branch_id().to_owned(),
+            })
+            .await
+            .unwrap();
+        global
+            .execute(
+                "UPDATE lix_key_value SET value = 'newer' WHERE key = 'g-update'",
+                &[],
+            )
+            .await
+            .unwrap();
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: draft_id,
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            draft.execute(remaining_sql, &[]).await.unwrap(),
+            remaining,
+            "refresh after partial checkpoint must retain unselected before images"
+        );
+        draft.execute("INSERT INTO lix_revert (row_ref) SELECT row_ref FROM lix_diff('lix_key_value') WHERE key = 'deleted'", &[]).await.unwrap();
+        assert_key_value(&draft, "deleted", Some("\"before\"")).await;
+        assert_key_value(&draft, "owned", Some("\"after\"")).await;
+        draft.create_checkpoint().await.unwrap();
+        let clean = draft
+            .execute(
+                &format!(
+                    "SELECT key FROM {} WHERE key IN ('owned', 'deleted')",
+                    key_value_diff_relation(&draft).await
+                ),
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            clean.len(),
+            0,
+            "checkpoint must close the retained working interval"
+        );
+        assert_key_value(&draft, "owned", Some("\"after\"")).await;
+    }
+);
+
+simulation_test!(
+    shared_branch_refresh_updates_inherited_catalog_and_preserves_local_override,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine.open_session_at(sim.main_branch_id()).await.unwrap(),
+            &engine,
+        );
+        let global = sim.wrap_session(
+            engine.open_session_at(lix::GLOBAL_BRANCH_ID).await.unwrap(),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('local-root', 'present')",
+            &[],
+        )
+        .await
+        .unwrap();
+        let schema = |key: &str, extra: bool| {
+            let mut columns =
+                vec![serde_json::json!({"name":"id", "type":"text", "nullable":false})];
+            if extra {
+                columns.push(serde_json::json!({"name":"extra", "type":"text", "nullable":true}));
+            }
+            Value::Jsonb(serde_json::json!({"$schema":"https://lix.dev/schema-v1.json", "key":key, "columns":columns, "primary_key":["id"]}).into())
+        };
+        for key in ["shared_catalog", "overridden_catalog"] {
+            global
+                .execute(
+                    "INSERT INTO lix_registered_schema (value, lixcol_global) VALUES ($1, true)",
+                    &[schema(key, false)],
+                )
+                .await
+                .unwrap();
+        }
+        let draft = create_draft(&engine, &main).await;
+        let draft_id = draft.active_branch_id().await.unwrap();
+        assert_eq!(draft.execute("SELECT schema_key FROM lix_registered_schema WHERE schema_key IN ('shared_catalog', 'overridden_catalog')", &[]).await.unwrap().len(), 2);
+        for key in ["overridden_catalog"] {
+            draft.execute(
+                "INSERT INTO lix_registered_schema (value) VALUES ($1) ON CONFLICT(schema_key) DO UPDATE SET value = excluded.value",
+                &[schema(key, true)],
+            ).await.unwrap();
+        }
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: sim.main_branch_id().to_owned(),
+            })
+            .await
+            .unwrap();
+        global
+            .execute(
+                "UPDATE lix_registered_schema SET value = $1 WHERE schema_key = 'shared_catalog'",
+                &[schema("shared_catalog", true)],
+            )
+            .await
+            .unwrap();
+        for key in ["overridden_catalog"] {
+            global
+                .execute(
+                    "UPDATE lix_registered_schema SET value = $1 WHERE schema_key = $2",
+                    &[schema(key, false), Value::Text(key.to_owned())],
+                )
+                .await
+                .unwrap();
+        }
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: draft_id,
+            })
+            .await
+            .unwrap();
+        assert_eq!(draft.execute("SELECT schema_key FROM lix_registered_schema WHERE schema_key = 'shared_catalog'", &[]).await.unwrap().len(), 1, "refreshed schema must be visible before any local write");
+        draft.execute("INSERT INTO shared_catalog (id, extra) VALUES ('probe', 'before-local-write')", &[]).await.expect("refreshed inherited schema validates before another local write");
+        draft
+            .execute(
+                "INSERT INTO overridden_catalog (id, extra) VALUES ('local', 'local-column')",
+                &[],
+            )
+            .await
+            .expect("local schema override must retain its extra column");
+        draft
+            .execute(
+                "INSERT INTO shared_catalog (id, extra) VALUES ('row', 'new-column')",
+                &[],
+            )
+            .await
+            .expect("new inherited schema must validate local writes");
+        assert_eq!(
+            draft
+                .execute("SELECT extra FROM shared_catalog WHERE id = 'row'", &[])
+                .await
+                .unwrap()
+                .rows()[0]
+                .values(),
+            &[Value::Text("new-column".to_owned())]
+        );
+        assert_eq!(
+            main.execute("SELECT id FROM shared_catalog", &[])
+                .await
+                .unwrap()
+                .len(),
+            0,
+            "shared roots do not share local mutations"
+        );
+    }
+);
+
+simulation_test!(
+    shared_branch_refresh_from_global_root_preserves_private_untracked,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let global = sim.wrap_session(
+            engine.open_session_at(lix::GLOBAL_BRANCH_ID).await.unwrap(),
+            &engine,
+        );
+        global.execute("INSERT INTO lix_key_value (key, value, lixcol_global) VALUES ('inherited', 'v0', true)", &[]).await.unwrap();
+        let draft = create_draft(&engine, &global).await;
+        let draft_id = draft.active_branch_id().await.unwrap();
+        draft.execute("INSERT INTO lix_key_value (key, value, lixcol_untracked) VALUES ('private', 'retained', true)", &[]).await.unwrap();
+        for version in ["v1", "v2", "v3"] {
+            draft
+                .switch_branch(SwitchBranchOptions {
+                    branch_id: sim.main_branch_id().to_owned(),
+                })
+                .await
+                .unwrap();
+            global
+                .execute(
+                    "UPDATE lix_key_value SET value = $1 WHERE key = 'inherited'",
+                    &[Value::Text(version.to_owned())],
+                )
+                .await
+                .unwrap();
+            draft
+                .switch_branch(SwitchBranchOptions {
+                    branch_id: draft_id.clone(),
+                })
+                .await
+                .unwrap();
+            assert_key_value(&draft, "inherited", Some(&format!("\"{version}\""))).await;
+            assert_key_value(&draft, "private", Some("\"retained\"")).await;
+            if version == "v1" {
+                draft
+                    .execute(
+                        "INSERT INTO lix_key_value (key, value) VALUES ('owned', 'local')",
+                        &[],
+                    )
+                    .await
+                    .unwrap();
+            } else {
+                assert_key_value(&draft, "owned", Some("\"local\"")).await;
+            }
+            if version == "v2" {
+                draft.create_checkpoint().await.unwrap();
+            }
+        }
+        let reopened = sim.wrap_session(engine.open_session_at(&draft_id).await.unwrap(), &engine);
+        assert_key_value(&reopened, "inherited", Some("\"v3\"")).await;
+        assert_key_value(&reopened, "owned", Some("\"local\"")).await;
+        assert_key_value(&reopened, "private", Some("\"retained\"")).await;
+        assert_key_value(&global, "private", None).await;
+        assert_key_value(&global, "owned", None).await;
+    }
+);
+
+simulation_test!(
+    shared_branch_refresh_rejects_inherited_catalog_untracked_collision_atomically,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine.open_session_at(sim.main_branch_id()).await.unwrap(),
+            &engine,
+        );
+        let global = sim.wrap_session(
+            engine.open_session_at(lix::GLOBAL_BRANCH_ID).await.unwrap(),
+            &engine,
+        );
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('local-root', 'present')",
+            &[],
+        )
+        .await
+        .unwrap();
+        let draft = create_draft(&engine, &main).await;
+        let draft_id = draft.active_branch_id().await.unwrap();
+        let schema = Value::Jsonb(serde_json::json!({"$schema":"https://lix.dev/schema-v1.json", "key":"private_catalog", "columns":[{"name":"id", "type":"text", "nullable":false}], "primary_key":["id"]}).into());
+        draft
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_untracked) VALUES ($1, true)",
+                &[schema.clone()],
+            )
+            .await
+            .unwrap();
+        draft
+            .execute(
+                "INSERT INTO private_catalog (id, lixcol_untracked) VALUES ('private', true)",
+                &[],
+            )
+            .await
+            .unwrap();
+        let head = engine.load_branch_head_commit_id(&draft_id).await.unwrap();
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: sim.main_branch_id().to_owned(),
+            })
+            .await
+            .unwrap();
+        global
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global) VALUES ($1, true)",
+                &[schema],
+            )
+            .await
+            .unwrap();
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: draft_id.clone(),
+            })
+            .await
+            .expect_err("inherited tracked catalog must not overwrite a private history-free row");
+        assert_eq!(
+            draft.active_branch_id().await.unwrap(),
+            sim.main_branch_id()
+        );
+        assert_eq!(
+            engine.load_branch_head_commit_id(&draft_id).await.unwrap(),
+            head,
+            "failed publication must preserve the target head"
+        );
+    }
+);
+
+simulation_test!(
+    shared_branch_refresh_preserves_collection_replacement_fence,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let main = sim.wrap_session(
+            engine.open_session_at(sim.main_branch_id()).await.unwrap(),
+            &engine,
+        );
+        let global = sim.wrap_session(
+            engine.open_session_at(lix::GLOBAL_BRANCH_ID).await.unwrap(),
+            &engine,
+        );
+        global.execute("INSERT INTO lix_key_value (key, value, lixcol_global) VALUES ('retired', 'v1', true)", &[]).await.unwrap();
+        main.execute("DELETE FROM lix_key_value", &[])
+            .await
+            .unwrap();
+        main.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('survivor', 'local')",
+            &[],
+        )
+        .await
+        .unwrap();
+        main.create_checkpoint().await.unwrap();
+        let draft = create_draft(&engine, &main).await;
+        let draft_id = draft.active_branch_id().await.unwrap();
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: sim.main_branch_id().to_owned(),
+            })
+            .await
+            .unwrap();
+        global
+            .execute(
+                "UPDATE lix_key_value SET value = 'v2' WHERE key = 'retired'",
+                &[],
+            )
+            .await
+            .unwrap();
+        draft
+            .switch_branch(SwitchBranchOptions {
+                branch_id: draft_id,
+            })
+            .await
+            .unwrap();
+        assert_key_value(&draft, "retired", None).await;
+        assert_key_value(&draft, "survivor", Some("\"local\"")).await;
+        draft
+            .execute(
+                "UPDATE lix_key_value SET value = 'draft' WHERE key = 'survivor'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_key_value(&main, "survivor", Some("\"local\"")).await;
+    }
+);
+
 simulation_test!(create_branch_from_main, |sim| async move {
     let (engine, main, draft) = create_draft_from_main(&sim).await;
 

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -730,8 +730,8 @@ async fn existing_session_ignores_later_default_branch_corruption() {
 
     let delta = storage.stats().delta_since(&before);
     assert_eq!(
-        delta.read_opened, 4,
-        "an externally invalidated session preflights its pinned branch/global base before SQL"
+        delta.read_opened, 5,
+        "an externally invalidated session preflights its pinned branch/global base and warms the atomically revised catalog before SQL"
     );
     assert_eq!(
         delta.write_opened, 1,


### PR DESCRIPTION
## Summary

- Create branches by sharing their immutable local root instead of copying every row into a new serving generation.
- Refresh only the inherited schema catalog when the global base changes, retaining unchanged local rows, private working-diff epochs, and untracked state. Keep the global-only to local-plane transition explicit.
- Publish an atomic catalog revision for empty local lifecycle commits so newly inherited schemas are usable by domain validation.
- Add branch-sharing, stale-global visibility, catalog override/collision, partial-checkpoint/revert, collection-fence, and rebuild regressions, plus a changenote.

## Measured source attribution

The recovered repository harness uses the original `/tmp/vscode-docs` fixture: 1,000 files, 4,071,401 bytes, SHA256 `93b3608457d12b8cba95f0f88d00b5eaf74ce05a0255eda5b220a8bfaa0bede3`. Baseline engine source was `192d04dc5`. Fixture seeding/checkpointing and byte validation are outside the measured phases.

Uninstrumented baseline medians over 20 samples: create **17.552 ms**, switch out **25.874 ms**, switch back **0.046 ms**. These are independent component timers, not one contiguous combined timing.

Separate acknowledged-FIFO-gated frame-pointer CPU profiles attribute **84.04% inclusive** of create to `stage_root_backed_branch_publication` (591 samples) and **84.27% inclusive** of switch-out to `stage_tracked_head` (827 samples). Separate tracing attributes 63.852/66.869 ms of switch-out materialization to tracked-head publication over three repetitions. Inclusive percentages overlap and are not additive. Source inspection identifies whole-overlay loading and complete generation publication in those callers; this patch removes that state-sized lifecycle work, not its correctness checks.

Raw harness/results remain outside the committed patch. CPU profiling used release debug=1 and frame pointers while preserving the repository's mold/SSE4.2/PCLMUL flags. The candidate default-release build uses debug=0 and the original config, without frame-pointer overrides.

## Validation and review

- Independent reviewer Lorentz approved source-diff SHA256 `92f708b7e745d50795b933113c69e51b9bb899b4e99c723f94a1b61dcafee44b`.
- Before rebase, exclusive worktree-target runs passed: targeted **15/15**, all simulations **3450 passed / 76 configured skips** (8 test workers), doc tests **10/10**; `git diff --check` and changenote validation passed.
- Shared-target runs are invalid and are not used as certification. An earlier isolated full run had a GC engagement timeout under concurrent load; it passed unchanged isolated reruns and the final full suite. No GC assertion or timeout was relaxed.
- Rebased without conflicts onto `9539a3fe5` (main advanced beyond the expected server-only commit). `git range-diff` confirms the reviewed commit's patch is unchanged. Post-rebase commit `8c2cdb9c7bc8293aa2c2d2dc6f47097fb3f9f57c` passed **3452 all-simulation tests / 76 configured skips** (8 workers, 68.843 seconds test runtime) and **10/10 doc tests**, using the exclusive worktree target.

## Merge gates — performance measurements pending

**Do not merge yet.** Candidate same-configuration A/B timings and gated profiles have not been captured. The original-baseline measurements above are attribution evidence, not a measured speedup claim. Require green CI and coordinated candidate measurements before merge. Parent owns final integration and merge.
