### PR TITLE
Freeze ready release candidates and isolate draft validation

### DIFF
--- a/.github/release-flow.md
+++ b/.github/release-flow.md
@@ -8,7 +8,7 @@
    CI. The bot will neither update it nor close it in favor of another version.
 3. Wait for **Release ready** on the current head commit. This aggregates the
    existing CI suites, rejecting failures, cancellations, and unexpected skips.
-   It also checks that the PR is still open, ready, and at the tested head.
+   It also checks that the PR is still open, ready, and at the tested head and base.
 4. Merge the candidate. The existing publishing workflow handles publication.
 
 To include newer changes, return the candidate to draft and manually dispatch
@@ -16,10 +16,19 @@ To include newer changes, return the candidate to draft and manually dispatch
 Do not rerun an old draft event to validate a ready candidate: reruns retain
 their original event payload. Rerun the ready-for-review run instead.
 
+If main advances during validation, refresh the candidate through the draft flow
+and start new CI. Rerunning the old event retains its old base SHA and is not a
+substitute for validating the refreshed candidate.
+
 ## One-time rollout
 
 After these workflows land, configure main's branch protection to require
 **Release ready** from GitHub Actions, preserving any other required checks.
+Also enable **Require branches to be up to date before merging** (required status
+checks `strict: true`). Both settings are required: the gate detects base changes
+before it finishes, while strict branch protection prevents an already-green
+candidate from merging after main advances. A completed check cannot invalidate
+itself when the base changes later. Do not bypass these protections for releases.
 GitHub requires checks on the target branch, so this lightweight aggregate is
 also emitted for ordinary ready PRs; it adds no test suite or build matrix.
 Draft CI uses a different check name and concurrency group, so it cannot cancel

--- a/.github/release-flow.md
+++ b/.github/release-flow.md
@@ -1,0 +1,31 @@
+# Releasing Lix
+
+1. While the release PR is a draft, pushes to main update its version metadata
+   and changelog. The generator validates metadata before writing; the separate
+   **Release metadata** workflow also validates draft PR events without building
+   the engine.
+2. Mark the release PR ready. This freezes automated updates and starts normal
+   CI. The bot will neither update it nor close it in favor of another version.
+3. Wait for **Release ready** on the current head commit. This aggregates the
+   existing CI suites, rejecting failures, cancellations, and unexpected skips.
+   It also checks that the PR is still open, ready, and at the tested head.
+4. Merge the candidate. The existing publishing workflow handles publication.
+
+To include newer changes, return the candidate to draft and manually dispatch
+**Release PR** from main. Review the refreshed diff, then mark it ready again.
+Do not rerun an old draft event to validate a ready candidate: reruns retain
+their original event payload. Rerun the ready-for-review run instead.
+
+## One-time rollout
+
+After these workflows land, configure main's branch protection to require
+**Release ready** from GitHub Actions, preserving any other required checks.
+GitHub requires checks on the target branch, so this lightweight aggregate is
+also emitted for ordinary ready PRs; it adds no test suite or build matrix.
+Draft CI uses a different check name and concurrency group, so it cannot cancel
+ready validation or overwrite the required check with a skipped result.
+
+Existing release PRs created before this change must be returned to draft and
+refreshed through **Release PR** once to pick up the workflow changes. Do not
+merge based on an older green run that skipped validation. Adding the job to YAML
+alone does not make it a required GitHub check.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # A rerun retains its original event payload. Draft reruns must never cancel
+  # ready-candidate validation, even when they reference the same head commit.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.draft && 'draft' || 'ready' }}
   cancel-in-progress: true
 
 permissions:
@@ -31,8 +33,36 @@ defaults:
     shell: bash --noprofile --norc -o errexit -o nounset -o pipefail -o xtrace -O nullglob -O dotglob {0}
 
 jobs:
