### PR TITLE
Avoid catalog invalidation for unchanged checkpoint and merge visibility

### DIFF
--- a/.changenotes/fix-catalog-visibility-invalidation.md
+++ b/.changenotes/fix-catalog-visibility-invalidation.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Avoid invalidating and warming unchanged schema catalogs when publishing checkpoints, three-way merges, or data-only inherited-base refreshes.
+
+Invalidate inherited catalogs when their visible definitions actually change, preserving local overrides, tombstones, and collection-generation fences.

--- a/packages/lix/src/catalog/context.rs
+++ b/packages/lix/src/catalog/context.rs
@@ -40,6 +40,8 @@ pub(crate) struct CatalogContext {
         Mutex<HashMap<TransactionOpeningCatalogKey, Arc<CatalogSnapshot>>>,
     #[cfg(test)]
     sql_read_schema_loads: AtomicUsize,
+    #[cfg(test)]
+    pub(crate) committed_catalog_warms: AtomicUsize,
 }
 
 /// Fingerprint of the raw catalog rows visible to a domain, hashed before any
@@ -63,6 +65,8 @@ impl CatalogContext {
             transaction_opening_catalogs: Mutex::new(HashMap::new()),
             #[cfg(test)]
             sql_read_schema_loads: AtomicUsize::new(0),
+            #[cfg(test)]
+            committed_catalog_warms: AtomicUsize::new(0),
         }
     }
 

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -1584,18 +1584,15 @@ async fn restage_exact_closure_collection_control(
     stage_complete_collection_controls(writes, branch_id, generation, &rows)
 }
 
