### PR TITLE
fix(sql): protect write decisions through atomic commit

### DIFF
--- a/.changenotes/protect-sql-write-decisions.md
+++ b/.changenotes/protect-sql-write-decisions.md
@@ -1,0 +1,14 @@
+---
+type: patch
+---
+
+Prevent concurrent SQL updates and deletes from silently committing stale decisions.
+
+Transactions that plan an `UPDATE` or `DELETE` now reject an intervening change
+to their active-branch or shared/global state with `LIX_TRANSACTION_CONFLICT`,
+instead of merging the stale write. Retry an explicit transaction from the
+beginning. Local `execute()` and `executeBatch()` retry conflicts automatically
+within their existing limits.
+`RETURNING` results inside an explicit transaction remain provisional until
+commit succeeds. The branch-level check can also reject unrelated concurrent
+edits; explicit branch merging remains available for collaborative changes.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -235,6 +235,26 @@ const tx = await lix.beginTransaction();
 
 Starts a transaction. While it is open, execute statements on the transaction handle.
 
+SQL `UPDATE` and `DELETE` decisions are protected until commit. If another
+transaction changes active-branch or shared/global state after this transaction
+opens, committing these statements fails with `LIX_TRANSACTION_CONFLICT`. Start
+a new transaction and rerun its statements against current state. This is a conservative branch
+check, including untracked rows: even changes to unrelated rows can require a
+retry. A successfully planned update or delete retains this check if it matches
+no rows or subsequently fails and the transaction continues with other writes.
+
+Rows returned by `RETURNING` inside a transaction are provisional. Report a
+publication as successful only after `commit()` succeeds. Ordinary local
+`execute()` and `executeBatch()` automatically retry transaction conflicts a
+bounded number of times by rerunning the statements; they can still return a
+conflict if contention persists. This check does not provide general serializable
+isolation for arbitrary reads or cross-branch dependencies.
+
+Unconditional `INSERT ... ON CONFLICT DO UPDATE` file saves and explicit branch
+merges retain their collaboration semantics. Use `UPDATE ... WHERE` with an
+expected revision and require commit success when publication depends on that
+revision remaining current.
+
 ```ts
 const tx = await lix.beginTransaction();
 try {

--- a/packages/e2e/tests/crdt_benchmarks_baseline.rs
+++ b/packages/e2e/tests/crdt_benchmarks_baseline.rs
@@ -3,7 +3,8 @@
 //! The heavier workloads here are ignored profiling runs. The upstream suite
 //! measures synchronous in-memory CRDT update exchange; Lix measures durable
 //! commit-to-convergence across same-base clients. These workloads use only the
-//! existing `begin_transaction()` API and never create synthetic branches.
+//! existing `begin_transaction()` API and unconditional file upserts, leaving
+//! plugin reconciliation responsible for composing document edits.
 
 use std::fs;
 use std::io::{Cursor, Write};
@@ -42,7 +43,8 @@ async fn crdt_benchmarks_b2_1_markdown_concurrent_prefix_inserts() {
         ] {
             transaction
                 .execute(
-                    "UPDATE lix_file SET content = $1 WHERE path = $2",
+                    "INSERT INTO lix_file (content, path) VALUES ($1, $2) \
+                     ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                     &[
                         Value::Blob(bytes.to_vec().into()),
                         Value::Text(path.to_owned()),
@@ -109,7 +111,6 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
         install_plugin(&lix, "plugin_json", &build_json_plugin_archive()).await;
         let path = format!("/b3-1-{sample}.json");
         write_file(&lix, &path, br#"{"v":-1}"#).await;
-        let file_id = file_id(&lix, &path).await;
         let mut peers = Vec::with_capacity(clients);
         let mut transactions = Vec::with_capacity(clients);
         for client in 0..clients {
@@ -123,11 +124,11 @@ async fn crdt_benchmarks_b3_1_json_concurrent_map_sets() {
                 .expect("same-base transaction should open");
             transaction
                 .execute(
-                    "UPDATE json_object_member SET scalar_json = $1 \
-                     WHERE parent_id = 'root' AND key = 'v' AND lixcol_file_id = $2",
+                    "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                     ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                     &[
-                        Value::Jsonb(serde_json::json!(client).into()),
-                        Value::Text(file_id.clone()),
+                        Value::Text(path.clone()),
+                        Value::Blob(format!(r#"{{"v":{client}}}"#).into_bytes().into()),
                     ],
                 )
                 .await
@@ -256,11 +257,11 @@ fn same_base_three_writer_cohort_converges_and_reuses_follower_session() {
                         let mut transaction = peer.begin_transaction().await.unwrap();
                         transaction
                             .execute(
-                                "UPDATE json_object_member SET scalar_json = $1 \
-                 WHERE parent_id = 'root' AND key = 'v' AND lixcol_file_id = $2",
+                                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                                 &[
-                                    Value::Jsonb(serde_json::json!(value).into()),
-                                    Value::Text(file_id.clone()),
+                                    Value::Text(path.to_owned()),
+                                    Value::Blob(format!(r#"{{"v":{value}}}"#).into_bytes().into()),
                                 ],
                             )
                             .await
@@ -345,7 +346,6 @@ fn serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes()
                     install_plugin(&lix, "plugin_json", &build_json_plugin_archive()).await;
                     let path = "/stale-follower-reconcile.json";
                     write_file(&lix, path, br#"{"a":0,"b":0,"c":0}"#).await;
-                    let file_id = file_id(&lix, path).await;
                     let mut peers = Vec::new();
                     let mut transactions = Vec::new();
                     for (key, value) in [("a", 1), ("b", 2), ("c", 3)] {
@@ -353,12 +353,16 @@ fn serialized_leader_forces_stale_followers_to_reconcile_without_losing_writes()
                         let mut transaction = peer.begin_transaction().await.unwrap();
                         transaction
                             .execute(
-                                "UPDATE json_object_member SET scalar_json = $1 \
-                                 WHERE parent_id = 'root' AND key = $2 AND lixcol_file_id = $3",
+                                "INSERT INTO lix_file (path, content) VALUES ($1, $2) \
+                                 ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                                 &[
-                                    Value::Jsonb(serde_json::json!(value).into()),
-                                    Value::Text(key.to_owned()),
-                                    Value::Text(file_id.clone()),
+                                    Value::Text(path.to_owned()),
+                                    Value::Blob({
+                                        let mut document =
+                                            serde_json::json!({"a": 0, "b": 0, "c": 0});
+                                        document[key] = serde_json::json!(value);
+                                        serde_json::to_vec(&document).unwrap().into()
+                                    }),
                                 ],
                             )
                             .await

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -4317,7 +4317,7 @@ async fn v2_json_row_write_rollback_keeps_original_bytes_and_actor() {
 }
 
 #[tokio::test]
-async fn same_base_json_transactions_resolve_overlap_and_converge() {
+async fn json_branch_transactions_resolve_overlap_and_converge() {
     let archive = build_json_plugin_archive();
     let first = open_lix().await.unwrap();
     install_reference_plugin_in_blank_registry(
@@ -4332,7 +4332,22 @@ async fn same_base_json_transactions_resolve_overlap_and_converge() {
         .await
         .unwrap();
     let file_id = file_id_at_path(&first, path).await;
+    let target_branch = first.active_branch_id().await.unwrap();
+    let source_branch = first
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "Merge source".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .unwrap();
     let second = first.open_another_session().await.unwrap();
+    second
+        .switch_branch(SwitchBranchOptions {
+            branch_id: source_branch.id.clone(),
+        })
+        .await
+        .unwrap();
     let mut first_transaction = first.begin_transaction().await.unwrap();
     let mut second_transaction = second.begin_transaction().await.unwrap();
     for (transaction, value) in [
@@ -4353,7 +4368,20 @@ async fn same_base_json_transactions_resolve_overlap_and_converge() {
     second_transaction
         .commit()
         .await
-        .expect("stale plugin overlap should resolve at commit");
+        .expect("source branch edit should commit");
+
+    first
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: source_branch.id,
+        })
+        .await
+        .expect("explicit branch merge should resolve plugin edits");
+    second
+        .switch_branch(SwitchBranchOptions {
+            branch_id: target_branch,
+        })
+        .await
+        .unwrap();
 
     let first_bytes = read_file(&first, path).await.unwrap().unwrap();
     let second_bytes = read_file(&second, path).await.unwrap().unwrap();
@@ -4381,9 +4409,11 @@ async fn same_base_json_file_edits_compose_disjoint_semantics_without_resolution
     let second = first.open_another_session().await.unwrap();
     let mut first_transaction = first.begin_transaction().await.unwrap();
     let mut second_transaction = second.begin_transaction().await.unwrap();
+    // Unconditional file upserts use the native content-edit merge semantics.
     first_transaction
         .execute(
-            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            "INSERT INTO lix_file (path, content) VALUES ($2, $1) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
             &[
                 Value::Blob(b"{\"a\":\"first\",\"b\":\"base\"}\n".to_vec().into()),
                 Value::Text(path.to_owned()),
@@ -4393,7 +4423,8 @@ async fn same_base_json_file_edits_compose_disjoint_semantics_without_resolution
         .unwrap();
     second_transaction
         .execute(
-            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            "INSERT INTO lix_file (path, content) VALUES ($2, $1) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
             &[
                 Value::Blob(b"{\"a\":\"base\",\"b\":\"second\"}\n".to_vec().into()),
                 Value::Text(path.to_owned()),
@@ -4437,7 +4468,8 @@ async fn stale_json_transaction_renders_retained_same_file_edits_with_resolution
     let mut winner = winner_client.begin_transaction().await.unwrap();
     stale
         .execute(
-            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            "INSERT INTO lix_file (path, content) VALUES ($2, $1) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
             &[
                 Value::Blob(
                     b"{\"overlap\":\"stale\",\"retained\":\"stale\"}\n"
@@ -4451,7 +4483,8 @@ async fn stale_json_transaction_renders_retained_same_file_edits_with_resolution
         .unwrap();
     winner
         .execute(
-            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            "INSERT INTO lix_file (path, content) VALUES ($2, $1) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
             &[
                 Value::Blob(
                     b"{\"overlap\":\"winner\",\"retained\":\"base\"}\n"
@@ -4512,7 +4545,8 @@ async fn stale_json_transaction_batches_conflicts_into_one_render_transition() {
         );
         transaction
             .execute(
-                "UPDATE lix_file SET content = $1 WHERE path = $2",
+                "INSERT INTO lix_file (path, content) VALUES ($2, $1) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                 &[
                     Value::Blob(
                         serde_json::to_vec(&changed)
@@ -4593,7 +4627,8 @@ async fn same_base_transactions_resolve_reference_plugin_file_overlaps() {
         ] {
             transaction
                 .execute(
-                    "UPDATE lix_file SET content = $1 WHERE path = $2",
+                    "INSERT INTO lix_file (path, content) VALUES ($2, $1) \
+             ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                     &[Value::Blob(bytes.into()), Value::Text(path.clone())],
                 )
                 .await

--- a/packages/e2e/tests/plugin_api_benchmarks.rs
+++ b/packages/e2e/tests/plugin_api_benchmarks.rs
@@ -280,12 +280,14 @@ async fn stage_file_update<StorageImpl>(
 ) where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    // Unconditional file upserts retain plugin reconciliation; SQL UPDATE
+    // decisions instead reject stale snapshots and require a caller retry.
     transaction
         .execute(
-            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            "INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content",
             &[
-                Value::Blob(bytes.to_vec().into()),
                 Value::Text(path.to_owned()),
+                Value::Blob(bytes.to_vec().into()),
             ],
         )
         .await

--- a/packages/e2e/tests/plugin_row_only_merge.rs
+++ b/packages/e2e/tests/plugin_row_only_merge.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::io::{Cursor, Write};
 use std::path::Path;
 
-use lix::{Value, open_lix};
+use lix::{CreateBranchOptions, MergeBranchOptions, SwitchBranchOptions, Value, open_lix};
 
 #[tokio::test]
 async fn test_only_row_merger_composes_text_without_a_file() {
@@ -28,7 +28,20 @@ async fn test_only_row_merger_composes_text_without_a_file() {
     .await
     .expect("merge test row should insert");
 
+    let source_branch = lix
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "Row merger source".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .expect("source branch should open");
     let peer = lix.open_another_session().await.expect("peer should open");
+    peer.switch_branch(SwitchBranchOptions {
+        branch_id: source_branch.id.clone(),
+    })
+    .await
+    .expect("peer should select source branch");
     let mut a = lix.begin_transaction().await.expect("transaction A");
     let mut b = peer.begin_transaction().await.expect("transaction B");
     a.execute(
@@ -52,9 +65,12 @@ async fn test_only_row_merger_composes_text_without_a_file() {
     .await
     .expect("B edit should stage");
     a.commit().await.expect("A should commit");
-    b.commit()
-        .await
-        .expect("B should invoke the row-only merger");
+    b.commit().await.expect("B should commit on its branch");
+    lix.merge_branch(MergeBranchOptions {
+        source_branch_id: source_branch.id,
+    })
+    .await
+    .expect("explicit merge should invoke the row-only merger");
 
     let result = lix
         .execute(

--- a/packages/e2e/tests/plugin_row_only_merge.rs
+++ b/packages/e2e/tests/plugin_row_only_merge.rs
@@ -66,6 +66,25 @@ async fn test_only_row_merger_composes_text_without_a_file() {
     .expect("B edit should stage");
     a.commit().await.expect("A should commit");
     b.commit().await.expect("B should commit on its branch");
+    // Host LWW orders durable change IDs, not source/target branch roles.
+    // Canonical UUID strings preserve the byte ordering used by ConflictRank.
+    let mut change_ids = Vec::new();
+    for session in [&lix, &peer] {
+        let row = session
+            .execute(
+                "SELECT lixcol_change_id FROM merge_test_row WHERE id = $1",
+                &[Value::Text("0198b7a1-0000-7000-8000-000000000001".to_owned())],
+            )
+            .await
+            .expect("branch change ID should read");
+        change_ids.push(row.rows()[0].get::<String>("lixcol_change_id").unwrap());
+    }
+    assert_ne!(change_ids[0], change_ids[1]);
+    let expected_label = if change_ids[0] > change_ids[1] {
+        "label-a"
+    } else {
+        "label-b"
+    };
     lix.merge_branch(MergeBranchOptions {
         source_branch_id: source_branch.id,
     })
@@ -87,7 +106,7 @@ async fn test_only_row_merger_composes_text_without_a_file() {
     );
     assert_eq!(
         result.rows()[0].get::<String>("label").unwrap(),
-        "label-a",
+        expected_label,
         "the non-custom column must retain host LWW behavior"
     );
 

--- a/packages/e2e/tests/realtime_collaboration_capacity.rs
+++ b/packages/e2e/tests/realtime_collaboration_capacity.rs
@@ -254,12 +254,14 @@ impl CollaborationCapacityBackend for LocalCapacityBackend {
                 .begin_transaction()
                 .await
                 .expect("wave transaction should open");
+            // Model native file saves with unconditional upserts so plugin
+            // reconciliation composes edits rather than retrying SQL decisions.
             transaction
                 .execute(
-                    "UPDATE lix_file SET content = $1 WHERE path = $2",
+                    "INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                     &[
-                        Value::Blob(self.format.edit(base, edit.slot, &edit.token).into()),
                         Value::Text(self.path.clone()),
+                        Value::Blob(self.format.edit(base, edit.slot, &edit.token).into()),
                     ],
                 )
                 .await
@@ -423,10 +425,10 @@ async fn abandoned_transactions_and_sessions_release_resources() {
             let edit = format!("{{\"value\":\"round-{round}-client-{client}\"}}\n");
             transaction
                 .execute(
-                    "UPDATE lix_file SET content = $1 WHERE path = $2",
+                    "INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content",
                     &[
-                        Value::Blob(edit.into_bytes().into()),
                         Value::Text(path.to_owned()),
+                        Value::Blob(edit.into_bytes().into()),
                     ],
                 )
                 .await

--- a/packages/e2e/tests/server_protocol_plugin_convergence.rs
+++ b/packages/e2e/tests/server_protocol_plugin_convergence.rs
@@ -1,5 +1,3 @@
-use std::io::{Cursor, Write as _};
-use std::path::Path;
 use http::{Request, StatusCode, header::CONTENT_TYPE};
 use http_body_util::BodyExt as _;
 use lix::server_protocol::{
@@ -8,34 +6,39 @@ use lix::server_protocol::{
 };
 use lix::{Memory, Value, open_lix};
 use serde_json::{Value as JsonValue, json};
+use std::io::{Cursor, Write as _};
+use std::path::Path;
 
 #[tokio::test]
-async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
+async fn same_base_server_protocol_plugin_updates_conflict_then_retry() {
     let storage = Memory::new();
     let setup = open_lix()
         .with_storage(storage.clone())
         .await
         .expect("open setup Lix");
-    setup.execute(
-        "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
-        &[
-            Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
-            Value::Blob(json_plugin_archive().into()),
-        ],
-    )
-    .await
-    .expect("install JSON plugin");
-    setup.execute(
-        "INSERT INTO lix_file (path, content) VALUES ('/remote-conflict.json', $1)",
-        &[Value::Blob(br#"{"value":"base"}"#.to_vec().into())],
-    )
-    .await
-    .expect("write base JSON file");
+    setup
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+            &[
+                Value::Text("/.lix/plugins/plugin_json.lixplugin".to_owned()),
+                Value::Blob(json_plugin_archive().into()),
+            ],
+        )
+        .await
+        .expect("install JSON plugin");
+    setup
+        .execute(
+            "INSERT INTO lix_file (path, content) VALUES ('/remote-conflict.json', $1)",
+            &[Value::Blob(br#"{"value":"base"}"#.to_vec().into())],
+        )
+        .await
+        .expect("write base JSON file");
 
     setup.close().await.expect("close setup Lix");
     let protocol = open_lix()
         .with_storage(storage.clone())
-        .serve().with_embedded_lix_id()
+        .serve()
+        .with_embedded_lix_id()
         .await
         .expect("serve Lix");
     let sessions = [
@@ -78,8 +81,48 @@ async fn same_base_server_protocol_plugin_writes_resolve_and_converge() {
         commit(&protocol, &sessions[1], &transactions[1]),
         commit(&protocol, &sessions[2], &transactions[2]),
     );
-    for response in [first, second, third] {
-        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    let responses = [first, second, third];
+    assert_eq!(
+        responses
+            .iter()
+            .filter(|response| response.status() == StatusCode::NO_CONTENT)
+            .count(),
+        1,
+        "only one same-base SQL update may publish"
+    );
+    for (index, response) in responses.into_iter().enumerate() {
+        if response.status() == StatusCode::NO_CONTENT {
+            continue;
+        }
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response_json(response).await["error"]["code"],
+            "LIX_TRANSACTION_CONFLICT"
+        );
+        let transaction = begin_transaction(&protocol, &sessions[index]).await;
+        let encoded = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            format!(r#"{{"value":"retry-{index}"}}"#),
+        );
+        let retried = transaction_request(
+            &protocol,
+            "POST",
+            "/lix/v1/transaction/execute",
+            &sessions[index],
+            &transaction,
+            Some(json!({
+                "sql": "UPDATE lix_file SET content = $1 WHERE path = '/remote-conflict.json'",
+                "params": [{ "kind": "blob", "base64": encoded }]
+            })),
+        )
+        .await;
+        assert_eq!(retried.status(), StatusCode::OK);
+        assert_eq!(
+            commit(&protocol, &sessions[index], &transaction)
+                .await
+                .status(),
+            StatusCode::NO_CONTENT
+        );
     }
 
     let verifier = open_lix()

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -12322,7 +12322,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_complete_journal_replacement_preserves_disjoint_insert() {
+    async fn stale_complete_journal_replacement_rejects_changed_branch() {
         const ROW_COUNT: usize = 1_024;
         let storage = Memory::default();
         Engine::initialize(storage.clone())
@@ -12409,10 +12409,23 @@ mod tests {
             )
             .await
             .expect("disjoint insert should commit first");
-        replacement
+        let conflict = replacement
             .commit()
             .await
-            .expect("stale disjoint replacement should reconcile");
+            .expect_err("prepared SQL updates must reject a changed opening snapshot");
+        assert_eq!(conflict.code, LixError::CODE_TRANSACTION_CONFLICT);
+
+        let unchanged = session
+            .execute(
+                "SELECT value FROM stale_journal_replacement_probe WHERE path = '0000'",
+                &[],
+            )
+            .await
+            .expect("rejected journal must leave the original row readable");
+        assert_eq!(
+            unchanged.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            serde_json::json!({"state": "base"})
+        );
 
         let rows = concurrent_session
             .execute(
@@ -12424,7 +12437,7 @@ mod tests {
         assert_eq!(
             rows.rows()[0].get::<i64>("count").unwrap(),
             (ROW_COUNT + 1) as i64,
-            "the stale complete-set proof must not erase the disjoint insert"
+            "rejecting the stale complete-set proof must preserve the disjoint insert"
         );
         let concurrent = concurrent_session
             .execute(
@@ -12439,18 +12452,18 @@ mod tests {
                 .unwrap(),
             serde_json::json!({"state": "concurrent"})
         );
-        let reconciled_created_at = session
+        let unchanged_created_at = session
             .execute(
                 "SELECT lixcol_created_at FROM stale_journal_replacement_probe WHERE path = '0000'",
                 &[],
             )
             .await
-            .expect("reconciled lifecycle should be readable")
+            .expect("unchanged lifecycle should be readable")
             .rows()[0]
             .get::<String>("lixcol_created_at")
             .unwrap()
             .clone();
-        assert_eq!(reconciled_created_at, original_created_at);
+        assert_eq!(unchanged_created_at, original_created_at);
     }
 
     #[tokio::test]

--- a/packages/lix/src/sql2/plan/write.rs
+++ b/packages/lix/src/sql2/plan/write.rs
@@ -1,11 +1,17 @@
 use crate::LixError;
-use crate::sql2::bind::write::BoundWrite;
+use crate::sql2::bind::write::{BoundWrite, BoundWriteOp};
 use crate::sql2::plan::predicate::{BoundPredicate, FilterSet};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct LogicalWritePlan {
     pub(crate) bound: BoundWrite,
     pub(crate) filters: PlannedWriteFilters,
+}
+
+impl LogicalWritePlan {
+    pub(crate) fn requires_current_write_snapshot(&self) -> bool {
+        matches!(self.bound.op, BoundWriteOp::Update | BoundWriteOp::Delete)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -24,7 +24,8 @@ use crate::GLOBAL_BRANCH_ID;
 use crate::binary_cas::{BinaryCasContext, BlobBytesBatch, BlobDataReader, BlobId};
 use crate::branch::{
     BRANCH_REF_SCHEMA_KEY, BranchContext, BranchHeadControlContext, BranchLifecycle,
-    BranchOperation, BranchRefReader, BranchReferenceRole, branch_ref_stage_row,
+    BranchOperation, BranchRefReader, BranchReferenceRole, branch_head_control_precondition,
+    branch_ref_stage_row,
 };
 use crate::catalog::{
     CatalogContext, CatalogFingerprint, CatalogRevision, CatalogSnapshot, ForeignKeyPlan,
@@ -241,6 +242,8 @@ where
         && a.opening_active_branch_head == b.opening_active_branch_head
         && a.opening_global_branch_head == b.opening_global_branch_head
         && a.opening_tracked_mutation_revision == b.opening_tracked_mutation_revision
+        && !a.protect_sql_write_snapshot
+        && !b.protect_sql_write_snapshot
         && a.idempotency_receipt.is_none()
         && b.idempotency_receipt.is_none()
         && a.atomic_metadata_writes.is_none()
@@ -708,6 +711,9 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     /// overlapping semantic write without creating a temporary branch.
     opening_active_branch_head: Option<CommitId>,
     opening_global_branch_head: Option<CommitId>,
+    /// SQL UPDATE/DELETE predicates and computed values are decisions against
+    /// the opening snapshot, not edits that may be silently reconciled later.
+    protect_sql_write_snapshot: bool,
     commit_boundary: Option<TransactionCommitBoundary>,
     trust_filesystem_planner: bool,
     origin_key: Option<SharedStr>,
@@ -1035,6 +1041,40 @@ where
         self.staged_writes
             .stage_empty_commit(self.active_branch_id.clone())?;
         Ok(true)
+    }
+
+    async fn fence_sql_write_snapshot<S>(&mut self, read: &S) -> Result<(), LixError>
+    where
+        S: StorageAdapterRead,
+    {
+        if !self.protect_sql_write_snapshot {
+            return Ok(());
+        }
+        let mut branches = vec![self.active_branch_id.clone()];
+        if self.active_branch_id != GLOBAL_BRANCH_ID {
+            branches.push(GLOBAL_BRANCH_ID.to_owned());
+        }
+        let controls = BranchHeadControlContext::new();
+        let opening = controls
+            .reader(self.opening_read())
+            .load_observed(&branches)
+            .await?;
+        let current = controls.reader(read).load_observed(&branches).await?;
+        for ((branch_id, opening), current) in branches.iter().zip(opening).zip(current) {
+            if opening.raw_token != current.raw_token {
+                return Err(LixError::new(
+                    LixError::CODE_TRANSACTION_CONFLICT,
+                    "SQL update or delete snapshot is stale because branch state changed",
+                )
+                .with_hint("Retry the transaction against the latest committed state."));
+            }
+            // The opening token includes history-free untracked mutations.
+            // Compare it again in the atomic storage commit so another engine
+            // cannot invalidate the decision after this coherent read.
+            self.atomic_metadata_preconditions
+                .push(branch_head_control_precondition(branch_id, opening.raw_token)?);
+        }
+        Ok(())
     }
 
     async fn reconcile_stale_disjoint_writes<S>(
@@ -1687,6 +1727,7 @@ where
                     opening_tracked_mutation_revision,
                     opening_active_branch_head,
                     opening_global_branch_head,
+                    protect_sql_write_snapshot: false,
                     commit_boundary: None,
                     trust_filesystem_planner: false,
                     origin_key: None,
@@ -1810,6 +1851,14 @@ where
             // and the transaction drops this read before its storage field.
             let commit_read = unsafe { assume_static_storage_read::<StorageImpl>(commit_read) };
             let mut read = SharedStorageAdapterRead::new(commit_read);
+            // Preserve the original statement snapshot until its SQL decisions
+            // have been fenced; reconciliation below uses the current read.
+            if let Err(error) = transaction.fence_sql_write_snapshot(&read).await {
+                transaction
+                    .discard_pending_plugin_actor_publications()
+                    .await;
+                return Err(error);
+            }
             // Commit-time reconciliation and validation must all observe this
             // current coherent snapshot, while user statements above observed the
             // snapshot retained from transaction open.
@@ -7333,7 +7382,7 @@ where
     }
 
     pub(crate) fn prepare_sql_write_logical_plan(
-        &self,
+        &mut self,
         sql: &str,
         statement: &DataFusionStatement,
     ) -> Result<crate::sql2::SqlLogicalPlan, LixError> {
@@ -7341,25 +7390,27 @@ where
             return Ok(crate::sql2::SqlLogicalPlan::Checkpoint(plan));
         }
         let fingerprint = self.sql_catalog_fingerprint();
-        if let Some(plan) =
+        let plan = if let Some(plan) =
             self.sql_planning_cache
                 .write_plan(sql, fingerprint, &self.active_branch_id)
         {
-            return Ok(crate::sql2::create_write_logical_plan_from_template(plan));
-        }
-
-        let catalog = self.sql_public_catalog()?;
-        let plan = crate::sql2::create_write_plan_template_from_parsed(
-            statement,
-            catalog.as_ref(),
-            &self.active_branch_id,
-        )?;
-        self.sql_planning_cache.remember_write_plan(
-            sql,
-            fingerprint.clone(),
-            &self.active_branch_id,
-            &plan,
-        );
+            plan
+        } else {
+            let catalog = self.sql_public_catalog()?;
+            let plan = crate::sql2::create_write_plan_template_from_parsed(
+                statement,
+                catalog.as_ref(),
+                &self.active_branch_id,
+            )?;
+            self.sql_planning_cache.remember_write_plan(
+                sql,
+                fingerprint.clone(),
+                &self.active_branch_id,
+                &plan,
+            );
+            plan
+        };
+        self.protect_sql_write_snapshot |= plan.requires_current_write_snapshot();
         Ok(crate::sql2::create_write_logical_plan_from_template(plan))
     }
 

--- a/packages/lix/src/transaction/context/cohort.rs
+++ b/packages/lix/src/transaction/context/cohort.rs
@@ -112,6 +112,7 @@ where
             && transaction.opening_global_branch_head == leader.opening_global_branch_head
             && transaction.opening_tracked_mutation_revision
                 == leader.opening_tracked_mutation_revision
+            && !transaction.protect_sql_write_snapshot
             && transaction.idempotency_receipt.is_none()
             && transaction.atomic_metadata_writes.is_none()
             && transaction.atomic_metadata_preconditions.is_empty()

--- a/packages/lix/tests/integration/transaction.rs
+++ b/packages/lix/tests/integration/transaction.rs
@@ -14,6 +14,356 @@ use lix::{engine::Engine, session::SessionContext};
 const TEST_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 const UNTRACKED_RACE_BRANCH_ID: &str = "01930000-0000-7000-8000-000000000018";
 
+#[tokio::test]
+async fn conditional_publication_rejects_stale_transaction() {
+    assert_conditional_publication_has_one_committed_winner(false, false, false).await;
+}
+
+#[tokio::test]
+async fn conditional_publication_rejects_stale_commit_cohort_member() {
+    assert_conditional_publication_has_one_committed_winner(true, false, false).await;
+}
+
+#[tokio::test]
+async fn conditional_publication_independent_engines_have_one_committed_winner() {
+    assert_conditional_publication_has_one_committed_winner(true, false, true).await;
+}
+
+#[tokio::test]
+async fn conditional_publication_untracked_fence_is_atomic_with_storage_write() {
+    let storage = InterferingStorage::new();
+    let gate = storage.gate();
+    Engine::initialize(storage.clone()).await.unwrap();
+    let first_engine = Engine::new(storage.clone()).await.unwrap();
+    let first_session = first_engine.open_session().await.unwrap();
+    first_session
+        .execute(
+            r#"INSERT INTO lix_registered_schema (value)
+               VALUES (CAST('{"$schema":"https://lix.dev/schema-v1.json","key":"atomic_publication_cas","columns":[{"name":"id","type":"text","nullable":false},{"name":"revision","type":"text","nullable":false}],"primary_key":["id"]}' AS JSONB))"#,
+            &[],
+        )
+        .await
+        .unwrap();
+    first_session
+        .execute(
+            "INSERT INTO atomic_publication_cas (id, revision, lixcol_untracked) VALUES ('canon', 'base', true)",
+            &[],
+        )
+        .await
+        .unwrap();
+    let second_engine = Engine::new(storage).await.unwrap();
+    let winner = second_engine.open_session().await.unwrap();
+    let mut first = first_session.begin_transaction().await.unwrap();
+    let staged = first
+        .execute(
+            "UPDATE atomic_publication_cas SET revision = 'stale' WHERE id = 'canon' AND revision = 'base' RETURNING revision",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(staged.rows().len(), 1);
+
+    gate.arm();
+    let competing_publication = async {
+        // The first commit has finished its snapshot checks and is parked
+        // immediately before opening its physical write. This independent
+        // engine changes only untracked state, leaving the branch head intact.
+        gate.wait_until_a_write_is_parked().await;
+        let result = winner
+            .execute(
+                "UPDATE atomic_publication_cas SET revision = 'winner' WHERE id = 'canon' AND revision = 'base' RETURNING revision",
+                &[],
+            )
+            .await;
+        gate.release_parked_write();
+        result
+    };
+    let (first_result, winner_result) =
+        tokio::time::timeout(TEST_WAIT_TIMEOUT * 15, async {
+            tokio::join!(first.commit(), competing_publication)
+        })
+        .await
+        .expect("independent publishers must not deadlock");
+    assert_eq!(winner_result.unwrap().rows().len(), 1);
+    let conflict = first_result.expect_err("storage must reject the now-stale untracked token");
+    assert_eq!(conflict.code, "LIX_TRANSACTION_CONFLICT");
+    let published = winner
+        .execute(
+            "SELECT revision FROM atomic_publication_cas WHERE id = 'canon'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(published.rows()[0].get::<String>("revision").unwrap(), "winner");
+}
+
+#[tokio::test]
+async fn conditional_publication_delete_conflict_discards_audit_write() {
+    assert_stale_publication_decision_discards_audit(
+        "DELETE FROM publication_cas WHERE id = 'canon' AND revision = 'base' RETURNING revision",
+        1,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn conditional_publication_zero_row_update_conflict_discards_audit_write() {
+    assert_stale_publication_decision_discards_audit(
+        "UPDATE publication_cas SET revision = 'stale' WHERE id = 'canon' AND revision = 'missing' RETURNING revision",
+        0,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn conditional_publication_untracked_rejects_stale_transaction() {
+    assert_conditional_publication_has_one_committed_winner(false, true, false).await;
+}
+
+#[tokio::test]
+async fn conditional_publication_untracked_rejects_stale_commit_cohort_member() {
+    assert_conditional_publication_has_one_committed_winner(true, true, false).await;
+}
+
+async fn assert_stale_publication_decision_discards_audit(sql: &str, affected: usize) {
+    let engine = publication_test_engine().await;
+    let stale_session = engine.open_session().await.unwrap();
+    let winner_session = engine.open_session().await.unwrap();
+    let mut stale = stale_session.begin_transaction().await.unwrap();
+    let decision = stale.execute(sql, &[]).await.unwrap();
+    assert_eq!(decision.rows().len(), affected);
+    stale
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('publication-audit', 'stale')",
+            &[],
+        )
+        .await
+        .unwrap();
+    winner_session
+        .execute(
+            "UPDATE publication_cas SET revision = 'winner' WHERE id = 'canon'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let conflict = stale
+        .commit()
+        .await
+        .expect_err("stale SQL decisions must abort their entire transaction");
+    assert_eq!(conflict.code, "LIX_TRANSACTION_CONFLICT");
+    let publication = winner_session
+        .execute(
+            "SELECT revision FROM publication_cas WHERE id = 'canon'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        publication.rows()[0].get::<String>("revision").unwrap(),
+        "winner"
+    );
+    let audit = winner_session
+        .execute(
+            "SELECT key FROM lix_key_value WHERE key = 'publication-audit'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(
+        audit.rows().is_empty(),
+        "a rejected publication must not leave an audit receipt"
+    );
+}
+
+#[tokio::test]
+async fn conditional_publication_warm_prepared_batch_rejects_stale_transaction() {
+    use crate::prepared_dml::PreparedDmlParameterBatch;
+    use lix::Value;
+
+    let engine = publication_test_engine().await;
+    let stale_session = engine.open_session().await.unwrap();
+    let winner_session = engine.open_session().await.unwrap();
+    let sql: Arc<str> =
+        "UPDATE publication_cas SET revision = $1 WHERE id = $2 AND revision = $3".into();
+    let parameters = || {
+        PreparedDmlParameterBatch::from_rows([vec![
+            Value::Text("stale".into()),
+            Value::Text("canon".into()),
+            Value::Text("base".into()),
+        ]])
+        .unwrap()
+    };
+    let mut warm = stale_session.begin_transaction().await.unwrap();
+    warm.execute_prepared_dml_batch(Arc::clone(&sql), parameters())
+        .await
+        .unwrap();
+    warm.rollback().await.unwrap();
+    let mut stale = stale_session.begin_transaction().await.unwrap();
+    let updates = stale
+        .execute_prepared_dml_batch(sql, parameters())
+        .await
+        .unwrap();
+    assert_eq!(updates[0].rows_affected(), 1);
+    winner_session
+        .execute(
+            "UPDATE publication_cas SET revision = 'winner' WHERE id = 'canon'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let conflict = stale
+        .commit()
+        .await
+        .expect_err("a cached prepared update needs the same commit guard");
+    assert_eq!(conflict.code, "LIX_TRANSACTION_CONFLICT");
+    let publication = winner_session
+        .execute(
+            "SELECT revision FROM publication_cas WHERE id = 'canon'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        publication.rows()[0].get::<String>("revision").unwrap(),
+        "winner"
+    );
+}
+
+#[tokio::test]
+async fn conditional_publication_file_change_id_rejects_stale_transaction() {
+    use lix::Value;
+
+    let engine = publication_test_engine().await;
+    let stale_session = engine.open_session().await.unwrap();
+    let winner_session = engine.open_session().await.unwrap();
+    winner_session.execute("INSERT INTO lix_file (path, content) VALUES ('/publication.txt', CAST('base' AS BYTEA))", &[]).await.unwrap();
+    let current = winner_session
+        .execute(
+            "SELECT lixcol_change_id FROM lix_file WHERE path = '/publication.txt'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let change_id = current.rows()[0].get::<String>("lixcol_change_id").unwrap();
+    let mut stale = stale_session.begin_transaction().await.unwrap();
+    let update = stale.execute(
+        "UPDATE lix_file SET content = CAST('stale' AS BYTEA) WHERE path = '/publication.txt' AND lixcol_change_id = $1",
+        &[Value::Text(change_id)],
+    ).await.unwrap();
+    assert_eq!(update.rows_affected(), 1);
+    winner_session
+        .upsert_file_content("/publication.txt".into(), b"winner".to_vec().into())
+        .await
+        .unwrap();
+    let conflict = stale
+        .commit()
+        .await
+        .expect_err("file predicates must not be silently reconciled");
+    assert_eq!(conflict.code, "LIX_TRANSACTION_CONFLICT");
+    let file = winner_session
+        .read_file_content("/publication.txt".into(), None)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(file.content().as_ref(), b"winner");
+}
+
+async fn publication_test_engine() -> Engine<Memory> {
+    publication_test_engine_in_mode(false).await
+}
+
+async fn publication_test_engine_in_mode(untracked: bool) -> Engine<Memory> {
+    let storage = Memory::new();
+    Engine::initialize(storage.clone()).await.unwrap();
+    let engine = Engine::new(storage).await.unwrap();
+    let alice_session = engine.open_session().await.unwrap();
+    alice_session
+        .execute(
+            r#"INSERT INTO lix_registered_schema (value)
+               VALUES (CAST('{"$schema":"https://lix.dev/schema-v1.json","key":"publication_cas","columns":[{"name":"id","type":"text","nullable":false},{"name":"revision","type":"text","nullable":false}],"primary_key":["id"]}' AS JSONB))"#,
+            &[],
+        )
+        .await
+        .unwrap();
+    alice_session
+        .execute(
+            &format!("INSERT INTO publication_cas (id, revision, lixcol_untracked) VALUES ('canon', 'base', {untracked})"),
+            &[],
+        )
+        .await
+        .unwrap();
+
+    engine
+}
+
+async fn assert_conditional_publication_has_one_committed_winner(
+    commit_together: bool,
+    untracked: bool,
+    independent_engines: bool,
+) {
+    let engine = publication_test_engine_in_mode(untracked).await;
+    let other_engine = if independent_engines {
+        Some(Engine::new(engine.storage().storage().clone()).await.unwrap())
+    } else {
+        None
+    };
+    let alice_session = engine.open_session().await.unwrap();
+    let bob_session = other_engine
+        .as_ref()
+        .unwrap_or(&engine)
+        .open_session()
+        .await
+        .unwrap();
+
+    // Both publishers have read the same base and stage their conditional
+    // update before either commits. RETURNING alone is provisional; committing
+    // must not acknowledge both incompatible publication decisions.
+    let mut alice = alice_session.begin_transaction().await.unwrap();
+    let mut bob = bob_session.begin_transaction().await.unwrap();
+    let alice_update = alice
+        .execute(
+            "UPDATE publication_cas SET revision = 'alice' WHERE id = 'canon' AND revision = 'base' RETURNING revision",
+            &[],
+        )
+        .await
+        .unwrap();
+    let bob_update = bob
+        .execute(
+            "UPDATE publication_cas SET revision = 'bob' WHERE id = 'canon' AND revision = 'base' RETURNING revision",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(alice_update.rows().len(), 1);
+    assert_eq!(bob_update.rows().len(), 1);
+
+    let (alice_commit, bob_commit) = if commit_together {
+        tokio::join!(alice.commit(), bob.commit())
+    } else {
+        (alice.commit().await, bob.commit().await)
+    };
+    let published = alice_session
+        .execute(
+            "SELECT revision FROM publication_cas WHERE id = 'canon'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let revision = published.rows()[0].get::<String>("revision").unwrap();
+    assert_eq!(
+        usize::from(alice_commit.is_ok()) + usize::from(bob_commit.is_ok()),
+        1,
+        "exactly one conditional publisher may commit; alice={alice_commit:?}, bob={bob_commit:?}, published={revision}"
+    );
+    let (winner, loser) = if alice_commit.is_ok() {
+        ("alice", bob_commit.unwrap_err())
+    } else {
+        ("bob", alice_commit.unwrap_err())
+    };
+    assert_eq!(revision, winner);
+    assert_eq!(loser.code, "LIX_TRANSACTION_CONFLICT");
+}
+
 async fn setup_untracked_race_branch<StorageImpl>(engine: &Engine<StorageImpl>)
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -105,7 +455,7 @@ async fn stale_transaction_composes_disjoint_semantic_writes() {
 }
 
 #[tokio::test]
-async fn stale_transaction_composes_different_columns_of_one_ordinary_row() {
+async fn stale_sql_update_retries_before_preserving_different_column_edits() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())
         .await
@@ -159,10 +509,18 @@ async fn stale_transaction_composes_different_columns_of_one_ordinary_row() {
         )
         .await
         .expect("winner body edit should commit");
-    stale
+    let conflict = stale
         .commit()
         .await
-        .expect("different columns should compose without a conflict API");
+        .expect_err("SQL decisions from an old branch head must be retried");
+    assert_eq!(conflict.code, "LIX_TRANSACTION_CONFLICT");
+    stale_session
+        .execute(
+            "UPDATE row_merge_note SET title = 'alice title' WHERE id = 'note-1'",
+            &[],
+        )
+        .await
+        .expect("a fresh update should preserve the other column edit");
 
     let result = winner_session
         .execute(
@@ -179,7 +537,7 @@ async fn stale_transaction_composes_different_columns_of_one_ordinary_row() {
 }
 
 #[tokio::test]
-async fn commit_cohort_composes_different_columns_of_one_ordinary_row() {
+async fn commit_cohort_sql_updates_retry_before_preserving_different_column_edits() {
     let storage = Memory::new();
     Engine::initialize(storage.clone())
         .await
@@ -238,8 +596,25 @@ async fn commit_cohort_composes_different_columns_of_one_ordinary_row() {
     .expect("bob body edit should stage");
 
     let (alice_result, bob_result) = tokio::join!(alice.commit(), bob.commit());
-    alice_result.expect("alice cohort member should commit");
-    bob_result.expect("bob cohort member should commit");
+    assert_eq!(
+        usize::from(alice_result.is_ok()) + usize::from(bob_result.is_ok()),
+        1
+    );
+    let (retry_session, retry_sql, conflict) = if alice_result.is_ok() {
+        (
+            &bob_session,
+            "UPDATE cohort_row_merge_note SET body = 'bob body' WHERE id = 'note-1'",
+            bob_result.unwrap_err(),
+        )
+    } else {
+        (
+            &alice_session,
+            "UPDATE cohort_row_merge_note SET title = 'alice title' WHERE id = 'note-1'",
+            alice_result.unwrap_err(),
+        )
+    };
+    assert_eq!(conflict.code, "LIX_TRANSACTION_CONFLICT");
+    retry_session.execute(retry_sql, &[]).await.unwrap();
 
     let result = setup
         .execute(


### PR DESCRIPTION
Two transactions could both execute `UPDATE ... WHERE revision = 'base' RETURNING revision` and commit successfully: stale-write reconciliation retained row edits but discarded the condition that made publication valid. The race reproduced on current main with both sequential and concurrent commits.

SQL `UPDATE` and `DELETE` now protect their opening active/global branch state through commit using existing branch-control storage preconditions. This includes untracked rows and prevents shared commit cohorts from combining competing decisions. A stale explicit transaction returns `LIX_TRANSACTION_CONFLICT`; ordinary local execute paths can rerun their statements through the existing bounded retry mechanism. No application queue, new storage format, or compatibility mode is introduced.

The guard is intentionally conservative: unrelated changes on the same branch can require retries. Native file upserts and explicit branch merging retain their reconciliation behavior. This does not add general serializable isolation for arbitrary reads or cross-branch dependencies.

Regression coverage includes tracked and untracked publication, concurrent commits, independent engines, cached prepared updates, file change-ID predicates, audit rollback, and an untracked write forced between validation and atomic publication. Replaced the old stale SQL update-composition expectations with conflict-and-retry behavior. Two independent subagents reviewed the implementation.

Validation:
- `cargo nextest run -p lix --features all-simulations --no-fail-fast`: 3,478 passed, 76 existing skips.
- `cargo test -p lix --doc`: 10 passed.
- `cargo clippy --profile test --workspace --all-targets --all-features -- -D warnings`: passed.
- Clippy for all six affected plugin end-to-end targets with warnings denied: passed.
- Changenote/protocol-document validation and diff checks: passed.
- Six affected plugin end-to-end test targets: 81 passed, 11 existing skips (including protocol conflict/retry and 100-writer collaboration). Repository CI must pass before merge.

Plugin collaboration tests now use unconditional file upserts or explicit branch merges. The server-protocol test retains SQL UPDATE and checks one successful publication, conflict responses, and successful fresh-transaction retries.