+  release-ready:
+    # Draft reruns must not overwrite the required ready-candidate check.
+    name: ${{ github.event.pull_request.draft && 'Draft - full CI deferred' || 'Release ready' }}
+    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    needs: [merge-reuse, promote-browser-sdk, changelog, cargo-config, cargo, js-sdk-test, preview-artifact-changes, preview-server-image]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require successful validation of the current candidate
+        uses: actions/github-script@v7
+        env:
+          VALIDATION_NEEDS: ${{ toJSON(needs) }}
+        with:
+          script: |
+            const { assertReleaseReady } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/release-candidate.mjs`);
+            const currentPr = context.eventName === 'pull_request'
+              ? (await github.rest.pulls.get({ ...context.repo, pull_number: context.issue.number })).data
+              : undefined;
+            assertReleaseReady({
+              needs: JSON.parse(process.env.VALIDATION_NEEDS),
+              eventName: context.eventName, event: context.payload, currentPr,
+            });
+
   merge-reuse:
     name: Reuse tested merge
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -146,7 +176,7 @@ jobs:
         run: node scripts/validate-server-protocol-docs.mjs
 
       - name: Validate CI workflow invariants
-        run: node --test scripts/ci-workflow.test.mjs scripts/ci-merge-reuse.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs
+        run: node --test scripts/ci-workflow.test.mjs scripts/ci-merge-reuse.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs scripts/release-candidate.test.mjs
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})

--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -1,0 +1,29 @@
+name: Release metadata
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, converted_to_draft]
+
+concurrency:
+  group: release-metadata-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  metadata:
+    name: Draft release metadata
+    if: github.event.pull_request.draft && startsWith(github.head_ref, 'release/v')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Validate release metadata without building the engine
+        run: |
+          node scripts/validate-publish-surface.mjs
+          node --test scripts/release.test.mjs scripts/release-candidate.test.mjs
+          git diff --check

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,7 +25,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Leave ready release candidates frozen
+        id: freeze
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { checkReleaseFreeze } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/release-candidate.mjs`);
+            await checkReleaseFreeze({ github, context, core });
+
       - name: Prepare release changes
+        if: steps.freeze.outputs.frozen != 'true'
         id: prepare
         run: |
           output="$(node scripts/prepare-release.mjs)"
@@ -45,28 +54,39 @@ jobs:
           node --test scripts/release.test.mjs
           git diff --check
 
-      - name: Create or update release PR
+      - name: Recheck candidate before writing
         if: steps.prepare.outputs.has_release == 'true'
