### PR TITLE
fix: read staged binary snapshots consistently

### DIFF
--- a/.changenotes/fix-transaction-predicate-reads.md
+++ b/.changenotes/fix-transaction-predicate-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed SQL filters missing rows inserted or updated within the same transaction.
+
+Queries, including CTEs, now evaluate predicates against staged values consistently. Updates and deletes that select rows by those values also see earlier writes in the transaction.

--- a/.changenotes/fix-transaction-predicate-reads.md
+++ b/.changenotes/fix-transaction-predicate-reads.md
@@ -5,3 +5,5 @@ type: patch
 Fixed SQL filters missing rows inserted or updated within the same transaction.
 
 Queries, including CTEs, now evaluate predicates against staged values consistently. Updates and deletes that select rows by those values also see earlier writes in the transaction.
+
+Branch deletion now respects default-branch changes made in the same transaction, and plugin file materialization recognizes staged binary blob references without losing their durable proof.

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -11978,6 +11978,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transaction_declared_column_filters_see_staged_rows() {
+        let session = open_session().await;
+        let schema = serde_json::json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": "transaction_filter_probe",
+            "columns": [
+                { "name": "id", "type": "text", "nullable": false },
+                { "name": "locale", "type": "text", "nullable": false },
+                { "name": "count", "type": "int8", "nullable": false }
+            ],
+            "primary_key": ["id"]
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (value) VALUES (CAST($1 AS JSONB))",
+                &[Value::Text(schema.to_string())],
+            )
+            .await
+            .expect("register schema");
+        session.execute(
+            "INSERT INTO transaction_filter_probe (id, locale, count) VALUES ('existing', 'de', 1)",
+            &[],
+        ).await.expect("seed committed row");
+        let mut transaction = session
+            .begin_transaction()
+            .await
+            .expect("begin transaction");
+        transaction
+            .execute(
+                "INSERT INTO transaction_filter_probe (id, locale, count) VALUES ('new', 'en', 7)",
+                &[],
+            )
+            .await
+            .expect("stage inserted row");
+        for sql in [
+            "SELECT id FROM transaction_filter_probe WHERE locale = 'en'",
+            "SELECT id FROM transaction_filter_probe WHERE locale IN ('en', 'fr')",
+            "SELECT id FROM transaction_filter_probe WHERE count > 6",
+            "WITH matching AS (SELECT id FROM transaction_filter_probe WHERE locale = 'en') SELECT id FROM matching",
+        ] {
+            let result = transaction
+                .execute(sql, &[])
+                .await
+                .expect("read staged row");
+            assert_eq!(result.len(), 1, "{sql}");
+            assert_eq!(
+                result.rows()[0].get::<String>("id").unwrap(),
+                "new",
+                "{sql}"
+            );
+        }
+        transaction.execute(
+            "UPDATE transaction_filter_probe SET locale = 'en', count = 8 WHERE id = 'existing'",
+            &[],
+        ).await.expect("stage updated row");
+        let matching = transaction
+            .execute(
+                "SELECT id FROM transaction_filter_probe WHERE locale = $1 ORDER BY id",
+                &[Value::Text("en".into())],
+            )
+            .await
+            .expect("read inserted and updated rows");
+        assert_eq!(matching.len(), 2);
+        let old_value = transaction
+            .execute(
+                "SELECT id FROM transaction_filter_probe WHERE locale = 'de'",
+                &[],
+            )
+            .await
+            .expect("staged update masks committed value");
+        assert!(old_value.is_empty());
+        transaction
+            .execute("DELETE FROM transaction_filter_probe WHERE count = 7", &[])
+            .await
+            .expect("delete by staged non-primary value");
+        let remaining = transaction
+            .execute(
+                "SELECT id FROM transaction_filter_probe WHERE locale = 'en'",
+                &[],
+            )
+            .await
+            .expect("deleted rows stay hidden");
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining.rows()[0].get::<String>("id").unwrap(), "existing");
+        transaction.rollback().await.expect("roll back transaction");
+        let committed = session
+            .execute(
+                "SELECT id FROM transaction_filter_probe WHERE locale = 'de'",
+                &[],
+            )
+            .await
+            .expect("rollback preserves original row");
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed.rows()[0].get::<String>("id").unwrap(), "existing");
+    }
+
+    #[tokio::test]
     async fn transaction_referenced_provider_reads_see_staged_writes() {
         let session = open_session().await;
         let mut transaction = session

--- a/packages/lix/src/sql2/providers/branch.rs
+++ b/packages/lix/src/sql2/providers/branch.rs
@@ -1048,20 +1048,21 @@ async fn load_default_branch_id(write_ctx: &SqlWriteContext) -> Result<String> {
         })
         .await
         .map_err(lix_error_to_datafusion_error)?;