-fn stage_complete_collection_controls(
-    writes: &mut StorageWriteSet,
-    branch_id: &str,
+fn complete_collection_generation_controls(
     branch_generation: CommitId,
     rows: &HotRowMap,
-) -> Result<(), LixError> {
+) -> Result<BTreeMap<(String, Option<String>), HotCollectionControl>, LixError> {
     use crate::collection_generation::{
-        COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef, collection_scope_from_row_pk,
+        COLLECTION_GENERATION_SCHEMA_KEY, collection_scope_from_row_pk,
     };
 
     let mut controls = BTreeMap::<(String, Option<String>), HotCollectionControl>::new();
-    let mut physical_buckets = BTreeMap::<(String, Option<String>), Vec<&HeadRowIdentity>>::new();
     for (identity, bytes) in rows {
         if identity.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
             let target = collection_scope_from_row_pk(&identity.row_pk)?;
@@ -1631,6 +1628,18 @@ fn stage_complete_collection_controls(
         }
     }
 
+    Ok(controls)
+}
+
+fn stage_complete_collection_controls(
+    writes: &mut StorageWriteSet,
+    branch_id: &str,
+    branch_generation: CommitId,
+    rows: &HotRowMap,
+) -> Result<(), LixError> {
+    use crate::collection_generation::{COLLECTION_GENERATION_SCHEMA_KEY, CollectionScopeRef};
+    let mut controls = complete_collection_generation_controls(branch_generation, rows)?;
+    let mut physical_buckets = BTreeMap::<(String, Option<String>), Vec<&HeadRowIdentity>>::new();
     for (identity, bytes) in rows {
         if identity.schema_key == COLLECTION_GENERATION_SCHEMA_KEY {
             continue;
@@ -1640,33 +1649,18 @@ fn stage_complete_collection_controls(
             continue;
         }
         let schema_scope = (identity.schema_key.clone(), None);
-        let schema_control = controls
-            .get(&schema_scope)
-            .expect("complete row schema control was initialized above");
-        let visible_after_schema_generation = schema_control.active_generation == branch_generation
-            || survives_collection_generation_fence(
-                value.untracked,
-                value.commit_id,
-                schema_control.active_generation,
-                false,
-            );
         let file_scope = identity
             .file_id
             .as_ref()
             .map(|file_id| (identity.schema_key.clone(), Some(file_id.clone())));
-        let visible_after_file_generation = file_scope
-            .as_ref()
-            .and_then(|scope| controls.get(scope))
-            .is_none_or(|control| {
-                control.active_generation == branch_generation
-                    || survives_collection_generation_fence(
-                        value.untracked,
-                        value.commit_id,
-                        control.active_generation,
-                        false,
-                    )
-            });
-        if !visible_after_schema_generation || !visible_after_file_generation {
+        if !row_belongs_to_active_collection_generation(
+            &controls,
+            branch_generation,
+            &identity.schema_key,
+            identity.file_id.as_deref(),
+            value.untracked,
+            value.commit_id,
+        ) {
             continue;
         }
         physical_buckets
@@ -5394,6 +5388,50 @@ enum WorkingDiffBaselineAction {
 }
 
 impl HotTrackedSnapshot {
+    /// Compares the proposed local-plus-inherited catalog with the actual
+    /// serving catalog read under the publication's branch control. Commit
+    /// identities, timestamps and working-diff baselines are not catalog facts.
+    /// Local tombstones mask inheritance just as local live definitions do.
+    pub(crate) fn inherited_catalog_differs_from(
+        &self,
+        previous: &MaterializedHotStateBatch,
+        local: &Self,
+        branch_generation: CommitId,
+    ) -> Result<bool, LixError> {
+        let mut rows = self.rows.clone();
+        rows.extend(local.rows.iter().map(|(key, value)| (key.clone(), value.clone())));
+        // Reuse the publisher's controls and visibility predicate before
+        // dropping commit identities. Equal payloads can cross a replacement
+        // fence, while an unchanged hidden row is not a visible catalog fact.
+        let controls = complete_collection_generation_controls(branch_generation, &rows)?;
+        let next = rows.iter()
+            .filter(|(key, _)| key.schema_key == "lix_registered_schema" && key.file_id.is_none())
+            .filter_map(|(key, bytes)| match decode_head_value(bytes) {
+                Ok(value) if value.deleted => None,
+                Ok(value) if !row_belongs_to_active_collection_generation(
+                    &controls, branch_generation, &key.schema_key, key.file_id.as_deref(),
+                    value.untracked, value.commit_id,
+                ) => None,
+                Ok(value) => Some(
+                    value
+                        .snapshot
+                        .map(|snapshot| (&key.row_pk, snapshot))
+                        .ok_or_else(|| head_value_error("live catalog row has no payload")),
+                ),
+                Err(error) => Some(Err(error)),
+            })
+            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+        let previous = previous
+            .iter()
+            .map(|row| {
+                row.raw_snapshot()
+                    .map(|snapshot| (row.row_pk(), snapshot.as_ref()))
+                    .ok_or_else(|| head_value_error("live serving catalog row has no payload"))
+            })
+            .collect::<Result<BTreeMap<_, _>, LixError>>()?;
+        Ok(next != previous)
+    }
+
     pub(crate) fn from_materialized_rows(
         tracked_rows: Vec<MaterializedTrackedStateRow>,
     ) -> Result<Self, LixError> {
@@ -13628,6 +13666,84 @@ mod tests {
             })
             .expect("closure fixture HOT value should encode"),
         )
+    }
+
+    #[tokio::test]
+    async fn inherited_catalog_visibility_compares_deletions_and_local_tombstones() {
+        let storage = crate::storage_adapter::StorageAdapter::new(crate::storage::Memory::new());
+        let generation = CommitId::for_test_label("catalog-visibility");
+        let identity = |key: &str| HeadRowIdentity {
+            schema_key: "lix_registered_schema".to_owned(),
+            row_pk: RowPk::single(key),
+            file_id: None,
+        };
+        let live = encoded_test_hot_value(generation, false, false);
+        let tombstone = encoded_test_hot_value(generation, false, true);
+        let mut writes = StorageWriteSet::new();
+        stage_complete_hot_rows(&mut writes, "branch", generation, HotRowMap::from([
+            (identity("closure-row"), live.clone()),
+        ]));
+        storage.commit_write_set(writes, StorageWriteOptions::default()).await.unwrap();
+        let read = storage.begin_read(StorageReadOptions::default()).await.unwrap();
+        let previous = TrackedHeadContext::new().reader(&read)
+            .scan_live_batch_for_generation("branch", generation, None, &TrackedStateScanRequest {
+                filter: TrackedStateFilter { schema_keys: vec!["lix_registered_schema".to_owned()], ..TrackedStateFilter::default() },
+                read_columns: TrackedStateReadColumns { columns: vec!["raw_snapshot".to_owned()] },
+                limit: None,
+            }).await.unwrap();
+        assert_eq!(previous.len(), 1);
+        let inherited = HotTrackedSnapshot { rows: HotRowMap::from([(identity("closure-row"), live)]) };
+        let local = HotTrackedSnapshot::default();
+        assert!(!inherited.inherited_catalog_differs_from(&previous, &local, generation).unwrap());
+        assert!(HotTrackedSnapshot::default().inherited_catalog_differs_from(&previous, &local, generation).unwrap(), "removing an inherited definition changes visibility");
+        let local = HotTrackedSnapshot { rows: HotRowMap::from([(identity("closure-row"), tombstone)]) };
+        let absent = MaterializedHotStateBatch::default();
+        assert!(!inherited.inherited_catalog_differs_from(&absent, &local, generation).unwrap(), "a local tombstone masks a new inherited definition");
+        assert!(!HotTrackedSnapshot::default().inherited_catalog_differs_from(&absent, &local, generation).unwrap(), "removing the masked inherited definition also leaves visibility unchanged");
+    }
+
+    #[tokio::test]
+    async fn inherited_catalog_visibility_reuses_publication_generation_fences() {
+        let storage = StorageAdapter::new(Memory::new());
+        let generation = CommitId::for_test_label("catalog-fence-serving");
+        let mut commits = [CommitId::for_test_label("catalog-fence-a"), CommitId::for_test_label("catalog-fence-b"), CommitId::for_test_label("catalog-fence-c")];
+        commits.sort();
+        let [old, fence, new] = commits;
+        assert_ne!(generation, fence);
+        let identity = HeadRowIdentity { schema_key: "lix_registered_schema".to_owned(), row_pk: RowPk::single("closure-row"), file_id: None };
+        let marker = HeadRowIdentity {
+            schema_key: crate::collection_generation::COLLECTION_GENERATION_SCHEMA_KEY.to_owned(),
+            row_pk: RowPk::single(crate::collection_generation::collection_scope_key(crate::collection_generation::CollectionScopeRef { schema_key: "lix_registered_schema", file_id: None })),
+            file_id: None,
+        };
+        let local = HotTrackedSnapshot { rows: HotRowMap::from([(marker, encoded_test_hot_value(fence, false, false))]) };
+        let inherited = |commit| HotTrackedSnapshot { rows: HotRowMap::from([(identity.clone(), encoded_test_hot_value(commit, false, false))]) };
+        let old_catalog = inherited(old);
+        let mut rows = local.rows.clone();
+        rows.extend(old_catalog.rows.clone());
+        let mut writes = StorageWriteSet::new();
+        stage_complete_collection_controls(&mut writes, "branch", generation, &rows).unwrap();
+        stage_complete_hot_rows(&mut writes, "branch", generation, rows);
+        storage.commit_write_set(writes, StorageWriteOptions::default()).await.unwrap();
+        let request = TrackedStateScanRequest {
+            filter: TrackedStateFilter { schema_keys: vec!["lix_registered_schema".to_owned()], ..TrackedStateFilter::default() },
+            read_columns: TrackedStateReadColumns { columns: vec!["raw_snapshot".to_owned()] },
+            limit: None,
+        };
+        let read = storage.begin_read(StorageReadOptions::default()).await.unwrap();
+        let previous = TrackedHeadContext::new().reader(&read).scan_live_batch_for_generation("branch", generation, None, &request).await.unwrap();
+        assert_eq!(previous.len(), 0, "the publisher's fence hides the old schema");
+        assert!(!old_catalog.inherited_catalog_differs_from(&previous, &local, generation).unwrap(), "unchanged hidden schema must not invalidate on a data-only global refresh");
+        assert!(!inherited(fence).inherited_catalog_differs_from(&previous, &local, generation).unwrap(), "a row at the exclusive fence is still hidden");
+        let new_catalog = inherited(new);
+        assert_eq!(decode_head_value(&old_catalog.rows[&identity]).unwrap().snapshot, decode_head_value(&new_catalog.rows[&identity]).unwrap().snapshot);
+        assert!(new_catalog.inherited_catalog_differs_from(&previous, &local, generation).unwrap(), "identical payload newly crossing the fence changes visibility");
+        let mut writes = StorageWriteSet::new();
+        TrackedHeadContext::new().writer(&read, &mut writes).stage_inherited_catalog_refresh("branch", generation, local, new_catalog).await.unwrap();
+        storage.commit_write_set(writes, StorageWriteOptions::default()).await.unwrap();
+        let read = storage.begin_read(StorageReadOptions::default()).await.unwrap();
+        let published = TrackedHeadContext::new().reader(&read).scan_live_batch_for_generation("branch", generation, None, &request).await.unwrap();
+        assert_eq!(published.len(), 1, "the comparison agrees with the actual publication");
     }
 
     #[tokio::test]

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -13670,7 +13670,7 @@ mod tests {
 
     #[tokio::test]
     async fn inherited_catalog_visibility_compares_deletions_and_local_tombstones() {
-        let storage = crate::storage_adapter::StorageAdapter::new(crate::storage::Memory::new());
+        let storage = StorageAdapter::new(Memory::new());
         let generation = CommitId::for_test_label("catalog-visibility");
         let identity = |key: &str| HeadRowIdentity {
             schema_key: "lix_registered_schema".to_owned(),

--- a/packages/lix/src/session/catalog_visibility_tests.rs
+++ b/packages/lix/src/session/catalog_visibility_tests.rs
@@ -1,0 +1,232 @@
+use std::sync::atomic::Ordering;
+
+use super::SessionContext;
+use crate::catalog::{CatalogRevision, load_catalog_revision};
+use crate::engine::Engine;
+use crate::storage_adapter::{Memory, StorageAdapter, StorageReadOptions};
+use crate::{CreateBranchOptions, MergeBranchOptions, MergeBranchOutcome, Value};
+
+async fn open() -> (
+    StorageAdapter<Memory>,
+    Engine<Memory>,
+    SessionContext<Memory>,
+) {
+    let storage = Memory::new();
+    let receipt = Engine::initialize(storage.clone()).await.unwrap();
+    let engine = Engine::new(storage.clone()).await.unwrap();
+    let session = engine
+        .open_session_at(&receipt.main_branch_id)
+        .await
+        .unwrap();
+    (StorageAdapter::new(storage), engine, session)
+}
+
+async fn catalog_stamp(
+    storage: &StorageAdapter<Memory>,
+    session: &SessionContext<Memory>,
+) -> (CatalogRevision, usize) {
+    let read = storage
+        .begin_read(StorageReadOptions::default())
+        .await
+        .unwrap();
+    (
+        load_catalog_revision(&read).await.unwrap().unwrap(),
+        session
+            .catalog_context
+            .committed_catalog_warms
+            .load(Ordering::Relaxed),
+    )
+}
+
+fn schema(key: &str, extra: bool) -> Value {
+    let mut columns = vec![serde_json::json!({"name":"id", "type":"text", "nullable":false})];
+    if extra {
+        columns.push(serde_json::json!({"name":"extra", "type":"text", "nullable":true}));
+    }
+    Value::Jsonb(
+        serde_json::json!({
+            "$schema":"https://lix.dev/schema-v1.json", "key":key,
+            "columns":columns, "primary_key":["id"]
+        })
+        .into(),
+    )
+}
+
+
+#[tokio::test]
+async fn unchanged_catalog_checkpoints_do_not_rotate_revision_or_warm() {
+    let (storage, _engine, main) = open().await;
+    main.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ('a', 'one'), ('b', 'two')",
+        &[],
+    )
+    .await
+    .unwrap();
+    let before = catalog_stamp(&storage, &main).await;
+    main.create_checkpoint().await.unwrap();
+    assert_eq!(catalog_stamp(&storage, &main).await, before);
+    main.execute("UPDATE lix_key_value SET value = 'changed'", &[])
+        .await
+        .unwrap();
+    main.execute(
+        "SELECT commit_id FROM lix_create_checkpoint(ARRAY[lix_row_ref('lix_key_value', 'a')])",
+        &[],
+    )
+    .await
+    .unwrap();
+    assert_eq!(catalog_stamp(&storage, &main).await, before);
+    main.create_checkpoint().await.unwrap();
+    assert_eq!(catalog_stamp(&storage, &main).await, before);
+}
+
+#[tokio::test]
+async fn unchanged_catalog_three_way_merge_does_not_rotate_revision_or_warm() {
+    let (storage, engine, main) = open().await;
+    let draft_id = "01920000-0000-7000-8000-0000000000d1";
+    main.create_branch(CreateBranchOptions {
+        id: Some(draft_id.to_owned()),
+        name: "catalog unchanged".to_owned(),
+        from_commit_id: None,
+    })
+    .await
+    .unwrap();
+    let draft = engine.open_session_at(draft_id).await.unwrap();
+    main.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ('target', 'one')",
+        &[],
+    )
+    .await
+    .unwrap();
+    draft
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('source', 'two')",
+            &[],
+        )
+        .await
+        .unwrap();
+    let before = catalog_stamp(&storage, &main).await;
+    let receipt = main
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: draft_id.to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(receipt.outcome, MergeBranchOutcome::MergeCommitted);
+    assert_eq!(catalog_stamp(&storage, &main).await, before);
+    assert_eq!(
+        main.execute(
+            "SELECT key FROM lix_key_value WHERE key IN ('target', 'source')",
+            &[]
+        )
+        .await
+        .unwrap()
+        .rows()
+        .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn unchanged_inherited_catalog_refresh_does_not_rotate_revision_or_warm() {
+    let (storage, engine, main) = open().await;
+    let global = engine
+        .open_session_at(crate::GLOBAL_BRANCH_ID)
+        .await
+        .unwrap();
+    // Exercise the initial global-root-backed branch, then an owned local root.
+    for local_root in [false, true] {
+        if local_root {
+            main.execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('owned', 'local')",
+                &[],
+            )
+            .await
+            .unwrap();
+        }
+        global.execute("INSERT INTO lix_key_value (key, value, lixcol_global) VALUES ('global-data', $1, true) ON CONFLICT(key) DO UPDATE SET value = excluded.value", &[Value::Text(if local_root { "second" } else { "first" }.to_owned())]).await.unwrap();
+        let before = catalog_stamp(&storage, &main).await;
+        main.execute(
+            "SELECT key FROM lix_key_value WHERE key = 'global-data'",
+            &[],
+        )
+        .await
+        .unwrap();
+        assert_eq!(catalog_stamp(&storage, &main).await, before);
+    }
+}
+
+#[tokio::test]
+async fn inherited_catalog_changes_invalidate_but_local_overrides_mask_changes() {
+    let (storage, engine, main) = open().await;
+    let global = engine
+        .open_session_at(crate::GLOBAL_BRANCH_ID)
+        .await
+        .unwrap();
+    main.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ('owned', 'local')",
+        &[],
+    )
+    .await
+    .unwrap();
+    for key in ["inherited_probe", "overridden_probe"] {
+        global
+            .execute(
+                "INSERT INTO lix_registered_schema (value, lixcol_global) VALUES ($1, true)",
+                &[schema(key, false)],
+            )
+            .await
+            .unwrap();
+    }
+    let before = catalog_stamp(&storage, &main).await;
+    main.execute("SELECT id FROM inherited_probe", &[])
+        .await
+        .unwrap();
+    let after = catalog_stamp(&storage, &main).await;
+    assert_ne!(
+        after.0, before.0,
+        "newly inherited definitions change visibility"
+    );
+    assert_eq!(after.1, before.1 + 1);
+    main.execute("INSERT INTO lix_registered_schema (value) VALUES ($1) ON CONFLICT(schema_key) DO UPDATE SET value = excluded.value", &[schema("overridden_probe", true)]).await.unwrap();
+
+    // Replacing the global definition cannot change the local override.
+    global
+        .execute(
+            "UPDATE lix_registered_schema SET value = $1 WHERE schema_key = 'overridden_probe'",
+            &[schema("overridden_probe", true)],
+        )
+        .await
+        .unwrap();
+    let before = catalog_stamp(&storage, &main).await;
+    main.execute("SELECT extra FROM overridden_probe", &[])
+        .await
+        .unwrap();
+    assert_eq!(catalog_stamp(&storage, &main).await, before);
+
+    global
+        .execute(
+            "UPDATE lix_registered_schema SET value = $1 WHERE schema_key = 'inherited_probe'",
+            &[schema("inherited_probe", true)],
+        )
+        .await
+        .unwrap();
+    let before = catalog_stamp(&storage, &main).await;
+    main.execute("SELECT extra FROM inherited_probe", &[])
+        .await
+        .unwrap();
+    let after = catalog_stamp(&storage, &main).await;
+    assert_ne!(after.0, before.0);
+    assert_eq!(after.1, before.1 + 1);
+    main.execute(
+        "INSERT INTO inherited_probe (id, extra) VALUES ('inherited', 'validated')",
+        &[],
+    )
+    .await
+    .unwrap();
+    main.execute(
+        "INSERT INTO overridden_probe (id, extra) VALUES ('local', 'validated')",
+        &[],
+    )
+    .await
+    .unwrap();
+}

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -15,6 +15,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 mod checkpoint;
+#[cfg(test)]
+mod catalog_visibility_tests;
 mod context;
 mod create_branch;
 mod execute;

--- a/packages/lix/src/transaction/commit.rs
+++ b/packages/lix/src/transaction/commit.rs
@@ -174,6 +174,9 @@ pub(crate) async fn commit_prepared_writes(
 pub(crate) struct MaterializedCommit {
     pub(crate) writes: StorageWriteSet,
     pub(crate) preconditions: Vec<StoragePrecondition>,
+    /// A base refresh changed inherited schema facts without staging schema
+    /// rows. Determined from immutable authority under the commit snapshot.
+    pub(crate) inherited_catalog_changed: bool,
     /// Filesystem descriptor and blob-ref rows staged by this commit, carrying
     /// their **final** identities.
     ///
@@ -444,6 +447,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
             filesystem_delta_rows: Vec::new(),
             sync_commits: Vec::new(),
             published_branch_controls: BTreeMap::new(),
+            inherited_catalog_changed: false,
         });
     }
 
@@ -741,6 +745,7 @@ pub(crate) async fn commit_prepared_writes_with_parent_heads(
         filesystem_delta_rows,
         sync_commits,
         published_branch_controls,
+        inherited_catalog_changed: staged_hot_heads.inherited_catalog_changed,
     })
 }
 
@@ -2939,6 +2944,7 @@ fn select_new_rootless_ordered_commits(
 
 struct StagedHotHeads {
     controls: BTreeMap<String, BranchHeadControl>,
+    inherited_catalog_changed: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -3704,6 +3710,7 @@ async fn stage_tracked_head(
         .collect::<BTreeSet<_>>();
     let tracked_head = TrackedHeadContext::new();
     let mut controls = BTreeMap::new();
+    let mut inherited_catalog_changed = false;
     let mut exclusive_certified_columnar_publication = false;
     let transaction_global_schema_keys = global_branch_schema_keys(
         state_rows,
@@ -3783,6 +3790,36 @@ async fn stage_tracked_head(
                 load_lifecycle_catalog(read, root.state_parent_commit_id, true).await?;
             let inherited_catalog =
                 load_lifecycle_catalog(read, staged.record.base_commit_id, false).await?;
+            let refreshed_generation = if root.state_parent_commit_id.is_some() {
+                parent_control.tracked_generation
+            } else {
+                lifecycle_generation(&root.branch_id, root.commit_id, root.ref_change_id)
+            };
+            // A metadata-only publication is not itself a schema mutation.
+            // Compare with the actual serving view, including root-backed
+            // rows and collection fences, not a predicted old-base catalog.
+            // This catalog-only read is exclusive to an actual base refresh.
+            let previous_catalog = tracked_head
+                .reader(read)
+                .scan_live_batch_for_retention(
+                    &root.branch_id,
+                    parent_control,
+                    &TrackedStateScanRequest {
+                        filter: TrackedStateFilter {
+                            schema_keys: vec!["lix_registered_schema".to_owned()],
+                            file_ids: vec![NullableKeyFilter::Null],
+                            ..TrackedStateFilter::default()
+                        },
+                        read_columns: TrackedStateReadColumns {
+                            columns: vec!["raw_snapshot".to_owned()],
+                        },
+                        limit: None,
+                    },
+                    Some(false),
+                )
+                .await?;
+            inherited_catalog_changed |= inherited_catalog
+                .inherited_catalog_differs_from(&previous_catalog, &local_catalog, refreshed_generation)?;
             let checkpoint_commit_id = parent_control
                 .working_diff_checkpoint_commit_id
                 .unwrap_or(root.parent_commit_id.expect("refresh has a parent"));
@@ -4970,7 +5007,10 @@ async fn stage_tracked_head(
         control.note_schemas(deltas.iter().map(|delta| delta.schema_key));
         insert_direct_branch_control(&mut controls, branch_id, control)?;
     }
-    Ok(StagedHotHeads { controls })
+    Ok(StagedHotHeads {
+        controls,
+        inherited_catalog_changed,
+    })
 }
 
 /// Builds the INSERT guards that still need current-state enforcement.

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -2042,8 +2042,9 @@ where
             } else {
                 Vec::new()
             };
-            let next_catalog_revision =
-                catalog_revision_changed.then(|| stage_catalog_revision(&mut writes));
+            let next_catalog_revision = (catalog_revision_changed
+                || materialized.inherited_catalog_changed)
+                .then(|| stage_catalog_revision(&mut writes));
             if tracked_state_changed {
                 StorageAdapter::<StorageImpl>::stage_tracked_mutation_revision(&mut writes);
             }
@@ -2174,6 +2175,10 @@ where
                             &transaction.active_branch_id,
                             next_catalog_revision,
                         )
+                        .instrument(tracing::debug_span!(
+                            target: "lix_perf",
+                            "lix.perf.catalog.post_commit_warm"
+                        ))
                         .await;
                 }
             }
@@ -11396,18 +11401,9 @@ fn parse_prepared_timestamp(column: &str, timestamp: &str) -> Result<LixTimestam
 }
 
 fn prepared_writes_change_catalog(prepared_writes: &PreparedWriteSet) -> bool {
-    // An explicitly empty local commit refreshes its pinned global base.
-    // Its inherited serving catalog can change without a schema row in this
-    // transaction. Publish a new revision atomically: transaction opening may
-    // already have cached the old local catalog under the global writer's
-    // revision, and retaining that key would hide newly inherited schemas.
-    if prepared_writes
-        .commit_change_refs_by_branch
-        .iter()
-        .any(|(branch_id, changes)| branch_id != GLOBAL_BRANCH_ID && changes.allow_empty)
-    {
-        return true;
-    }
+    // Empty commits also represent checkpoints and merges, neither of which
+    // necessarily changes schema visibility. Materialization reports actual
+    // inherited-catalog changes separately from these explicit schema writes.
     prepared_writes.state_rows.iter().any(|row| {
         matches!(
             row.schema_key.as_str(),

--- a/packages/lix/src/transaction/schema_resolver.rs
+++ b/packages/lix/src/transaction/schema_resolver.rs
@@ -108,6 +108,10 @@ impl TransactionSchemaResolver {
         branch_id: &str,
         revision: &crate::catalog::CatalogRevision,
     ) -> Result<(), LixError> {
+        #[cfg(test)]
+        self.context
+            .committed_catalog_warms
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         self.context
             .compiled_catalog_for_transaction_open(
                 hot_state,

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -730,8 +730,8 @@ async fn existing_session_ignores_later_default_branch_corruption() {
 
     let delta = storage.stats().delta_since(&before);
     assert_eq!(
-        delta.read_opened, 5,
-        "an externally invalidated session preflights its pinned branch/global base and warms the atomically revised catalog before SQL"
+        delta.read_opened, 4,
+        "an externally invalidated session preflights its pinned branch/global base without warming an unchanged catalog before SQL"
     );
     assert_eq!(
         delta.write_opened, 1,


### PR DESCRIPTION
## Summary

Fix avoidable checkpoint/three-way-merge catalog invalidation introduced by branch structural sharing. `allow_empty` permits several publication kinds; it does not prove a catalog change.

- Keep explicit schema, selected-schema and branch-ref invalidation unchanged.
- Report inherited visibility changes from commit materialization, comparing the actual old serving catalog under the resolved branch control with the proposed local-plus-inherited catalog.
- Reuse publisher collection-generation controls and visibility predicates before comparing native payloads. Preserve overrides, tombstones, history-free rows and atomic revision publication, including the existing concurrent-revision warming guard.
- Add a tracing span for post-commit catalog warming; no public API or fallback added.

## Evidence and validation

Matched combined-control repository runs showed checkpoint/merge penalties around 0.10–0.23 ms (16–35% in the reported fixtures). Source analysis identified synchronous catalog warming caused by the overbroad empty-commit predicate. This PR removes that unnecessary trigger; candidate performance measurements remain a merge gate, not a claimed result.

- All simulations: **3,474 passed, 76 skipped**, isolated target, eight test threads.
- Doctests: **10 passed**.
- Four identical session regressions fail against unchanged main `8b65c98e5` production code with only test instrumentation, at the intended revision/warm-count assertions; all pass on this candidate.
- Additional tests cover hidden catalog rows, same-payload fence crossing, deletion/tombstone comparison, and existing inherited-schema validation, sharing, collision, and rebuild regressions.
- Independent Socrates review approved exact source/test diff SHA256 `b8847e2caa2ef417eeda500f036b6a4e8dde7f97e98b90aed08a5d8d2499b2b9`.

Raw evidence and benchmark harness remain outside the PR. Base is `8b65c98e5`; the subsequent main change is the separate OPFS test fix. Parent owns performance qualification and merge after green CI.