+        id: recheck
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { checkReleaseFreeze } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/release-candidate.mjs`);
+            await checkReleaseFreeze({ github, context, core });
+
+      - name: Create or update release PR
+        if: steps.prepare.outputs.has_release == 'true' && steps.recheck.outputs.frozen == 'false'
         id: release_pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/v${{ steps.prepare.outputs.version }}
           delete-branch: true
-          draft: always-true
+          draft: true
           commit-message: Release v${{ steps.prepare.outputs.version }}
           title: Release v${{ steps.prepare.outputs.version }}
           body: |
             This PR was generated from `.changenotes/*` fragments.
 
-            Mark this PR ready for review when the release is ready. This runs full CI.
-            Automated updates return it to draft; metadata is validated on every update.
+            Mark this PR ready for review to freeze the candidate and run full CI.
+            Merge only after the Release ready check passes for this commit.
+            To include newer changes, return this PR to draft and manually run the Release PR workflow.
+            Draft updates validate metadata; automated updates leave ready candidates untouched.
 
             Merging this PR updates `CHANGELOG.md`, bumps lockstep package versions,
             and enables the release workflow to create `v${{ steps.prepare.outputs.version }}` and publish packages.
 
       - name: Close superseded release PRs
-        if: steps.prepare.outputs.has_release == 'true'
+        if: steps.release_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_PR: ${{ steps.release_pr.outputs.pull-request-number }}
@@ -76,8 +96,8 @@ jobs:
             --state open \
             --base main \
             --limit 100 \
-            --json number,headRefName,isCrossRepository \
-            --jq '.[] | select(.isCrossRepository == false and (.headRefName | test("^release/v[0-9]+\\.[0-9]+\\.[0-9]+$"))) | [.number, .headRefName] | @tsv' |
+            --json number,headRefName,isCrossRepository,isDraft \
+            --jq '.[] | select(.isDraft == true and .isCrossRepository == false and (.headRefName | test("^release/v[0-9]+\\.[0-9]+\\.[0-9]+$"))) | [.number, .headRefName] | @tsv' |
           while IFS=$'\t' read -r number branch; do
             if [ "$branch" = "$TARGET_BRANCH" ]; then
               continue

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -18,12 +18,13 @@ const publishWorkflow = readFileSync(
 	"utf8",
 );
 
-test("superseded CI runs are cancelled per pull request or branch", () => {
+test("draft reruns cannot cancel ready-candidate CI", () => {
 	assert.match(
 		workflow,
 		/group: \$\{\{ github\.workflow \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
 	);
 	assert.match(workflow, /cancel-in-progress: true/);
+	assert.match(workflow, /github\.event\.pull_request\.draft && 'draft' \|\| 'ready'/);
 });
 
 test("Rust test scopes run independently with workspace-specific caches", () => {
@@ -188,7 +189,11 @@ test("server-changing pull requests retain one reusable preview image", () => {
 });
 
 test("release PR updates validate metadata and defer full CI until ready for review", () => {
-	assert.match(releasePrWorkflow, /draft: always-true/);
+	assert.match(releasePrWorkflow, /draft: true/);
+	assert.doesNotMatch(releasePrWorkflow, /draft: always-true/);
+	assert.match(releasePrWorkflow, /steps\.freeze\.outputs\.frozen != 'true'/);
+	assert.match(releasePrWorkflow, /steps\.recheck\.outputs\.frozen == 'false'/);
+	assert.match(releasePrWorkflow, /select\(\.isDraft == true/);
 	assert.match(
 		releasePrWorkflow,
 		/node scripts\/validate-publish-surface\.mjs/,
@@ -196,6 +201,21 @@ test("release PR updates validate metadata and defer full CI until ready for rev
 	assert.match(releasePrWorkflow, /node --test scripts\/release\.test\.mjs/);
 	assert.doesNotMatch(releasePrWorkflow, /gh workflow run|actions: write/);
 	assert.match(workflow, /ready_for_review/);
+});
+
+test("the readiness gate aggregates real results and draft runs have a distinct check name", () => {
+	const gate = workflow.split("\n  release-ready:\n")[1].split("\n  merge-reuse:\n")[0];
+	assert.match(gate, /always\(\)/);
+	assert.match(gate, /'Draft - full CI deferred' \|\| 'Release ready'/);
+	for (const job of ["merge-reuse", "promote-browser-sdk", "changelog", "cargo-config", "cargo", "js-sdk-test", "preview-artifact-changes", "preview-server-image"]) {
+		assert.ok(gate.split("    needs: ")[1].split("\n")[0].includes(job));
+	}
+	assert.match(gate, /github\.rest\.pulls\.get/);
+	assert.match(gate, /assertReleaseReady/);
+	const metadata = readFileSync(resolve(repositoryRoot, ".github/workflows/release-metadata.yml"), "utf8");
+	assert.match(metadata, /group: release-metadata-/);
+	assert.match(metadata, /converted_to_draft/);
+	assert.doesNotMatch(metadata, /cargo |build:wasm|build:native/);
 });
 
 test("SDK binary reuse never skips TypeScript builds or integration tests", () => {

--- a/scripts/release-candidate.mjs
+++ b/scripts/release-candidate.mjs
@@ -1,0 +1,49 @@
+// Kept small and pure so the release policy is covered without building Lix.
+export function frozenReleaseCandidates(prs, repository) {
+	return prs.filter(pr => pr.state === "open" && !pr.draft &&
+		pr.base.ref === "main" && pr.head.repo?.full_name === repository &&
+		/^release\/v\d+\.\d+\.\d+$/.test(pr.head.ref));
+}
+
+export async function checkReleaseFreeze({ github, context, core }) {
+	const prs = await github.paginate(github.rest.pulls.list, {
+		...context.repo, state: "open", base: "main", per_page: 100,
+	});
+	const frozen = frozenReleaseCandidates(prs, `${context.repo.owner}/${context.repo.repo}`);
+	core.setOutput("frozen", frozen.length > 0 ? "true" : "false");
+	if (frozen.length) core.info(`Release candidate frozen: ${frozen.map(pr => `#${pr.number}`).join(", ")}. Return it to draft and dispatch Release PR to refresh.`);
+}
+
+export function assertReleaseReady({ needs, eventName, event, currentPr }) {
+	const requireSuccess = name => {
+		if (needs[name]?.result !== "success") throw new Error(`${name} did not pass (${needs[name]?.result ?? "missing"})`);
+	};
+	if (eventName === "pull_request") {
+		if (event.pull_request.draft || !currentPr || currentPr.draft || currentPr.state !== "open") {
+			throw new Error("Not an open, ready candidate; mark ready and run full CI.");
+		}
+		if (currentPr.head.sha !== event.pull_request.head.sha) {
+			throw new Error("The candidate changed; validate its current head commit.");
+		}
+	}
+	requireSuccess("merge-reuse");
+	// Only push runs can reuse exact-tree evidence verified by merge-reuse.
+	if (needs["merge-reuse"].outputs?.reuse === "true") {
+		if (eventName !== "push") throw new Error("PR candidates must run validation.");
+		requireSuccess("promote-browser-sdk");
+		return;
+	}
+	for (const name of ["changelog", "cargo-config", "js-sdk-test"]) requireSuccess(name);
+	// Retain the existing intentional Rust-only skip for SDK TypeScript changes.
+	if (needs.changelog.outputs?.rust === "false") {
+		if (needs.cargo?.result !== "skipped") throw new Error("Unexpected Rust scope result");
+	} else requireSuccess("cargo");
+	if (eventName === "pull_request") {
+		requireSuccess("preview-artifact-changes");
+		const server = needs["preview-artifact-changes"].outputs?.server;
+		if (server === "true") requireSuccess("preview-server-image");
+		else if (server !== "false" || needs["preview-server-image"]?.result !== "skipped") {
+			throw new Error("Unexpected server preview scope result");
+		}
+	}
+}

--- a/scripts/release-candidate.mjs
+++ b/scripts/release-candidate.mjs
@@ -25,6 +25,12 @@ export function assertReleaseReady({ needs, eventName, event, currentPr }) {
 		if (currentPr.head.sha !== event.pull_request.head.sha) {
 			throw new Error("The candidate changed; validate its current head commit.");
 		}
+		const testedBase = event.pull_request.base;
+		const currentBase = currentPr.base;
+		if (!testedBase?.sha || !currentBase?.sha ||
+			currentBase.sha !== testedBase.sha || currentBase.ref !== testedBase.ref) {
+			throw new Error("The base branch changed or is unknown; refresh the candidate and run new CI.");
+		}
 	}
 	requireSuccess("merge-reuse");
 	// Only push runs can reuse exact-tree evidence verified by merge-reuse.

--- a/scripts/release-candidate.test.mjs
+++ b/scripts/release-candidate.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertReleaseReady, checkReleaseFreeze, frozenReleaseCandidates } from "./release-candidate.mjs";
+
+const pr = (overrides = {}) => ({
+	number: 1669, state: "open", draft: false, base: { ref: "main" },
+	head: { ref: "release/v0.15.0", sha: "candidate", repo: { full_name: "opral/lix" } },
+	...overrides,
+});
+
+function validation() {
+	return {
+		eventName: "pull_request", event: { pull_request: pr() }, currentPr: pr(),
+		needs: {
+			"merge-reuse": { result: "success", outputs: { reuse: "false" } },
+			"promote-browser-sdk": { result: "skipped" },
+			changelog: { result: "success", outputs: { rust: "true" } },
+			"cargo-config": { result: "success" }, cargo: { result: "success" },
+			"js-sdk-test": { result: "success" },
+			"preview-artifact-changes": { result: "success", outputs: { server: "true" } },
+			"preview-server-image": { result: "success" },
+		},
+	};
+}
+
+test("any ready release candidate freezes updates, even across version bumps", async () => {
+	const ready = pr();
+	const inputs = [ready, pr({ draft: true }), pr({ state: "closed" }),
+		pr({ base: { ref: "other" } }), pr({ head: { ref: "fix/foo" } }),
+		pr({ head: { ...ready.head, repo: { full_name: "fork/lix" } } })];
+	assert.deepEqual(frozenReleaseCandidates(inputs, "opral/lix"), [ready]);
+	const outputs = {};
+	await checkReleaseFreeze({
+		github: { rest: { pulls: { list() {} } }, paginate: async () => inputs },
+		context: { repo: { owner: "opral", repo: "lix" } },
+		core: { setOutput: (key, value) => { outputs[key] = value; }, info() {} },
+	});
+	assert.equal(outputs.frozen, "true");
+	assert.deepEqual(frozenReleaseCandidates([pr({ draft: true })], "opral/lix"), []);
+});
+
+test("a validated unchanged ready candidate passes", () => {
+	assert.doesNotThrow(() => assertReleaseReady(validation()));
+});
+
+test("failures, cancellations, skipped or missing required jobs never pass", () => {
+	for (const name of ["merge-reuse", "changelog", "cargo-config", "cargo", "js-sdk-test", "preview-artifact-changes", "preview-server-image"]) {
+		for (const result of ["failure", "cancelled", "skipped", undefined]) {
+			const input = validation();
+			input.needs[name].result = result;
+			assert.throws(() => assertReleaseReady(input), /did not pass/);
+		}
+	}
+});
+
+test("draft reruns cannot certify a now-ready PR; changed or withdrawn candidates fail", () => {
+	const draftRerun = validation();
+	draftRerun.event.pull_request.draft = true;
+	assert.throws(() => assertReleaseReady(draftRerun), /ready candidate/);
+	for (const change of [{ draft: true }, { state: "closed" }, { head: { sha: "new-head" } }]) {
+		const input = validation();
+		Object.assign(input.currentPr, change);
+		assert.throws(() => assertReleaseReady(input));
+	}
+});
+
+test("existing explicit SDK-only and unchanged-server scopes remain allowed", () => {
+	const input = validation();
+	input.needs.changelog.outputs.rust = "false";
+	input.needs.cargo.result = "skipped";
+	input.needs["preview-artifact-changes"].outputs.server = "false";
+	input.needs["preview-server-image"].result = "skipped";
+	assert.doesNotThrow(() => assertReleaseReady(input));
+});
+
+test("verified exact-tree reuse is push-only and requires artifact promotion", () => {
+	const input = validation();
+	input.needs["merge-reuse"].outputs.reuse = "true";
+	assert.throws(() => assertReleaseReady(input), /PR candidates/);
+	input.eventName = "push";
+	assert.throws(() => assertReleaseReady(input), /promote-browser-sdk/);
+	input.needs["promote-browser-sdk"].result = "success";
+	assert.doesNotThrow(() => assertReleaseReady(input));
+});
+
+test("unknown or inconsistent preview scope fails closed", () => {
+	const input = validation();
+	delete input.needs["preview-artifact-changes"].outputs.server;
+	assert.throws(() => assertReleaseReady(input), /preview scope/);
+	input.needs["preview-artifact-changes"].outputs.server = "false";
+	input.needs["preview-server-image"].result = "failure";
+	assert.throws(() => assertReleaseReady(input), /preview scope/);
+});

--- a/scripts/release-candidate.test.mjs
+++ b/scripts/release-candidate.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 import { assertReleaseReady, checkReleaseFreeze, frozenReleaseCandidates } from "./release-candidate.mjs";
 
 const pr = (overrides = {}) => ({
-	number: 1669, state: "open", draft: false, base: { ref: "main" },
+	number: 1669, state: "open", draft: false, base: { ref: "main", sha: "tested-base" },
 	head: { ref: "release/v0.15.0", sha: "candidate", repo: { full_name: "opral/lix" } },
 	...overrides,
 });
@@ -71,6 +71,29 @@ test("existing explicit SDK-only and unchanged-server scopes remain allowed", ()
 	input.needs["preview-artifact-changes"].outputs.server = "false";
 	input.needs["preview-server-image"].result = "skipped";
 	assert.doesNotThrow(() => assertReleaseReady(input));
+});
+
+test("an unchanged head cannot certify an advanced or retargeted base", () => {
+	for (const base of [
+		{ ref: "main", sha: "new-base" },
+		{ ref: "other", sha: "tested-base" },
+	]) {
+		const input = validation();
+		input.currentPr.base = base;
+		assert.equal(input.currentPr.head.sha, input.event.pull_request.head.sha);
+		assert.throws(() => assertReleaseReady(input), /base branch changed/);
+	}
+});
+
+test("missing base evidence fails closed on either side", () => {
+	for (const side of ["event", "current"]) {
+		for (const base of [undefined, { ref: "main" }]) {
+			const input = validation();
+			if (side === "event") input.event.pull_request.base = base;
+			else input.currentPr.base = base;
+			assert.throws(() => assertReleaseReady(input), /base branch changed or is unknown/);
+		}
+	}
 });
 
 test("verified exact-tree reuse is push-only and requires artifact promotion", () => {


### PR DESCRIPTION
## Summary
- Leave any ready release candidate untouched by automated release updates, even across target-version changes; recheck before writing and only close superseded drafts.
- Separate cheap draft release metadata validation from full CI, with distinct concurrency groups and check names so old draft reruns cannot cancel or mask ready validation.
- Add a lightweight Release ready aggregate over existing CI results. Reject failed, cancelled, missing, or unexpectedly skipped jobs, stale heads, and withdrawn candidates. Preserve intentional SDK-only scopes and verified push-only exact-tree reuse.
- Document draft -> ready/frozen -> green -> merge, plus explicit return-to-draft refresh.

## Validation
- All 66 Node script tests pass (under one second).
- actionlint v1.7.12 passes for all three changed/new workflows.
- Publish surface, protocol docs, changenotes, and git diff validation pass.
- No engine tests, build matrices, or long-running conformance suites added.

## Rollout
After merging, require Release ready from GitHub Actions in main branch protection, preserving existing rules. The check also runs for normal ready PRs because GitHub requires checks on the target branch. Refresh existing release PR #1669 through the documented draft flow to pick up these workflows before validating it. Branch protection and #1669 have not been changed by this PR.