-    let snapshot = rows
-        .row(0)
-        .and_then(MaterializedHotStateRowRef::snapshot_content)
+    let row = rows.row(0).ok_or_else(|| {
+        DataFusionError::Execution("repository default branch is missing".to_string())
+    })?;
+    // Transaction-local key/value updates can retain only a binary snapshot.
+    // Read the logical value independently of its serving representation.
+    let snapshot = row
+        .snapshot_json_value()
+        .map_err(lix_error_to_datafusion_error)?
         .ok_or_else(|| {
             DataFusionError::Execution("repository default branch is missing".to_string())
         })?;
-    serde_json::from_str::<JsonValue>(snapshot)
-        .ok()
-        .and_then(|value| {
-            value
-                .get("value")
-                .and_then(JsonValue::as_str)
-                .map(str::to_owned)
-        })
+    snapshot
+        .get("value")
+        .and_then(JsonValue::as_str)
+        .map(str::to_owned)
         .filter(|value| !value.is_empty())
         .ok_or_else(|| {
             DataFusionError::Execution("repository default branch is invalid".to_string())

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -3551,8 +3551,8 @@ fn apply_row_batch_filters(
     // a deletion slot so later layers can reconcile it; compact those slots
     // before Arrow projection even when the SQL query has no predicate.
     let rows = rows.filter(|row| !row.deleted(), None);
-    validate_typed_row_schema_bindings(spec, &rows)?;
     if filters.is_empty() {
+        validate_typed_row_schema_bindings(spec, &rows)?;
         return Ok(FilteredRowBatch { rows });
     }
     let mut filter_columns = BTreeSet::new();
@@ -3569,7 +3569,21 @@ fn apply_row_batch_filters(
             if failure.is_some() {
                 return false;
             }
-            if let Some(typed) = row.decoded_snapshot() {
+            // Staged mutation journals retain durable binary payloads, while
+            // committed scans may already have decoded rows. A predicate must
+            // see the same logical values in either representation.
+            let typed = match row.materialize_decoded_snapshot() {
+                Ok(typed) => typed,
+                Err(error) => {
+                    failure = Some(lix_error_to_datafusion_error(error));
+                    return false;
+                }
+            };
+            if let Some(typed) = typed {
+                if let Err(error) = validate_typed_row_schema_binding(spec, row.schema_key(), &typed) {
+                    failure = Some(error);
+                    return false;
+                }
                 for filter in filters {
                     match filter.matches_typed(&typed.row, row.schema_key()) {
                         Ok(true) => {}
@@ -5008,6 +5022,59 @@ mod tests {
             })),
         );
         batch.finish()
+    }
+
+    fn raw_typed_binding_test_batch(schema_fingerprint: [u8; 32]) -> MaterializedHotStateBatch {
+        let rows = typed_binding_test_batch("project_message", schema_fingerprint);
+        let row = rows.iter().next().expect("one typed row");
+        let payload = row
+            .decoded_snapshot()
+            .unwrap()
+            .durable_payload()
+            .expect("encode row");
+        let mut builder = crate::hot_state::MaterializedHotStateBatchBuilder::with_capacity(1);
+        builder.push_ref(row, None);
+        builder.set_decoded_snapshot(0, None);
+        builder.set_raw_snapshot(0, Some(Bytes::copy_from_slice(&payload)));
+        builder.finish()
+    }
+
+    #[test]
+    fn raw_typed_row_filters_match_decoded_rows() {
+        let spec = typed_binding_test_spec();
+        for (value, expected) in [("hello", 1), ("other", 0)] {
+            let filter = super::RowFilter::ColumnEq {
+                column: "body".to_owned(),
+                column_type: SchemaColumnType::String,
+                value: super::RowFilterValue::String(value.to_owned()),
+            };
+            let rows = raw_typed_binding_test_batch(spec.schema_fingerprint);
+            let filtered = super::apply_row_batch_filters(&spec, rows, &[filter])
+                .expect("raw typed row filter should evaluate");
+            assert_eq!(filtered.rows.len(), expected);
+        }
+    }
+
+    #[test]
+    fn raw_typed_row_filters_reject_stale_schema_fingerprint() {
+        let spec = typed_binding_test_spec();
+        let mut stale = spec.schema_fingerprint;
+        stale[0] ^= 0xff;
+        let rows = raw_typed_binding_test_batch(stale);
+        let filter = super::RowFilter::ColumnEq {
+            column: "body".to_owned(),
+            column_type: SchemaColumnType::String,
+            value: super::RowFilterValue::String("other".to_owned()),
+        };
+        let result = super::apply_row_batch_filters(&spec, rows, &[filter]);
+        let error = result
+            .err()
+            .expect("invalid binding must fail even for a nonmatching row");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match the resolved schema")
+        );
     }
 
     #[test]

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -526,10 +526,19 @@ fn decode_visible_materialization_ref(
     row: MaterializedHotStateRowRef<'_>,
     file_id: &str,
 ) -> Result<VisibleMaterialization, LixError> {
+    // Staged materializations retain the durable native payload rather than
+    // the JSON projection supplied by committed reads.
+    let native_snapshot = row
+        .materialize_decoded_snapshot()?
+        .map(|snapshot| snapshot.to_json_shared())
+        .transpose()?;
     decode_visible_materialization_parts(
         row.schema_key(),
         row.change_id(),
-        row.snapshot_content().map(|content| content.as_str()),
+        native_snapshot
+            .as_ref()
+            .or_else(|| row.snapshot_content())
+            .map(|content| content.as_str()),
         file_id,
     )
 }
@@ -15015,6 +15024,50 @@ mod tests {
                 "global={global} untracked={untracked} must force a rebuild"
             );
         }
+    }
+
+    #[test]
+    fn visible_materialization_reads_staged_native_blob_ref() {
+        let file_id = "01920000-0000-7000-8000-0000000000a2";
+        let blob_hash = BlobId::from_content(b"staged");
+        let row_pk = RowPk::uuid_from_canonical(file_id).expect("canonical file identity");
+        let typed = WasmTypedRow::from_builtin_json(
+            BLOB_REF_SCHEMA_KEY,
+            &row_pk,
+            &json!({"id": file_id, "blob_hash": blob_hash.to_hex(), "size_bytes": 6}),
+        )
+        .expect("valid built-in blob reference");
+        let timestamp = LixTimestamp::from_unix_millis_utc_lossy(0);
+        let mut builder = crate::hot_state::MaterializedHotStateBatchBuilder::with_capacity(1);
+        let ordinal = builder.push_materialized_ref(
+            &row_pk,
+            BLOB_REF_SCHEMA_KEY,
+            Some(file_id),
+            None,
+            None,
+            false,
+            timestamp,
+            timestamp,
+            false,
+            Some(ChangeId::default()),
+            None,
+            false,
+            "main",
+        );
+        builder.set_raw_snapshot(
+            ordinal,
+            Some(Bytes::copy_from_slice(
+                &typed
+                    .durable_payload()
+                    .expect("encode native blob reference"),
+            )),
+        );
+        let batch = builder.finish();
+        let visible = decode_visible_materialization_ref(batch.row(0), file_id)
+            .expect("staged native blob reference must retain its durable proof");
+        assert!(
+            matches!(visible.bytes, VisibleMaterializationBytes::Blob { hash } if hash == blob_hash)
+        );
     }
 
     #[test]

--- a/packages/lix/tests/integration/sql/lix_branch.rs
+++ b/packages/lix/tests/integration/sql/lix_branch.rs
@@ -985,3 +985,89 @@ async fn count_rows(
         ref other => panic!("expected integer count for query {sql}, got {other:?}"),
     }
 }
