### PR TITLE
test(sdk): await native telemetry phase callbacks

### DIFF
--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -518,16 +518,30 @@ test("observe.next samples its own telemetry parent", async () => {
 
 test("openLix forwards production commit phases through onSpan", async () => {
 	const names = new Set<string>();
+	const pendingNames = new Set([
+		"lix.sql.query",
+		"lix.transaction.materialize",
+		"lix.transaction.storage",
+		"lix.transaction.notify",
+	]);
+	let resolveSpans!: () => void;
+	const received = new Promise<void>((resolve) => {
+		resolveSpans = resolve;
+	});
 	const lix = await openLix({
 		telemetry: {
 			onSpan(span) {
 				names.add(span.name);
+				pendingNames.delete(span.name);
+				if (pendingNames.size === 0) resolveSpans();
 			},
 		},
 	});
 	await lix.execute(
 		"INSERT INTO lix_key_value (key, value) VALUES ('telemetry-cut', '1')",
 	);
+	// Native telemetry callbacks are queued independently of execute's promise.
+	await received;
 	expect(names.has("lix.sql.query")).toBe(true);
 	expect(names.has("lix.transaction.materialize")).toBe(true);
 	expect(names.has("lix.transaction.storage")).toBe(true);


### PR DESCRIPTION
## Diagnosis

The native SDK telemetry sink dispatches completed spans with `ThreadsafeFunctionCallMode::NonBlocking` (`packages/js-sdk/native/napi.rs:1650`). The execute command settles its deferred result independently (`napi.rs:963-971`), so awaiting `lix.execute()` does not fence JavaScript telemetry callback delivery. The test's immediate assertions therefore assume ordering that the native binding does not guarantee; there is no evidence here of a missing production phase.

Observed regression: #1684, [JS SDK Native Test job 101609036067](https://github.com/opral/lix/actions/runs/34078453627/job/101609036067), head `87068ce195cb12bd0444f835639eed1101c313d8`, failed at `src/open-lix.test.ts:531` because `names.has("lix.sql.query")` was still false immediately after execute. That job reported 201 passed / 1 failed tests.

## Change

- Add a callback-resolved promise that waits until all four required names have been received: query, materialize, storage, and notify.
- Retain all four positive assertions and all three negative assertions. Any missing required phase leaves the promise pending and fails via the test runner's timeout.
- No fixed sleep, polling, fallback, production code, public API, or changenote changes. One test file, 14 added lines; matches the callback-await pattern used by neighboring telemetry tests.

## Provenance and validation

- Isolated branch/worktree from fetched `origin/main` at `9539a3fe5c84260363e2208c93c7538b1ad7a780` (#1683), which was newer than the initially supplied `eb362543c`.
- Parent independently reviewed and statically approved this exact 14-line diff.
- `git diff --check` passes.
- Before the parent's reserved performance timing slot, five lightweight smoke iterations using the existing matching SDK JS dist and original native addon from the `192d04dc5` worktree received all four phases. They did **not** reproduce the scheduling race. This was a compatibility smoke only, not a patched-test run or certification of the latest engine. Original artifacts were preserved.
- **Local patched test is pending.** No local builds/tests/profiles are being run during the parent's active timing slot; targeted compatibility smoke will follow slot release.
- CI is requested to build/test this PR's matching engine and SDK sources. Full green CI is required before the parent merges; this PR is not being auto-merged.
