### PR TITLE
perf(lix): bound packed state primary-key reads

### DIFF
--- a/.changenotes/bounded-packed-primary-key-reads.md
+++ b/.changenotes/bounded-packed-primary-key-reads.md
@@ -1,0 +1,4 @@
+---
+type: patch
+---
+Use immutable scope certificates and row-primary-key catalogs for bounded packed-state point reads instead of decoding unrelated rows. Preserve file scopes, selected-source identities, and native columnar lookup behavior.

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -2878,34 +2878,105 @@ async fn scan_packed_current_base_rows(
                 continue;
             }
         }
-        let compact = crate::tracked_state::scan_commit_delta_values(
-            store,
-            base_ref.commit_id,
-            &request.filter.schema_keys,
-        )
-        .await?;
-        let mut keys = Vec::new();
-        for row in compact.iter() {
-            let key = row.key_ref();
-            if row.value().deleted
-                || !packed_identity_matches_filter(
-                    key.schema_key,
-                    key.row_pk,
-                    key.file_id,
-                    &request.filter,
-                )
-            {
-                continue;
+        let catalog_lookup =
+            !request.filter.schema_keys.is_empty() && !request.filter.row_pks.is_empty();
+        let keys = if catalog_lookup {
+            // A logical PK does not identify its file scope. A certified
+            // single-partition inventory supplies that scope directly,
+            // including native columnar generations that do not duplicate
+            // their identities in the ordinary row-PK tree. Otherwise use
+            // the immutable catalog. Both routes produce candidates; exact
+            // delta reads below establish actual membership in this commit.
+            let mut keys = BTreeSet::new();
+            let mut next_owner = Some(base_ref.commit_id);
+            let mut visited = BTreeSet::new();
+            while let Some(owner) = next_owner {
+                if !visited.insert(owner) {
+                    return Err(head_value_error(
+                        "packed current-base selected-source cycle",
+                    ));
+                }
+                let manifest = crate::tracked_state::load_commit_state_manifest(store, owner)
+                    .await?
+                    .ok_or_else(|| {
+                        head_value_error("packed current-base has no commit-state manifest")
+                    })?;
+                if let Some(scope) = manifest.mutations.single_partition.as_ref() {
+                    for row_pk in &request.filter.row_pks {
+                        let key = TrackedStateKey {
+                            schema_key: scope.schema_key.clone(),
+                            file_id: scope.file_id.clone(),
+                            row_pk: row_pk.clone(),
+                        };
+                        if packed_identity_matches_filter(
+                            &key.schema_key,
+                            &key.row_pk,
+                            key.file_id.as_deref(),
+                            &request.filter,
+                        ) {
+                            keys.insert(key);
+                        }
+                    }
+                } else {
+                    let mut reader = crate::tracked_state::TrackedStateContext::new().reader(store);
+                    for schema_key in &request.filter.schema_keys {
+                        for key in reader
+                            .enumerate_schema_row_pk_keys_at_commit(
+                                owner,
+                                schema_key,
+                                &request.filter.row_pks,
+                            )
+                            .await?
+                        {
+                            if packed_identity_matches_filter(
+                                &key.schema_key,
+                                &key.row_pk,
+                                key.file_id.as_deref(),
+                                &request.filter,
+                            ) {
+                                keys.insert(key);
+                            }
+                        }
+                    }
+                }
+                // A whole-source alias can supply additional scopes, including
+                // columnar identities absent from the ordinary catalog. Union
+                // its candidate identities, then resolve through the original
+                // owner below so local overrides retain precedence.
+                next_owner = manifest.mutations.selected_source_commit_id();
             }
-            keys.push(TrackedStateKey {
-                schema_key: key.schema_key.to_owned(),
-                row_pk: key.row_pk.clone(),
-                file_id: key.file_id.map(str::to_owned),
-            });
-            if single_base && limit.is_some_and(|limit| keys.len() >= limit) {
-                break;
+            keys.into_iter().collect::<Vec<_>>()
+        } else {
+            let compact = crate::tracked_state::scan_commit_delta_values(
+                store,
+                base_ref.commit_id,
+                &request.filter.schema_keys,
+            )
+            .await?;
+            let mut keys = Vec::new();
+            for row in compact.iter() {
+                let key = row.key_ref();
+                if row.value().deleted
+                    || !packed_identity_matches_filter(
+                        key.schema_key,
+                        key.row_pk,
+                        key.file_id,
+                        &request.filter,
+                    )
+                {
+                    continue;
+                }
+                keys.push(TrackedStateKey {
+                    schema_key: key.schema_key.to_owned(),
+                    row_pk: key.row_pk.clone(),
+                    file_id: key.file_id.map(str::to_owned),
+                });
+                if single_base && limit.is_some_and(|limit| keys.len() >= limit) {
+                    break;
+                }
             }
-        }
+            keys
+        };
         let requests = keys
             .iter()
             .cloned()
@@ -2915,10 +2986,18 @@ async fn scan_packed_current_base_rows(
             crate::tracked_state::load_owned_commit_delta_entries(store, &requests).await?;
         for (key, loaded_entry) in keys.into_iter().zip(loaded) {
             let Some(loaded_entry) = loaded_entry else {
+                if catalog_lookup {
+                    // An inherited identity need not occur in this packed
+                    // commit. It is not a missing certified delta member.
+                    continue;
+                }
                 return Err(head_value_error(
                     "packed current-base manifest lost an indexed commit member",
                 ));
             };
+            if loaded_entry.value.deleted {
+                continue;
+            }
             let identity = (
                 key.schema_key.clone(),
                 key.row_pk.clone(),
@@ -13061,6 +13140,346 @@ mod tests {
     struct JsonCountingRead<R> {
         inner: R,
         json_get_many_calls: Arc<AtomicUsize>,
+    }
+
+    struct PackedSegmentCountingRead<R> {
+        inner: R,
+        segments: Arc<AtomicUsize>,
+    }
+
+    impl<R: StorageAdapterRead> StorageAdapterRead for PackedSegmentCountingRead<R> {
+        async fn get_many(
+            &self,
+            requests: &[StorageGetManyRequest<'_>],
+        ) -> Result<StorageGetManyResult, crate::storage_adapter::StorageError> {
+            for request in requests {
+                if request.space == crate::tracked_state::TRACKED_STATE_COMMIT_DELTA_SEGMENT_SPACE {
+                    self.segments
+                        .fetch_add(request.keys.len(), Ordering::Relaxed);
+                }
+            }
+            self.inner.get_many(requests).await
+        }
+
+        async fn begin_scan(
+            &self,
+            space: StorageSpace,
+            range: StorageKeyRange,
+            opts: StorageBeginScanOptions,
+        ) -> Result<StorageScanCursor<'_>, crate::storage_adapter::StorageError> {
+            self.inner.begin_scan(space, range, opts).await
+        }
+    }
+
+    #[tokio::test]
+    async fn packed_logical_pk_lookup_is_bounded_and_keeps_file_scopes() {
+        const BRANCH: &str = "01991b1d-6d8b-7000-8000-000000000071";
+        const FILE_A: &str = "01991b1d-6d8b-7000-8000-000000000072";
+        const FILE_B: &str = "01991b1d-6d8b-7000-8000-000000000073";
+        const FILE_C: &str = "01991b1d-6d8b-7000-8000-000000000074";
+        for row_count in [512, 5_000] {
+            let storage = StorageAdapter::new(Memory::new());
+            let label = format!("packed-pk-catalog-{row_count}");
+            let generation = CommitId::for_test_label(&label);
+            let selected = format!("row-{:05}", row_count / 2);
+            let make_row =
+                |key: String, file_id: Option<&str>, deleted: bool| MaterializedTrackedStateRow {
+                    row_pk: RowPk::single(key.clone()),
+                    schema_key: "lix_key_value".to_owned(),
+                    file_id: file_id.map(str::to_owned),
+                    snapshot_content: (!deleted).then(|| {
+                        serde_json::json!({"key": key, "value": "payload"})
+                            .to_string()
+                            .into()
+                    }),
+                    decoded_snapshot: None,
+                    metadata: None,
+                    deleted,
+                    created_at: timestamp().to_string(),
+                    updated_at: timestamp().to_string(),
+                    change_id: ChangeId::for_test_label(&format!("{label}-{key}-{file_id:?}")),
+                    commit_id: generation,
+                };
+            let mut rows = (0..row_count)
+                .map(|index| make_row(format!("row-{index:05}"), None, false))
+                .collect::<Vec<_>>();
+            rows.push(make_row(selected.clone(), Some(FILE_A), false));
+            rows.push(make_row(selected.clone(), Some(FILE_B), false));
+            rows.push(make_row(selected.clone(), Some(FILE_C), true));
+            rows.push(make_row("aab-deleted".to_owned(), None, true));
+            // An identity inherited from the first commit must not be mistaken
+            // for membership in the second commit's packed delta.
+            let parent_label = format!("{label}-parent");
+            let mut inherited = make_row("aaa-inherited-only".to_owned(), None, false);
+            inherited.commit_id = CommitId::for_test_label(&parent_label);
+            crate::test_support::seed_branch_head_with_rows(
+                storage.clone(),
+                BRANCH,
+                &parent_label,
+                &[inherited],
+            )
+            .await;
+            let mut read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .unwrap();
+            let mut writes = StorageWriteSet::new();
+            crate::test_support::stage_tracked_root_from_materialized(
+                &mut read,
+                &mut writes,
+                &crate::tracked_state::TrackedStateContext::new(),
+                &label,
+                Some(&parent_label),
+                &rows,
+            )
+            .await
+            .unwrap();
+            let mut base_key = hot_scope_prefix(BRANCH, generation);
+            base_key.extend_from_slice(generation.as_uuid().as_bytes());
+            writes.put(
+                PACKED_CURRENT_BASE_CONTROL_SPACE,
+                StorageKey(Bytes::from(hot_scope_prefix(BRANCH, generation))),
+                StorageValue {
+                    bytes: Bytes::from_static(&[1]),
+                },
+            );
+            writes.put(
+                PACKED_CURRENT_BASE_SPACE,
+                StorageKey(Bytes::from(base_key)),
+                StorageValue {
+                    bytes: Bytes::from_static(&[0; 16]),
+                },
+            );
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .unwrap();
+
+            let segments = Arc::new(AtomicUsize::new(0));
+            let counted = PackedSegmentCountingRead {
+                inner: storage
+                    .begin_read(StorageReadOptions::default())
+                    .await
+                    .unwrap(),
+                segments: Arc::clone(&segments),
+            };
+            let request = TrackedStateScanRequest {
+                filter: TrackedStateFilter {
+                    schema_keys: vec!["lix_key_value".to_owned()],
+                    row_pks: vec![
+                        RowPk::single("aaa-inherited-only"),
+                        RowPk::single("aab-deleted"),
+                        RowPk::single(selected.clone()),
+                        RowPk::single("zzz-missing"),
+                    ],
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let found = scan_packed_current_base_rows(&counted, BRANCH, generation, &request, None)
+                .await
+                .unwrap();
+            assert_eq!(found.len(), 3);
+            assert_eq!(
+                found
+                    .iter()
+                    .map(|row| row.file_id().map(str::to_owned))
+                    .collect::<Vec<_>>(),
+                vec![None, Some(FILE_A.to_owned()), Some(FILE_B.to_owned())]
+            );
+            assert!(
+                segments.load(Ordering::Relaxed) <= 8,
+                "finite PK lookup read {} packed segments for {row_count} unrelated rows",
+                segments.load(Ordering::Relaxed)
+            );
+            let mut null_only = request.clone();
+            null_only.filter.file_ids = vec![NullableKeyFilter::Null];
+            assert_eq!(
+                scan_packed_current_base_rows(&counted, BRANCH, generation, &null_only, None)
+                    .await
+                    .unwrap()
+                    .len(),
+                1
+            );
+            let limited =
+                scan_packed_current_base_rows(&counted, BRANCH, generation, &request, Some(1))
+                    .await
+                    .unwrap();
+            assert_eq!(
+                limited.len(),
+                1,
+                "an absent inherited candidate must not consume LIMIT"
+            );
+            assert_eq!(
+                limited.iter().next().unwrap().row_pk(),
+                &RowPk::single(selected)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn packed_logical_pk_lookup_unions_local_and_selected_source_scopes() {
+        const BRANCH: &str = "01991b1d-6d8b-7000-8000-000000000091";
+        const FILE_A: &str = "01991b1d-6d8b-7000-8000-000000000092";
+        const FILE_B: &str = "01991b1d-6d8b-7000-8000-000000000093";
+        const SCHEMA: &str = "packed_alias_scope_probe";
+        let storage = StorageAdapter::new(Memory::new());
+        let source = CommitId::for_test_label("packed-alias-scope-source");
+        let owner = CommitId::for_test_label("packed-alias-scope-owner");
+        let row_pk = RowPk::single("shared");
+        let source_payload =
+            native_snapshot_payload(&row_pk, serde_json::json!({"value": "source"}));
+        let local_payload = native_snapshot_payload(&row_pk, serde_json::json!({"value": "local"}));
+        let source_delta = crate::tracked_state::TrackedStateDeltaRef {
+            schema_key: SCHEMA,
+            file_id: Some(FILE_B),
+            row_pk: &row_pk,
+            change_id: ChangeId::for_test_label("packed-alias-scope-source-row"),
+            commit_id: source,
+            deleted: false,
+            created_at: timestamp(),
+            updated_at: timestamp(),
+        };
+        let local_delta = crate::tracked_state::TrackedStateDeltaRef {
+            file_id: Some(FILE_A),
+            change_id: ChangeId::for_test_label("packed-alias-scope-local-row"),
+            commit_id: owner,
+            ..source_delta
+        };
+        let packed_delta = |delta, snapshot| crate::tracked_state::TrackedStateCommitDeltaRef {
+            delta,
+            metadata: None,
+            snapshot: Some(snapshot),
+            origin_key: None,
+            base_coordinate: None,
+            authored: true,
+        };
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let mut writes = StorageWriteSet::new();
+        let source_stage = crate::tracked_state::stage_addressable_commit_deltas(
+            &mut writes,
+            &[packed_delta(source_delta, source_payload.as_slice())],
+            &[false],
+        )
+        .unwrap();
+        let local_stage =
+            crate::tracked_state::stage_addressable_commit_deltas_with_selected_source(
+                &mut writes,
+                &[packed_delta(local_delta, local_payload.as_slice())],
+                &[false],
+                source,
+            )
+            .unwrap();
+        // Publish complete catalogs and immutable manifests once. The alias's
+        // local single-partition certificate must not hide its source scope.
+        // Native columnar inventories cannot represent file B (only null file).
+        for (commit_id, staged, deltas, file_id) in [
+            (source, source_stage, vec![source_delta], FILE_B),
+            (owner, local_stage, vec![source_delta, local_delta], FILE_A),
+        ] {
+            let mutations = staged.mutation_inventory().clone();
+            let scope = mutations.single_partition.as_ref().unwrap();
+            assert_eq!(scope.schema_key, SCHEMA);
+            assert_eq!(scope.file_id.as_deref(), Some(file_id));
+            let mut overlay = crate::tracked_state::TrackedStateChunkOverlay::new();
+            let catalog = crate::tracked_state::stage_row_pk_index_from_deltas(
+                &read,
+                &mut writes,
+                &mut overlay,
+                deltas,
+                commit_id,
+            )
+            .await
+            .unwrap();
+            crate::tracked_state::stage_commit_state_manifest(
+                &mut writes,
+                &crate::tracked_state::CommitStateManifest {
+                    commit_id,
+                    change_account_id: crate::ANONYMOUS_ACCOUNT_ID.to_owned(),
+                    replay_debt: crate::tracked_state::CommitStateReplayDebt {
+                        depth: 1,
+                        rows: u64::from(mutations.member_count),
+                        bytes: 0,
+                    },
+                    mutations,
+                    touched_scope_filter: Default::default(),
+                    global_scope: false,
+                    current_state_scoped_ranges: None,
+                    row_pk_index_root_id: catalog,
+                    snapshot_root: None,
+                },
+            )
+            .unwrap();
+        }
+        let scope_key = hot_scope_prefix(BRANCH, owner);
+        writes.put(
+            PACKED_CURRENT_BASE_CONTROL_SPACE,
+            StorageKey(Bytes::from(scope_key.clone())),
+            StorageValue {
+                bytes: Bytes::from_static(&[1]),
+            },
+        );
+        let mut base_key = scope_key;
+        base_key.extend_from_slice(owner.as_uuid().as_bytes());
+        writes.put(
+            PACKED_CURRENT_BASE_SPACE,
+            StorageKey(Bytes::from(base_key)),
+            StorageValue {
+                bytes: Bytes::from_static(&[0; 16]),
+            },
+        );
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let request = TrackedStateScanRequest {
+            filter: TrackedStateFilter {
+                schema_keys: vec![SCHEMA.to_owned()],
+                row_pks: vec![row_pk.clone(), RowPk::single("missing")],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let rows = scan_packed_current_base_rows(&read, BRANCH, owner, &request, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            2,
+            "the selected source contributes a second file scope"
+        );
+        let keys = [FILE_A, FILE_B].map(|file_id| TrackedStateKeyRef {
+            schema_key: SCHEMA,
+            file_id: Some(file_id),
+            row_pk: &row_pk,
+        });
+        let refs = packed_current_base_refs(&read, BRANCH, owner)
+            .await
+            .unwrap();
+        let exact = load_packed_current_base_exact_entries_from_refs(&read, &refs, &keys, None)
+            .await
+            .unwrap();
+        for ((row, exact), expected_value) in rows.iter().zip(exact).zip(["local", "source"]) {
+            let (value, change, _, _) = exact.expect("exact identity must exist");
+            assert_eq!(row.file_id(), change.file_id.as_deref());
+            assert_eq!(
+                row.commit_id(),
+                Some(owner),
+                "source values resolve through the alias owner"
+            );
+            assert_eq!(row.change_id(), Some(value.change_id));
+            let snapshot: serde_json::Value =
+                serde_json::from_str(row.snapshot_content().unwrap()).unwrap();
+            assert_eq!(snapshot["value"], expected_value);
+        }
     }
 
     impl<R: StorageAdapterRead> StorageAdapterRead for JsonCountingRead<R> {

--- a/packages/lix/src/test_support.rs
+++ b/packages/lix/src/test_support.rs
@@ -330,7 +330,7 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_certified_replacem
         .stage_commit_root_with_absence_guards(
             &commit_id_text,
             parent_commit_id_text.as_deref(),
-            root_deltas,
+            root_deltas.iter().copied(),
             &BTreeSet::new(),
             certified_replacement_markers,
         )
@@ -343,7 +343,16 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_certified_replacem
     drop(root_writer);
     let mutations = inventories.remove(&commit_id).unwrap_or_default();
     reject_unconsumed_test_inventories(&inventories, commit_id)?;
-    stage_test_commit_state_manifest(writes, &staged, mutations, Some(snapshot_root))?;
+    let catalog =
+        stage_test_identity_catalog(read, writes, parent_commit_id_text.as_deref(), &root_deltas)
+            .await?;
+    stage_test_commit_state_manifest(
+        writes,
+        &staged,
+        mutations,
+        Some(snapshot_root),
+        Some(catalog),
+    )?;
     Ok(())
 }
 
@@ -410,7 +419,14 @@ pub(crate) async fn stage_rootless_tracked_commit_from_materialized(
     let mut inventories = stage_test_commit_deltas_by_owner(writes, &commit_deltas)?;
     let mutations = inventories.remove(&commit_id).unwrap_or_default();
     reject_unconsumed_test_inventories(&inventories, commit_id)?;
-    stage_test_commit_state_manifest(writes, &staged, mutations, None)
+    let catalog = stage_test_identity_catalog(
+        read,
+        writes,
+        parent_id_texts.first().map(String::as_str),
+        &root_deltas,
+    )
+    .await?;
+    stage_test_commit_state_manifest(writes, &staged, mutations, None, Some(catalog))
 }
 
 #[cfg(test)]
@@ -500,7 +516,7 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
         .stage_commit_root(
             &commit_id_text,
             commit_root_parent_commit_id_text.as_deref(),
-            root_deltas,
+            root_deltas.iter().copied(),
         )
         .await?;
     let snapshot_root = root_writer
@@ -509,7 +525,20 @@ pub(crate) async fn stage_tracked_root_from_materialized_with_parents(
         .cloned()
         .ok_or_else(|| crate::LixError::unknown("test rooted commit did not stage a root"))?;
     drop(root_writer);
-    stage_test_commit_state_manifest(writes, &staged, mutations, Some(snapshot_root))?;
+    let catalog = stage_test_identity_catalog(
+        read,
+        writes,
+        commit_root_parent_commit_id_text.as_deref(),
+        &root_deltas,
+    )
+    .await?;
+    stage_test_commit_state_manifest(
+        writes,
+        &staged,
+        mutations,
+        Some(snapshot_root),
+        Some(catalog),
+    )?;
     Ok(())
 }
 
@@ -554,11 +583,115 @@ fn reject_unconsumed_test_inventories(
     )))
 }
 
+/// Publish the identity catalog with test commit authority, just as ordinary
+/// authoring does. Packed logical-PK readers must not need incomplete fixtures
+/// to select a different algorithm from production.
+#[cfg(test)]
+#[tokio::test]
+async fn identity_catalog_fixture_rejects_missing_parent_authority() {
+    use crate::storage_adapter::{Memory, StorageReadOptions, StorageWriteOptions};
+    let storage = StorageAdapter::new(Memory::new());
+    let mut read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .unwrap();
+    let mut writes = StorageWriteSet::new();
+    let error = stage_test_identity_catalog(&read, &mut writes, Some("missing-parent"), &[])
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("parent has no catalog authority")
+    );
+
+    let parent = test_commit_id("parent-without-catalog").to_string();
+    let mut staged = stage_test_changelog_commit(&mut read, &mut writes, &parent, &[], &[], false)
+        .await
+        .unwrap();
+    staged.replay_debt.depth = 1;
+    stage_test_commit_state_manifest(
+        &mut writes,
+        &staged,
+        CommitStateMutationInventory::default(),
+        None,
+        None,
+    )
+    .unwrap();
+    storage
+        .commit_write_set(writes, StorageWriteOptions::default())
+        .await
+        .unwrap();
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .unwrap();
+    let error = stage_test_identity_catalog(&read, &mut StorageWriteSet::new(), Some(&parent), &[])
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("parent has no catalog authority")
+    );
+}
+
+async fn stage_test_identity_catalog(
+    read: &(impl StorageAdapterRead + ?Sized),
+    writes: &mut StorageWriteSet,
+    parent: Option<&str>,
+    deltas: &[TrackedStateDeltaRef<'_>],
+) -> Result<crate::tracked_state::TrackedStateRootId, crate::LixError> {
+    let parent_root = if let Some(parent) = parent {
+        crate::tracked_state::load_commit_state_manifest(read, test_commit_id(parent))
+            .await?
+            .and_then(|manifest| manifest.row_pk_index_root_id)
+            .map(Some)
+            .ok_or_else(|| {
+                crate::LixError::unknown("test identity catalog parent has no catalog authority")
+            })?
+    } else {
+        None
+    };
+    let mut primary =
+        crate::tracked_state::TrackedStateMutationBatchBuilder::with_row_capacity(deltas.len());
+    for delta in deltas {
+        primary.push(
+            crate::tracked_state::TrackedStateKeyRef {
+                schema_key: delta.schema_key,
+                file_id: delta.file_id,
+                row_pk: delta.row_pk,
+            },
+            crate::tracked_state::TrackedStateIndexValueRef {
+                change_id: delta.change_id,
+                commit_id: delta.commit_id,
+                deleted: false,
+                created_at: delta.created_at,
+                updated_at: delta.updated_at,
+            },
+        );
+    }
+    let (_, secondary) = crate::tracked_state::with_row_pk_index_mutations(primary.finish())?;
+    let mut overlay = crate::tracked_state::TrackedStateChunkOverlay::new();
+    Ok(crate::tracked_state::TrackedStateTree::new()
+        .apply_mutations_with_overlay(
+            read,
+            writes,
+            &mut overlay,
+            parent_root.as_ref(),
+            secondary,
+            None,
+        )
+        .await?
+        .root_id)
+}
+
 fn stage_test_commit_state_manifest(
     writes: &mut StorageWriteSet,
     staged: &TestStagedChangelogCommit,
     mutations: CommitStateMutationInventory,
     snapshot_root: Option<TrackedStateCommitRoot>,
+    row_pk_index_root_id: Option<crate::tracked_state::TrackedStateRootId>,
 ) -> Result<(), crate::LixError> {
     let replay_debt = if snapshot_root.is_some() {
         CommitStateReplayDebt::default()
@@ -573,7 +706,7 @@ fn stage_test_commit_state_manifest(
         touched_scope_filter: Default::default(),
         global_scope: false,
         current_state_scoped_ranges: None,
-        row_pk_index_root_id: None,
+        row_pk_index_root_id,
         snapshot_root: snapshot_root.map(Box::new),
     };
     crate::tracked_state::stage_commit_state_manifest(writes, &manifest)
@@ -605,11 +738,14 @@ pub(crate) async fn stage_empty_changelog_commit(
         .cloned()
         .ok_or_else(|| crate::LixError::unknown("empty test commit did not stage a root"))?;
     drop(root_writer);
+    let catalog =
+        stage_test_identity_catalog(read, writes, parent_commit_id_text.as_deref(), &[]).await?;
     stage_test_commit_state_manifest(
         writes,
         &staged,
         CommitStateMutationInventory::default(),
         Some(snapshot_root),
+        Some(catalog),
     )
 }
 
@@ -640,11 +776,13 @@ pub(crate) async fn stage_empty_changelog_commit_with_parents(
         .cloned()
         .ok_or_else(|| crate::LixError::unknown("empty test commit did not stage a root"))?;
     drop(root_writer);
+    let catalog = stage_test_identity_catalog(read, writes, first_parent, &[]).await?;
     stage_test_commit_state_manifest(
         writes,
         &staged,
         CommitStateMutationInventory::default(),
         Some(snapshot_root),
+        Some(catalog),
     )
 }
 

--- a/packages/lix/src/tracked_state/context.rs
+++ b/packages/lix/src/tracked_state/context.rs
@@ -9415,13 +9415,22 @@ mod tests {
             .await
             .expect("genesis root should load")
             .expect("genesis root should exist");
-        drop(read);
         let root_bytes = *root_id.as_bytes();
-        let mut candidates = stored_tree_chunk_hashes_for_test(&storage)
+        // The fixture also stores the secondary identity catalog. Damage
+        // only this primary root's closure: unrelated catalog chunks do not
+        // determine whether primary-state replay can resume from this root.
+        let mut candidates = TrackedStateTree::new()
+            .reachable_chunk_hashes_with_overlay(
+                &read,
+                &storage::TrackedStateChunkOverlay::new(),
+                &root_id,
+            )
             .await
+            .expect("primary root closure should load")
             .into_iter()
             .filter(|chunk| chunk != &root_bytes)
             .collect::<Vec<_>>();
+        drop(read);
         // Sorted so the sweep order, and any failure message, is reproducible.
         candidates.sort_unstable();
         assert!(

--- a/packages/lix/tests/integration/sql/lix_key_value.rs
+++ b/packages/lix/tests/integration/sql/lix_key_value.rs
@@ -2,6 +2,94 @@ use lix::ExecuteResult;
 use lix::LixError;
 use lix::Value;
 
+simulation_test!(
+    packed_pk_reads_match_full_state_across_publications,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+        let first_file = "01991b1d-6d8b-7000-8000-000000000081";
+        let second_file = "01991b1d-6d8b-7000-8000-000000000082";
+        session
+            .execute(
+                "INSERT INTO lix_file (id, path, content) VALUES \
+         ($1, '/packed-first', CAST('a' AS BYTEA)), \
+         ($2, '/packed-second', CAST('b' AS BYTEA))",
+                &[
+                    Value::Text(first_file.into()),
+                    Value::Text(second_file.into()),
+                ],
+            )
+            .await
+            .unwrap();
+        let values = (0..512)
+            .map(|index| format!("('packed-key-{index:04}', 'original')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        session
+            .execute(
+                &format!("INSERT INTO lix_key_value (key, value) VALUES {values}"),
+                &[],
+            )
+            .await
+            .unwrap();
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_file_id) VALUES \
+         ('packed-key-0010', 'first-file', $1), ('packed-key-0010', 'second-file', $2)",
+                &[
+                    Value::Text(first_file.into()),
+                    Value::Text(second_file.into()),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let second_values = (0..512)
+            .map(|index| format!("('packed-later-{index:04}', 'later')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let phases = [
+        ("SELECT 1".to_owned(), 4),
+        ("UPDATE lix_key_value SET value = 'updated' WHERE key = 'packed-key-0010'".to_owned(), 4),
+        ("SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('lix_key_value', 'packed-key-0010')])".to_owned(), 4),
+        ("DELETE FROM lix_key_value WHERE key = 'packed-key-0200'".to_owned(), 3),
+        ("SELECT commit_id FROM lix_create_checkpoint()".to_owned(), 3),
+        (format!("INSERT INTO lix_key_value (key, value) VALUES {second_values}"), 3),
+        ("DELETE FROM lix_key_value".to_owned(), 0),
+        ("INSERT INTO lix_key_value (key, value) VALUES ('packed-key-0010', 'recreated')".to_owned(), 1),
+        ("SELECT commit_id FROM lix_create_checkpoint()".to_owned(), 1),
+    ];
+        for (phase, (statement, expected_count)) in phases.into_iter().enumerate() {
+            session
+                .execute(&statement, &[])
+                .await
+                .unwrap_or_else(|error| panic!("phase {phase}: {error}"));
+            let full = session.execute(
+            "SELECT key, value, lixcol_file_id FROM lix_key_value ORDER BY key, lixcol_file_id",
+            &[],
+        ).await.unwrap();
+            let expected = full.rows().iter().filter(|row| {
+            matches!(&row.values()[0], Value::Text(key) if key == "packed-key-0010" || key == "packed-key-0200")
+        }).map(|row| row.values().to_vec()).collect::<Vec<_>>();
+            assert_eq!(
+                expected.len(),
+                expected_count,
+                "full state at phase {phase}"
+            );
+            let point = session
+                .execute(
+                    "SELECT key, value, lixcol_file_id FROM lix_key_value \
+             WHERE key IN ('packed-key-0010', 'packed-key-0200', 'packed-missing') \
+             ORDER BY key, lixcol_file_id",
+                    &[],
+                )
+                .await
+                .unwrap_or_else(|error| panic!("point read at phase {phase}: {error}"));
+            super::assert_rows_eq(point, expected);
+        }
+    }
+);
+
 simulation_test!(lix_key_value_roundtrips_arbitrary_json, |sim| async move {
     let engine = sim.boot_engine().await;
     let session = sim.wrap_session(


### PR DESCRIPTION
## Summary

Replace broad packed-delta decoding for finite schema/primary-key queries with candidate enumeration from immutable authority followed by exact delta point reads. This is an internal read-plan change, with no public API or storage-format change.

- Certified single-partition inventories directly provide the file scope, including native columnar generations that do not duplicate identities in the ordinary row-PK tree.
- Other inventories enumerate file-scoped identities through the immutable row-PK catalog.
- Whole-source aliases union candidates from their selected source, then resolve through the original owner to preserve local precedence.
- Missing authority and cycles fail explicitly. Inherited catalog identities are a superset, so an exact local-delta miss is intentional absence, not a reason to retry a full scan.
- Apply tombstone filtering and final ordering before LIMIT. Leave unbounded scan plans unchanged.

## Profile evidence

On the actual inlang SDK update workload, gated frame-pointer CPU sampling attributes 31.36% inclusive CPU to `scan_packed_current_base_rows` and 25.28% to broad authenticated delta scanning. Inclusive percentages overlap and are not additive predicted speedups. Initial profile base: `192d04dc59ea5a98fa0dc3cd532c3c3da6ec0012`.

## Correctness and review

- Independent subagent source review approved the final production plan and test fixtures.
- Bounded-work regression at 512 and 5,000 unrelated rows; duplicate logical keys across null/non-null file scopes; inherited absent candidates; tombstones; missing keys; result limits.
- Alias regression with local and selected-source file scopes sharing a logical key, exact-read equivalence, and owner provenance.
- Public SQL lifecycle simulation covers point updates, partial/full checkpoint, packed replacement, deletion and recreation under both base and rebuild modes.
- Existing native-columnar lifecycle and large certified insert tests caught an early draft's missing scope path and now pass; no scan fallback was added.
- Fixture catalogs now reflect production authority. Missing supplied parent authority is rejected. The corruption sweep targets the primary root's actual closure rather than unrelated secondary-index chunks.

Isolated final qualification on the profiled base: `cargo nextest run -p lix --features all-simulations` passed all 3443 tests (76 skipped); `cargo test -p lix --doc` passed all 10. Post-rebase qualification and release A/B results will be recorded before merge. Raw benchmark datasets and profiling artifacts remain on disk and are excluded from this PR.