+
+simulation_test!(
+    lix_branch_delete_reads_staged_default_branch,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine
+                .open_session_at("ffffffff-ffff-7fff-bfff-ffffffffffff")
+                .await
+                .expect("global session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_branch (id, name) VALUES ('01930000-0000-7000-8000-000000000018', 'New default')",
+                &[],
+            )
+            .await
+            .expect("branch should be created");
+        let mut protected_transaction = session.begin_transaction().await.unwrap();
+        protected_transaction
+            .execute(
+                "UPDATE lix_key_value SET value = $1 WHERE key = 'lix_default_branch_id'",
+                &[Value::Text(
+                    "01930000-0000-7000-8000-000000000018".to_string(),
+                )],
+            )
+            .await
+            .expect("new default branch should be staged");
+        let error = protected_transaction
+            .execute(
+                "DELETE FROM lix_branch WHERE id = '01930000-0000-7000-8000-000000000018'",
+                &[],
+            )
+            .await
+            .expect_err("the staged default branch must remain protected");
+        assert!(
+            error
+                .to_string()
+                .contains("cannot delete repository default branch"),
+            "deletion must reject the new default, not a missing payload: {error}"
+        );
+        protected_transaction.rollback().await.unwrap();
+
+        let mut transaction = session.begin_transaction().await.unwrap();
+        transaction
+            .execute(
+                "UPDATE lix_key_value SET value = $1 WHERE key = 'lix_default_branch_id'",
+                &[Value::Text(
+                    "01930000-0000-7000-8000-000000000018".to_string(),
+                )],
+            )
+            .await
+            .expect("default branch should be staged");
+        let result = transaction
+            .execute(
+                "DELETE FROM lix_branch WHERE id = $1",
+                &[Value::Text(sim.main_branch_id().to_string())],
+            )
+            .await
+            .expect("branch deletion should read the staged default branch");
+        assert_eq!(result, ExecuteResult::from_rows_affected(1));
+        transaction.commit().await.expect("deletion should commit");
+        let old_branch = session
+            .execute(
+                "SELECT id FROM lix_branch WHERE id = $1",
+                &[Value::Text(sim.main_branch_id().to_string())],
+            )
+            .await
+            .unwrap();
+        assert!(
+            old_branch.is_empty(),
+            "old default branch should be deleted"
+        );
+        let reopened = engine
+            .open_session()
+            .await
+            .expect("new default should open");
+        let transaction = reopened.begin_transaction().await.unwrap();
+        assert_eq!(
+            transaction.active_branch_id().unwrap(),
+            "01930000-0000-7000-8000-000000000018"
+        );
+        transaction.rollback().await.unwrap();
+    }
+);


