### PR TITLE
fix: preserve working diff values and directory paths

### DIFF
--- a/.changenotes/fix-working-diff-payloads.md
+++ b/.changenotes/fix-working-diff-payloads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed missing values and directory paths in working diffs.
+
+Default-range `lix_diff` queries now return the requested before and after values and metadata instead of silently returning null or failing to reconstruct directory paths.

--- a/packages/lix/src/hot_state/tracked_head.rs
+++ b/packages/lix/src/hot_state/tracked_head.rs
@@ -2749,7 +2749,10 @@ mod tests {
             delete_head,
             checkpoint,
             checkpoint,
-            &TrackedStateDiffRequest::default(),
+            &TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            },
         )
         .await;
         assert!(
@@ -2784,7 +2787,10 @@ mod tests {
             reinsert_head,
             checkpoint,
             checkpoint,
-            &TrackedStateDiffRequest::default(),
+            &TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            },
         )
         .await;
         assert_eq!(coverage.group_count, 1, "one identity stays dirty");
@@ -2889,7 +2895,10 @@ mod tests {
             segmented_head,
             checkpoint,
             checkpoint,
-            &TrackedStateDiffRequest::default(),
+            &TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            },
         )
         .await;
         assert_eq!(coverage.group_count, 128);
@@ -2981,7 +2990,10 @@ mod tests {
             restore_head,
             checkpoint,
             checkpoint,
-            &TrackedStateDiffRequest::default(),
+            &TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            },
         )
         .await;
         assert_eq!(
@@ -3051,7 +3063,10 @@ mod tests {
             update_head,
             checkpoint,
             checkpoint,
-            &TrackedStateDiffRequest::default(),
+            &TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            },
         )
         .await;
         assert_eq!(diff.diff.entries.len(), 1);
@@ -3134,7 +3149,7 @@ mod tests {
                 file_ids: vec![NullableKeyFilter::Value(file_id.to_string())],
                 ..Default::default()
             },