### PR DESCRIPTION
SQL predicates could miss rows inserted or updated earlier in the same transaction. For example, inserting a row with `locale = 'en'` and immediately selecting it with `WHERE locale = 'en'` returned no rows, although an unfiltered scan could see it. This also affected CTEs and mutations whose predicates read staged values.

The generic schema filter evaluator handled decoded typed rows and JSON snapshots, but staged mutation journals retain raw binary snapshots. It treated those rows as having no snapshot and discarded them. Materialize the typed row through the existing snapshot accessor, validate its schema binding, and evaluate the predicate against those values. This preserves the existing query planning and index paths without SQL rewrites or application-specific exceptions.

Regression coverage checks literal and parameterized equality, IN, ranges, CTEs, staged updates, deletion by a staged value, rollback, raw payload filtering, and stale schema fingerprint rejection. All three predicate regressions failed against the original implementation. Includes a patch changenote.

Related snapshot readers now also handle staged binary values: branch deletion respects transaction-local default-branch changes, and plugin materialization retains the durable proof in staged blob references. Both additional regressions failed before their fixes; branch coverage also verifies default protection, rollback, commit, and reopening. Existing identity and proof validation remains intact.

This fixes the engine issue behind the temporary workaround in opral/inlang#4411.

Validation:
- `cargo nextest run -p lix --features all-simulations --no-fail-fast`: 3,503 passed; 76 existing skips.
- `cargo test -p lix --doc --profile test`: 10 passed.
- `cargo clippy --profile test -p lix --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all --check` and `git diff --check`: passed.