-            ..Default::default()
+            retain_payloads: false,
         };
         let diff = read_working_diff(
             &storage,
@@ -3304,7 +3319,10 @@ mod tests {
             .working_diff_for_control(
                 branch_id,
                 control(first_head, checkpoint, checkpoint),
-                &TrackedStateDiffRequest::default(),
+                &TrackedStateDiffRequest {
+                    retain_payloads: false,
+                    ..TrackedStateDiffRequest::default()
+                },
             )
             .await
             .expect("first direct diff should read")
@@ -3454,7 +3472,10 @@ mod tests {
             .working_diff_for_control(
                 branch_id,
                 control(no_op_checkpoint, checkpoint, no_op_checkpoint),
-                &TrackedStateDiffRequest::default(),
+                &TrackedStateDiffRequest {
+                    retain_payloads: false,
+                    ..TrackedStateDiffRequest::default()
+                },
             )
             .await
             .expect("no-op checkpoint direct diff should read")
@@ -3475,7 +3496,7 @@ mod tests {
                         row_pks: vec![row_pk.clone()],
                         ..TrackedStateFilter::default()
                     },
-                    ..TrackedStateDiffRequest::default()
+                    retain_payloads: false,
                 },
             )
             .await
@@ -3548,7 +3569,10 @@ mod tests {
             .working_diff_for_control(
                 branch_id,
                 control(second_head, checkpoint, no_op_checkpoint),
-                &TrackedStateDiffRequest::default(),
+                &TrackedStateDiffRequest {
+                    retain_payloads: false,
+                    ..TrackedStateDiffRequest::default()
+                },
             )
             .await
             .expect("second direct diff should read")
@@ -3589,13 +3613,16 @@ mod tests {
             .await
             .expect("commit same-generation stale epoch");
         for request in [
-            TrackedStateDiffRequest::default(),
+            TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            },
             TrackedStateDiffRequest {
                 filter: TrackedStateFilter {
                     row_pks: vec![row_pk.clone()],
                     ..Default::default()
                 },
-                ..Default::default()
+                retain_payloads: false,
             },
         ] {
             let read = storage
@@ -3641,7 +3668,10 @@ mod tests {
             .working_diff_for_control(
                 branch_id,
                 control(second_head, checkpoint, no_op_checkpoint),
-                &TrackedStateDiffRequest::default(),
+                &TrackedStateDiffRequest {
+                    retain_payloads: false,
+                    ..TrackedStateDiffRequest::default()
+                },
             )
             .await
             .expect("uncertified coverage should not error")

--- a/packages/lix/src/hot_state/tracked_head/hot.rs
+++ b/packages/lix/src/hot_state/tracked_head/hot.rs
@@ -5313,9 +5313,68 @@ where
         else {
             return Ok(None);
         };
+        // HOT_DIFF classifies changed identities without retaining payload bytes.
+        // Consumers projecting values need the exact live changes on both sides,
+        // not a replay of the checkpoint/head history. Use the same validated
+        // local-change/physical-owner lookup as working-diff comparisons.
+        let diff = if request.retain_payloads {
+            let mut changes: BTreeMap<
+                ChangeId,
+                crate::tracked_state::AuthoritativeLiveChangeRequest,
+            > = BTreeMap::new();
+            for row in entries.iter().flat_map(|entry| {
+                [
+                    entry.visible_before(),
+                    entry.after.as_ref().filter(|row| !row.deleted),
+                ]
+                .into_iter()
+                .flatten()
+            }) {
+                let key = TrackedStateKey {
+                    schema_key: row.identity.schema_key().to_owned(),
+                    file_id: row.identity.file_id().map(str::to_owned),
+                    row_pk: row.identity.row_pk().clone(),
+                };
+                if let Some(existing) = changes.get(&row.change_id) {
+                    if existing.key != key || existing.updated_at != row.updated_at {
+                        return Err(LixError::new(
+                            LixError::CODE_INTERNAL_ERROR,
+                            format!(
+                                "working diff contains conflicting identities or lifetimes for change '{}'",
+                                row.change_id
+                            ),
+                        ));
+                    }
+                } else {
+                    changes.insert(
+                        row.change_id,
+                        crate::tracked_state::AuthoritativeLiveChangeRequest {
+                            change_id: row.change_id,
+                            source_commit_id: row.commit_id,
+                            key,
+                            updated_at: row.updated_at,
+                        },
+                    );
+                }
+            }
+            let requests = changes.into_values().collect::<Vec<_>>();
+            let records = crate::tracked_state::load_authoritative_live_change_records(
+                &self.store,
+                &requests,
+            )
+            .await?;
+            let payloads = crate::tracked_state::TrackedStatePayloadBatch::from_payloads(
+                records
+                    .into_iter()
+                    .map(|record| (record.change_id, record.snapshot, record.metadata)),
+            )?;
+            TrackedStateDiff::from_entries_with_payloads(entries, payloads)
+        } else {
+            TrackedStateDiff::from_entries(entries)
+        };
         Ok(Some(TrackedWorkingDiff {
             checkpoint_commit_id: epoch.checkpoint_commit_id,
-            diff: TrackedStateDiff::from_entries(entries),
+            diff,
         }))
     }
 

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -509,6 +509,10 @@ where
                         direct_candidates,
                     )
                     .await?;
+                    if route.request.retain_payloads {
+                        diff.validate_live_payloads()
+                            .map_err(lix_error_to_datafusion_error)?;
+                    }
                     let (from_global_rows, to_global_rows) = if needs_global_provenance {
                         (from_global_rows, to_global_rows)
                     } else {

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -9040,7 +9040,14 @@ mod tests {
             .expect("active branch control should exist");
         TrackedHeadContext::new()
             .reader(&read)
-            .working_diff_for_control(&branch_id, control, &TrackedStateDiffRequest::default())
+            .working_diff_for_control(
+                &branch_id,
+                control,
+                &TrackedStateDiffRequest {
+                    retain_payloads: false,
+                    ..TrackedStateDiffRequest::default()
+                },
+            )
             .await
             .expect("working diff should remain readable")
             .expect("certified working diff should be installed")

--- a/packages/lix/src/sync/simulation_tests.rs
+++ b/packages/lix/src/sync/simulation_tests.rs
@@ -617,6 +617,101 @@ async fn lazy_history_and_binary_cas_scenarios(sim: Simulation) {
     assert!(!checkpoints.rows().is_empty());
 }
 
+#[test]
+fn sparse_working_diff_retains_payloads_without_authored_history_base() {
+    run_sync_simulation(
+        concat!(module_path!(), "::sparse_working_diff_retains_payloads_without_authored_history"),
+        sparse_working_diff_retains_payloads_without_authored_history,
+    );
+}
+
+async fn sparse_working_diff_retains_payloads_without_authored_history(_sim: Simulation) {
+    let authority = fresh_authority().await;
+    write_key_value(&authority, "modified", "before").await;
+    authority
+        .execute("INSERT INTO lix_directory (path) VALUES ('/docs/original')", &[])
+        .await
+        .expect("baseline directory should insert");
+    let checkpoint = authority.create_checkpoint().await.expect("checkpoint should commit").commit_id;
+    let mut authored_commits = Vec::new();
+    for sql in [
+        "UPDATE lix_key_value SET value = 'after' WHERE key = 'modified'",
+        "UPDATE lix_directory SET path = '/docs/renamed' WHERE path = '/docs/original'",
+    ] {
+        authority.execute(sql, &[]).await.expect("working edit should commit");
+        authored_commits.push(
+            authority
+                .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+                .await
+                .expect("authored owner should resolve")
+                .rows()[0]
+                .get::<String>("id")
+                .expect("authored owner should decode"),
+        );
+    }
+    // Keep both payload owners behind the exact head body included by snapshot
+    // bootstrap. The replica receives their live payloads, not authored history.
+    write_key_value(&authority, "tail", "head").await;
+    let replica = Replica::bootstrap(AuthorityTransport::connected(authority)).await;
+    replica.transport.set_offline(true);
+    let head = replica
+        .lix
+        .execute("SELECT lix_active_branch_commit_id() AS id", &[])
+        .await
+        .expect("replica head should resolve")
+        .rows()[0]
+        .get::<String>("id")
+        .expect("replica head should decode");
+    for owner in &authored_commits {
+        let error = replica.lix.sync_history(owner, 1).await
+            .expect_err("fixture must omit the authored payload owner body");
+        assert_eq!(error.code, "LIX_SYNC_HISTORY_REQUIRED");
+    }
+
+    crate::tracked_state::arm_diff_commits_test_probe(&checkpoint, &head);
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    let identities = replica.lix.execute(
+        "SELECT key FROM lix_diff('lix_key_value') WHERE key = 'modified'", &[],
+    ).await.expect("identity-only working diff should remain local");
+    assert_eq!(identities.rows().len(), 1);
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "identity-only working diff must not load cold payload owners",
+    );
+
+    crate::tracked_state::arm_point_replay_authority_batch_probe_for_test();
+    let values = replica.lix.execute(
+        "SELECT from_value, to_value FROM lix_diff('lix_key_value') WHERE key = 'modified'", &[],
+    ).await.expect("working values should use snapshot-local payloads while offline");
+    assert_eq!(values.rows().len(), 1);
+    assert_eq!(values.rows()[0].get::<serde_json::Value>("from_value").unwrap(), serde_json::json!("before"));
+    assert_eq!(values.rows()[0].get::<serde_json::Value>("to_value").unwrap(), serde_json::json!("after"));
+    assert!(
+        crate::tracked_state::take_point_replay_authority_batch_probe_for_test().is_empty(),
+        "snapshot-local generic payloads must not load their cold authored owners",
+    );
+
+    let directories = replica.lix.execute(
+        "SELECT from_name, to_name, from_path, to_path FROM lix_diff('lix_directory')", &[],
+    ).await.expect("working directory paths should use local endpoint snapshots while offline");
+    assert_eq!(directories.rows().len(), 1);
+    for (column, expected) in [
+        ("from_name", "original"), ("to_name", "renamed"),
+        ("from_path", "/docs/original"), ("to_path", "/docs/renamed"),
+    ] {
+        assert_eq!(directories.rows()[0].get::<String>(column).unwrap(), expected);
+    }
+    assert_eq!(
+        crate::tracked_state::take_diff_commits_test_probe(&checkpoint, &head), 0,
+        "payload projections must not reconstruct the certified working interval",
+    );
+    for owner in &authored_commits {
+        let error = replica.lix.sync_history(owner, 1).await
+            .expect_err("working payload reads must leave authored history cold");
+        assert_eq!(error.code, "LIX_SYNC_HISTORY_REQUIRED");
+    }
+}
+
 async fn sparse_partial_checkpoint_uses_hot_working_diff(_sim: Simulation) {
     let authority = fresh_authority().await;
     write_key_value(&authority, "selected", "baseline").await;

--- a/packages/lix/src/tracked_state/diff.rs
+++ b/packages/lix/src/tracked_state/diff.rs
@@ -371,6 +371,24 @@ impl TrackedStateDiff {
     pub(crate) fn payloads(&self) -> &TrackedStatePayloadBatch {
         &self.payloads
     }
+
+    /// Payload projections must distinguish an absent row from an unloaded
+    /// live row. Otherwise an identity-only result can silently become SQL NULL.
+    pub(crate) fn validate_live_payloads(&self) -> Result<(), LixError> {
+        for row in self.entries.iter().flat_map(|entry| {
+            [entry.visible_before(), entry.after.as_ref().filter(|row| !row.deleted)]
+                .into_iter()
+                .flatten()
+        }) {
+            if self.payloads.get(row.change_id).and_then(|payload| payload.snapshot).is_none() {
+                return Err(LixError::new(
+                    LixError::CODE_INTERNAL_ERROR,
+                    format!("tracked-state diff is missing the requested live payload for change '{}'", row.change_id),
+                ));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Diffs two tracked-state commit roots with hash-guided subtree skipping.
@@ -1395,6 +1413,44 @@ mod tests {
 
     fn change_id(label: &str) -> String {
         ChangeId::for_test_label(label).to_string()
+    }
+
+    #[test]
+    fn requested_payloads_reject_unloaded_live_rows_but_allow_absent_sides() {
+        let identity = TrackedStateDiffIdentity::from_key(TrackedStateKey {
+            schema_key: "test_schema".into(),
+            file_id: None,
+            row_pk: RowPk::single("row"),
+        });
+        let change_id = ChangeId::for_test_label("live-payload");
+        let row = TrackedStateDiffRow {
+            identity: identity.clone(),
+            deleted: false,
+            created_at: ts("2024-01-01T00:00:00.000Z"),
+            updated_at: ts("2024-01-01T00:00:00.000Z"),
+            change_id,
+            commit_id: CommitId::for_test_label("payload-commit"),
+        };
+        let entry = TrackedStateDiffEntry {
+            identity,
+            kind: TrackedStateDiffKind::Added,
+            before: None,
+            after: Some(row),
+        };
+        let missing = TrackedStateDiff::from_entries(vec![entry.clone()]);
+        assert!(missing.validate_live_payloads().is_err());
+        let tombstone_payload = TrackedStatePayloadBatch::from_payloads([(change_id, None, None)])
+            .expect("payload batch");
+        assert!(TrackedStateDiff::from_entries_with_payloads(vec![entry.clone()], tombstone_payload)
+            .validate_live_payloads().is_err());
+        let live_payload = TrackedStatePayloadBatch::from_payloads([(change_id, Some(vec![1]), None)])
+            .expect("payload batch with nullable metadata");
+        TrackedStateDiff::from_entries_with_payloads(vec![entry.clone()], live_payload)
+            .validate_live_payloads().expect("live snapshot is retained");
+        let mut deleted = entry;
+        deleted.after.as_mut().expect("after row").deleted = true;
+        TrackedStateDiff::from_entries(vec![deleted])
+            .validate_live_payloads().expect("absent sides need no live payload");
     }
 
     async fn stage_snapshot_authority_for_test(

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -9374,11 +9374,13 @@ pub(crate) async fn load_commit_delta_change_records_for_owners(
         .collect())
 }
 
-/// The complete address of one live change payload.
+/// Identity and endpoint provenance of one live change payload.
 ///
 /// The change id addresses the ordinary local changelog. The source commit and
-/// row identity address the immutable physical fallback used by compact or
-/// deferred history. The timestamp prevents a same-identity record from a
+/// row identity address an immutable fallback used by compact or deferred
+/// history. The endpoint can name a checkpoint rather than the authored owner;
+/// an encoded change address supplies a second exact owner candidate.
+/// The timestamp prevents a same-identity record from a
 /// different row lifetime from being accepted as the requested payload.
 pub(crate) struct AuthoritativeLiveChangeRequest {
     pub(crate) change_id: crate::changelog::ChangeId,
@@ -9388,7 +9390,9 @@ pub(crate) struct AuthoritativeLiveChangeRequest {
 }
 
 /// Resolves live payloads from local changelog authority first, then co-loads
-/// only the exact physical owners that were absent or did not match.
+/// only the exact physical owners that were absent or did not match. Encoded
+/// change owners and endpoint owners are candidates, never trusted payloads:
+/// every result must match the requested identity and lifetime.
 ///
 /// Both paths apply the same identity and lifetime validation. Callers decide
 /// which changes need payloads; this function is the single authority policy
@@ -9433,16 +9437,69 @@ pub(crate) async fn load_authoritative_live_change_records(
             fallback_indices.push(index);
         }
     }
-    let owner_requests = fallback_indices
-        .iter()
-        .map(|&index| {
-            let request = &requests[index];
-            (request.source_commit_id, request.key.clone())
-        })
-        .collect::<Vec<_>>();
+    let mut owner_requests = Vec::new();
+    let mut owner_outputs = Vec::new();
+    for index in fallback_indices {
+        let request = &requests[index];
+        if let Some(locator) = direct_change_locator(request.change_id)
+            && locator.commit_id != request.source_commit_id
+        {
+            // A checkpoint can rebase logical provenance without rewriting
+            // the change ID. Resolve its authored owner directly, not by
+            // replaying the endpoint's ancestry.
+            owner_requests.push((locator.commit_id, request.key.clone()));
+            owner_outputs.push(index);
+        }
+        owner_requests.push((request.source_commit_id, request.key.clone()));
+        owner_outputs.push(index);
+    }
     let fallback = load_commit_delta_change_records_for_owners(store, &owner_requests).await?;
-    for (index, record) in fallback_indices.into_iter().zip(fallback) {
-        records[index] = record;
+    for (index, record) in owner_outputs.into_iter().zip(fallback) {
+        if record
+            .as_ref()
+            .is_some_and(|record| authoritative_live_change_matches(&requests[index], record))
+        {
+            records[index] = record;
+        }
+    }
+    // Non-direct change IDs can outlive their standalone record as well. Their
+    // explicit locator names an exact owner; it does not require walking the
+    // logical checkpoint's history. Keep this lookup off the ordinary path.
+    let unresolved = records
+        .iter()
+        .enumerate()
+        .filter_map(|(index, record)| record.is_none().then_some(index))
+        .collect::<Vec<_>>();
+    if !unresolved.is_empty() {
+        let keys = unresolved
+            .iter()
+            .map(|&index| {
+                StorageKey(Bytes::copy_from_slice(
+                    requests[index].change_id.as_uuid().as_bytes(),
+                ))
+            })
+            .collect::<Vec<_>>();
+        let locators = PointReadPlan::new(TRACKED_STATE_CHANGE_LOCATOR_SPACE, &keys)
+            .materialize(store, StorageGetOptions::default())
+            .await?;
+        let mut owners = Vec::new();
+        let mut outputs = Vec::new();
+        for (index, value) in unresolved.into_iter().zip(locators.value) {
+            if let Some(bytes) = value.and_then(full_value_bytes) {
+                let locator = decode_change_locator(requests[index].change_id, &bytes)?;
+                owners.push((locator.commit_id, requests[index].key.clone()));
+                outputs.push(index);
+            }
+        }
+        let located = load_commit_delta_change_records_for_owners(store, &owners).await?;
+        for (index, record) in outputs.into_iter().zip(located) {
+            if record
+                .as_ref()
+                .is_some_and(|record| authoritative_live_change_matches(&requests[index], record))
+            {
+                records[index] = record;
+            }
+        }
     }
     requests
         .iter()
@@ -18569,6 +18626,123 @@ mod tests {
                 .await
                 .expect("missing exact locator read should succeed")
                 .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn live_payload_resolves_authored_owner_after_checkpoint_rebases_provenance() {
+        let storage = StorageAdapter::new(Memory::new());
+        let authored = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+            0x0192_0000_0000_7000_8000_1234_0000_0000,
+        ));
+        let checkpoint = CommitId::for_test_label("live-payload-checkpoint");
+        let fixture = packed_commit_delta_fixtures().into_iter().nth(1).unwrap();
+        let mut writes = storage.new_write_set();
+        let deltas = commit_delta_refs(authored, std::slice::from_ref(&fixture));
+        let staged = stage_addressable_commit_deltas(&mut writes, &deltas, &[true]).unwrap();
+        let requested_change = staged.assigned_change_ids[0];
+        assert!(staged.locators.is_empty());
+        // The same endpoint identity can name another change. It must not
+        // replace a matching record already found at the encoded owner.
+        let other_deltas = commit_delta_refs(checkpoint, std::slice::from_ref(&fixture));
+        stage_addressable_commit_deltas(&mut writes, &other_deltas, &[false]).unwrap();
+        storage
+            .commit_write_set(writes, StorageWriteOptions::default())
+            .await
+            .unwrap();
+        let read = storage
+            .begin_read(StorageReadOptions::default())
+            .await
+            .unwrap();
+        let loaded = super::load_authoritative_live_change_records(
+            &read,
+            &[super::AuthoritativeLiveChangeRequest {
+                change_id: requested_change,
+                source_commit_id: checkpoint,
+                key: fixture.key(),
+                updated_at: fixture.updated_at,
+            }],
+        )
+        .await
+        .expect("logical checkpoint provenance must resolve the authored change");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].change_id, requested_change);
+        assert_eq!(
+            loaded[0].snapshot.as_deref(),
+            Some(b"typed-live-fixture".as_slice())
+        );
+        let wrong_lifetime = super::load_authoritative_live_change_records(
+            &read,
+            &[super::AuthoritativeLiveChangeRequest {
+                change_id: requested_change,
+                source_commit_id: checkpoint,
+                key: fixture.key(),
+                updated_at: fixture.created_at,
+            }],
+        )
+        .await;
+        assert!(
+            wrong_lifetime.is_err(),
+            "an owner hint must not bypass lifetime validation"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_payload_uses_explicit_locator_when_owner_candidates_do_not_match() {
+        for address_shaped in [false, true] {
+            let storage = StorageAdapter::new(Memory::new());
+            let hinted_owner = CommitId::with_change_address_space(uuid::Uuid::from_u128(
+                0x0192_0000_0000_7000_8000_4321_0000_0000,
+            ));
+            let explicit_owner = CommitId::for_test_label("live-payload-explicit-owner");
+            let endpoint = CommitId::for_test_label("live-payload-logical-endpoint");
+            let other = packed_commit_delta_fixtures().into_iter().nth(1).unwrap();
+            let mut requested = other.clone();
+            requested.change_id = if address_shaped {
+                super::addressable_change_id(hinted_owner, 0, 0).unwrap()
+            } else {
+                // A non-direct ID is valid legacy/selected payload identity.
+                ChangeId::new(uuid::Uuid::from_u128(
+                    0x0192_0000_0000_7000_8000_9876_0000_0000,
+                ))
+            };
+            let mut writes = storage.new_write_set();
+            // Both guessed and supplied owners contain the same key but the
+            // wrong change. Neither is sufficient authority for this request.
+            for owner in [hinted_owner, endpoint] {
+                let deltas = commit_delta_refs(owner, std::slice::from_ref(&other));
+                stage_addressable_commit_deltas(&mut writes, &deltas, &[false]).unwrap();
+            }
+            let deltas = commit_delta_refs(explicit_owner, std::slice::from_ref(&requested));
+            let staged = stage_addressable_commit_deltas(&mut writes, &deltas, &[false]).unwrap();
+            assert_eq!(staged.locators.len(), 1);
+            stage_change_locators(&mut writes, &staged.locators);
+            storage
+                .commit_write_set(writes, StorageWriteOptions::default())
+                .await
+                .unwrap();
+            let read = storage
+                .begin_read(StorageReadOptions::default())
+                .await
+                .unwrap();
+            let loaded = super::load_authoritative_live_change_records(
+                &read,
+                &[super::AuthoritativeLiveChangeRequest {
+                    change_id: requested.change_id,
+                    source_commit_id: endpoint,
+                    key: requested.key(),
+                    updated_at: requested.updated_at,
+                }],
+            )
+            .await
+            .expect("mismatched owner candidates must not suppress explicit locator resolution");
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(loaded[0].change_id, requested.change_id);
+            assert_eq!(loaded[0].row_pk, requested.row_pk);
+            assert_eq!(
+                loaded[0].snapshot.as_deref(),
+                Some(b"typed-live-fixture".as_slice())
             );
         }
     }

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -9010,7 +9010,10 @@ where
             // schema registration, parent directory, FK target, or unique
             // value owner outside the explicitly selected relation.
             requests.clear();
-            requests.push(TrackedStateDiffRequest::default());
+            requests.push(TrackedStateDiffRequest {
+                retain_payloads: false,
+                ..TrackedStateDiffRequest::default()
+            });
         }
 
         let source = selections
@@ -9495,7 +9498,10 @@ where
                     .working_diff_for_control(
                         &branch_id,
                         control,
-                        &TrackedStateDiffRequest::default(),
+                        &TrackedStateDiffRequest {
+                            retain_payloads: false,
+                            ..TrackedStateDiffRequest::default()
+                        },
                     )
                     .await?;
                 let hot_working_diff_certified = direct_diff.is_some();
@@ -9507,7 +9513,10 @@ where
                             .diff_commits(
                                 &previous_checkpoint_commit_id.to_string(),
                                 &head_commit_id.to_string(),
-                                &TrackedStateDiffRequest::default(),
+                                &TrackedStateDiffRequest {
+                                    retain_payloads: false,
+                                    ..TrackedStateDiffRequest::default()
+                                },
                             )
                             .await?
                     }

--- a/packages/lix/tests/integration/sql/diff_relation.rs
+++ b/packages/lix/tests/integration/sql/diff_relation.rs
@@ -725,3 +725,142 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    working_diff_retains_relation_payloads_on_both_sides,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value, lixcol_metadata) VALUES \
+                 ('modified', 'before', '{\"stage\":\"before\"}'), ('removed', 'deleted', NULL)",
+                &[],
+            )
+            .await
+            .expect("baseline rows should insert");
+        session.create_checkpoint().await.expect("checkpoint should succeed");
+        for sql in [
+            "INSERT INTO lix_key_value (key, value) VALUES ('added', 'new')",
+            "UPDATE lix_key_value SET value = 'after', lixcol_metadata = '{\"stage\":\"after\"}' WHERE key = 'modified'",
+            "DELETE FROM lix_key_value WHERE key = 'removed'",
+        ] {
+            session.execute(sql, &[]).await.expect("working edit should succeed");
+        }
+        assert_eq!(
+            select_rows(&session,
+                "SELECT key, diff_type FROM lix_diff('lix_key_value') ORDER BY key"
+            ).await,
+            vec![
+                vec![Value::Text("added".into()), Value::Text("added".into())],
+                vec![Value::Text("modified".into()), Value::Text("modified".into())],
+                vec![Value::Text("removed".into()), Value::Text("removed".into())],
+            ],
+            "identity-only projections must preserve the same changed rows",
+        );
+        let projection = "key, diff_type, from_value, to_value, from_lixcol_global, to_lixcol_global";
+        let expected = vec![
+            vec![
+                Value::Text("added".into()), Value::Text("added".into()),
+                Value::Null, Value::Jsonb(json!("new").into()),
+                Value::Null, Value::Boolean(false),
+            ],
+            vec![
+                Value::Text("modified".into()), Value::Text("modified".into()),
+                Value::Jsonb(json!("before").into()), Value::Jsonb(json!("after").into()),
+                Value::Boolean(false), Value::Boolean(false),
+            ],
+            vec![
+                Value::Text("removed".into()), Value::Text("removed".into()),
+                Value::Jsonb(json!("deleted").into()), Value::Null,
+                Value::Boolean(false), Value::Null,
+            ],
+        ];
+        for arguments in [
+            "'lix_key_value'",
+            "'lix_key_value', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()",
+        ] {
+            assert_eq!(
+                select_rows(&session, &format!(
+                    "SELECT {projection} FROM lix_diff({arguments}) ORDER BY key"
+                )).await,
+                expected,
+                "working and explicit ranges must preserve payload values and side presence: {arguments}",
+            );
+        }
+        assert_eq!(
+            select_rows(&session,
+                "SELECT from_lixcol_metadata, to_lixcol_metadata \
+                 FROM lix_diff('lix_key_value') WHERE key = 'modified'"
+            ).await,
+            vec![vec![
+                Value::Jsonb(json!({"stage": "before"}).into()),
+                Value::Jsonb(json!({"stage": "after"}).into()),
+            ]],
+            "metadata must be loaded from each side's exact change",
+        );
+        assert_eq!(
+            select_rows(&session,
+                "SELECT key FROM lix_diff('lix_key_value') WHERE from_value IS NOT NULL AND to_value IS NOT NULL"
+            ).await,
+            vec![vec![Value::Text("modified".into())]],
+            "payloads used only by a predicate must also be retained",
+        );
+    }
+);
+
+simulation_test!(
+    working_diff_retains_directory_descriptors_on_both_sides,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_directory (path) VALUES ('/docs/original'), ('/docs/removed')",
+                &[],
+            )
+            .await
+            .expect("nested baseline directories should insert");
+        session.create_checkpoint().await.expect("checkpoint should succeed");
+        for sql in [
+            "INSERT INTO lix_directory (path) VALUES ('/docs/added')",
+            "UPDATE lix_directory SET path = '/docs/renamed' WHERE path = '/docs/original'",
+            "DELETE FROM lix_directory WHERE path = '/docs/removed'",
+        ] {
+            session.execute(sql, &[]).await.expect("working edit should succeed");
+        }
+        let expected = vec![
+            vec![
+                Value::Text("added".into()), Value::Null, Value::Text("added".into()),
+                Value::Null, Value::Text("/docs/added".into()),
+            ],
+            vec![
+                Value::Text("removed".into()), Value::Text("removed".into()), Value::Null,
+                Value::Text("/docs/removed".into()), Value::Null,
+            ],
+            vec![
+                Value::Text("modified".into()), Value::Text("original".into()), Value::Text("renamed".into()),
+                Value::Text("/docs/original".into()), Value::Text("/docs/renamed".into()),
+            ],
+        ];
+        for arguments in [
+            "'lix_directory'",
+            "'lix_directory', lix_latest_checkpoint_commit_id(), lix_active_branch_commit_id()",
+        ] {
+            assert_eq!(
+                select_rows(&session, &format!(
+                    "SELECT diff_type, from_name, to_name, from_path, to_path \
+                     FROM lix_diff({arguments}) ORDER BY coalesce(to_path, from_path)"
+                )).await,
+                expected,
+                "working and explicit ranges must reconstruct paths through unchanged parents: {arguments}",
+            );
+        }
+    }
+);


### PR DESCRIPTION
Default working diffs could identify changed rows while omitting their payloads: directory paths failed with “filesystem descriptor is missing its snapshot,” and ordinary values and metadata silently became null. Working diffs now honor requested payload retention, and SQL rejects incomplete live payloads instead of treating them as null.

Resolve payloads through validated local records and exact physical owners. Checkpoint provenance can differ from the authored owner, so the shared resolver checks encoded owners, endpoint owners, and explicit locators without replaying commit ancestry. Identity-only queries and checkpoint selection continue to avoid payload loading.

Validation: 3,497 Lix tests passed with `cargo nextest run -p lix --features all-simulations` (76 existing skips), and all 10 documentation tests passed. Regression coverage includes values, metadata, additions/modifications/deletions, payload predicates, nested directory paths, checkpoint-rebased owners, explicit locators, invalid timestamps, and an offline sparse replica with authored history unavailable. Two independent sub-agent reviews approved the final design and implementation.
