### PR TITLE
Move Linux CI and release jobs to Ubicloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,12 @@ jobs:
               . -> target
               tooling -> target
             runner: ubicloud-standard-30-ubuntu-2404
+          # Consumer checks compile different feature/toolchain combinations.
+          # Run them alongside lint instead of extending its critical path.
+          - name: Compatibility
+            task: compatibility
+            workspace: .
+            runner: ubicloud-standard-30-ubuntu-2404
           - name: Test
             task: test
             workspace: .
@@ -266,7 +272,7 @@ jobs:
           sudo apt-get install -y llvm-dev libclang-dev clang mold
 
       - name: Install cargo-nextest
-        if: matrix.task != 'clippy'
+        if: matrix.junit
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
@@ -315,11 +321,11 @@ jobs:
       # `test`: the matrix below already runs the tests, this only has to prove
       # the configuration compiles.
       - name: Check lix test targets with default features
-        if: matrix.task == 'clippy'
+        if: matrix.task == 'compatibility'
         run: cargo check -p lix --tests
 
       - name: Verify stable Cargo can embed the local Rust SDK
-        if: matrix.task == 'clippy'
+        if: matrix.task == 'compatibility'
         run: |
           rustup toolchain install 1.93.0 --profile minimal
           rustup run 1.93.0 cargo metadata --locked --format-version 1 --no-deps --manifest-path packages/lix/Cargo.toml
@@ -381,7 +387,7 @@ jobs:
         run: cargo nextest run --config-file .config/nextest.toml --profile ci-e2e --locked --manifest-path tooling/Cargo.toml --cargo-profile test -p lix_e2e --features sdk-tests,plugin-tests,server-protocol,storage-benches,slatedb,root-replay-trace --tests --timings
 
       - name: Upload Rust test timing reports
-        if: matrix.task != 'clippy' && !cancelled()
+        if: matrix.junit && !cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: rust-nextest-junit-${{ matrix.task }}
@@ -389,7 +395,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Cargo build timings
-        if: matrix.task != 'clippy' && !cancelled()
+        if: matrix.junit && !cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: rust-cargo-timings-${{ matrix.task }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,6 @@ name: CI
 
 on:
   workflow_dispatch:
-    inputs:
-      runner_provider:
-        description: Use the smallest qualified runners by default; Blacksmith forces larger compilation runners
-        type: choice
-        default: default
-        options:
-          - default
-          - blacksmith
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
@@ -38,7 +30,7 @@ jobs:
     name: ${{ github.event.pull_request.draft && 'Draft - full CI deferred' || 'Release ready' }}
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs: [merge-reuse, promote-browser-sdk, changelog, cargo-config, cargo, js-sdk-test, preview-artifact-changes, preview-server-image]
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-2-ubuntu-2404
     timeout-minutes: 5
     permissions:
       contents: read
@@ -63,7 +55,7 @@ jobs:
   merge-reuse:
     name: Reuse tested merge
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-2-ubuntu-2404
     timeout-minutes: 5
     permissions:
       contents: read
@@ -87,7 +79,7 @@ jobs:
     name: Reuse tested browser SDK
     needs: merge-reuse
     if: needs.merge-reuse.outputs.reuse == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-2-ubuntu-2404
     timeout-minutes: 5
     permissions:
       actions: read
@@ -131,7 +123,7 @@ jobs:
     name: Changelog
     needs: merge-reuse
     if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-2-ubuntu-2404
     outputs:
       rust: ${{ steps.scope.outputs.rust }}
 
@@ -188,7 +180,7 @@ jobs:
       matrix:
         include:
           - name: Linux x64
-            runner: ubuntu-24.04
+            runner: ubicloud-standard-2-ubuntu-2404
           - name: macOS arm64
             runner: macos-15
           - name: Windows x64
@@ -204,10 +196,11 @@ jobs:
           node --test scripts/release.test.mjs
 
   cargo:
+    # Large Rust builds need memory and parallel compilation to target <10 min.
     name: Cargo ${{ matrix.name }}
     needs: changelog
     if: needs.changelog.outputs.rust != 'false' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || matrix.default_runner || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
       # The root Cargo config otherwise sends --manifest-path tooling builds
@@ -223,25 +216,22 @@ jobs:
             cache_workspaces: |
               . -> target
               tooling -> target
-            blacksmith_runner: blacksmith-32vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
           - name: Test
             task: test
             workspace: .
             junit: target/nextest/ci/junit.xml
-            # The 16 GiB GitHub VM shut down twice during this compilation.
-            # Use 32 GiB here; the other Rust/SDK jobs passed on free runners.
-            default_runner: blacksmith-8vcpu-ubuntu-2404
-            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
           - name: Tooling Test
             task: tooling
             workspace: tooling
             junit: tooling/target/nextest/ci/junit.xml
-            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
           - name: E2E Test
             task: e2e
             workspace: tooling
             junit: tooling/target/nextest/ci-e2e/junit.xml
-            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
 
     steps:
       - name: Checkout repository
@@ -249,11 +239,6 @@ jobs:
 
       - name: Prepare Linux build runner
         uses: ./.github/actions/prepare-linux-runner
-
-      - name: Limit root test compilation concurrency
-        if: matrix.task == 'test' && inputs.runner_provider != 'blacksmith'
-        # Leave headroom for the large root test crate on the 32 GiB VM.
-        run: echo 'CARGO_BUILD_JOBS=4' >> "$GITHUB_ENV"
 
       - name: set envs
         run: |
@@ -461,7 +446,7 @@ jobs:
     name: JS SDK ${{ matrix.name }} Test
     needs: merge-reuse
     if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ${{ inputs.runner_provider == 'blacksmith' && matrix.blacksmith_runner || 'ubuntu-24.04' }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
       # Pull request workflows normally check out GitHub's synthetic merge
@@ -474,10 +459,10 @@ jobs:
         include:
           - name: Native
             runtime: native
-            blacksmith_runner: blacksmith-16vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
           - name: Browser
             runtime: browser
-            blacksmith_runner: blacksmith-32vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
 
     steps:
       - name: Checkout repository
@@ -704,7 +689,7 @@ jobs:
   preview-artifact-changes:
     name: Select preview artifacts
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-2-ubuntu-2404
     outputs:
       server: ${{ steps.changes.outputs.server }}
 
@@ -722,6 +707,8 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            .github/workflows/ci.yml \
+            .github/workflows/publish-packages.yml \
             .cargo \
             .dockerignore \
             Cargo.lock \
@@ -743,7 +730,7 @@ jobs:
     name: Lix server preview artifact
     if: needs.preview-artifact-changes.outputs.server == 'true'
     needs: preview-artifact-changes
-    runs-on: ${{ inputs.runner_provider == 'blacksmith' && 'blacksmith-32vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
+    runs-on: ubicloud-standard-30-ubuntu-2404
     timeout-minutes: 45
     env:
       LIX_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   release-version:
     name: Validate release version
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-ubuntu-2404
     outputs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
@@ -131,7 +131,7 @@ jobs:
 
   publish-lix-server:
     name: Publish Lix reference server
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-30-ubuntu-2404
     timeout-minutes: 45
     needs: release-version
     permissions:
@@ -229,9 +229,9 @@ jobs:
       matrix:
         include:
           - suffix: linux-x64
-            runner: blacksmith-32vcpu-ubuntu-2404
+            runner: ubicloud-standard-30-ubuntu-2404
           - suffix: linux-arm64
-            runner: blacksmith-32vcpu-ubuntu-2404-arm
+            runner: ubicloud-standard-30-arm-ubuntu-2404
           - suffix: darwin-arm64
             runner: blacksmith-12vcpu-macos-15
           - suffix: win32-x64
@@ -293,7 +293,7 @@ jobs:
 
   build-js-sdk:
     name: Build @lix-js/sdk
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-30-ubuntu-2404
     needs: release-version
     if: needs.release-version.outputs.has_release == 'true'
 
@@ -384,7 +384,7 @@ jobs:
 
   test-js-sdk:
     name: Test @lix-js/sdk
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-8-ubuntu-2404
     needs:
       - release-version
       - build-js-sdk
@@ -459,7 +459,7 @@ jobs:
 
   publish-rust-crates:
     name: Publish crates.io packages
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubicloud-standard-30-ubuntu-2404
     environment: production
     # All reversible build and test work must succeed before the first
     # immutable registry upload. Registry publication is then serialized:
@@ -519,7 +519,7 @@ jobs:
 
   publish-js-sdk:
     name: Publish @lix-js/sdk packages
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-ubuntu-2404
     environment: production
     needs:
       - release-version
@@ -645,7 +645,7 @@ jobs:
 
   create-github-release:
     name: Create GitHub release
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-ubuntu-2404
     needs:
       - release-version
       - publish-rust-crates
@@ -715,7 +715,7 @@ jobs:
 
   publish-status:
     name: Publish status
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-ubuntu-2404
     needs:
       - release-version
       - publish-lix-server

--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -15,7 +15,7 @@ jobs:
   metadata:
     name: Draft release metadata
     if: github.event.pull_request.draft && startsWith(github.head_ref, 'release/v')
-    runs-on: ubuntu-24.04
+    runs-on: ubicloud-standard-2-ubuntu-2404
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   release-pr:
     name: Open release PR
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-ubuntu-2404
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-download-stats.yml
+++ b/.github/workflows/update-download-stats.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/ci-rust-scope.mjs
+++ b/scripts/ci-rust-scope.mjs
@@ -82,6 +82,6 @@ if (
 	console.log(
 		rust
 			? "Run all Rust checks (Rust/unknown inputs, push, dispatch, or uncertain diff)."
-			: "SDK TypeScript-only PR: run both SDK suites; skip the four Rust-only jobs.",
+			: "SDK TypeScript-only PR: run both SDK suites; skip the Rust-only jobs.",
 	);
 }

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -30,6 +30,7 @@ test("draft reruns cannot cancel ready-candidate CI", () => {
 test("Rust test scopes run independently with workspace-specific caches", () => {
 	for (const [name, task, workspace, runner] of [
 		["Clippy", "clippy", ".", "ubicloud-standard-30-ubuntu-2404"],
+		["Compatibility", "compatibility", ".", "ubicloud-standard-30-ubuntu-2404"],
 		["Test", "test", ".", "ubicloud-standard-30-ubuntu-2404"],
 		["Tooling Test", "tooling", "tooling", "ubicloud-standard-30-ubuntu-2404"],
 		["E2E Test", "e2e", "tooling", "ubicloud-standard-30-ubuntu-2404"],
@@ -298,4 +299,17 @@ test("tested merges skip validation but retain SDK artifacts for the landed revi
 	assert.match(promotion, /run-id: \$\{\{ needs\.merge-reuse\.outputs\.run_id \}\}/);
 	assert.match(promotion, /name: lix-browser-sdk-\$\{\{ github\.sha \}\}/);
 	assert.doesNotMatch(promotion, /\bcargo\b|\bnpm\b/);
+});
+
+// These checks protect different consumer configurations and must both execute
+// even when the all-feature lint job passes. They do not emit nextest reports.
+test("consumer compatibility runs independently without requiring nextest artifacts", () => {
+	for (const name of ["Check lix test targets with default features", "Verify stable Cargo can embed the local Rust SDK"]) {
+		const step = workflow.split(`- name: ${name}\n`)[1].split("\n      - name:")[0];
+		assert.match(step, /if: matrix\.task == 'compatibility'/);
+	}
+	for (const name of ["Upload Rust test timing reports", "Upload Cargo build timings"]) {
+		const step = workflow.split(`- name: ${name}\n`)[1].split("\n      - name:")[0];
+		assert.match(step, /if: matrix\.junit && !cancelled\(\)/);
+	}
 });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -29,15 +29,15 @@ test("draft reruns cannot cancel ready-candidate CI", () => {
 
 test("Rust test scopes run independently with workspace-specific caches", () => {
 	for (const [name, task, workspace, runner] of [
-		["Clippy", "clippy", ".", "blacksmith-32vcpu-ubuntu-2404"],
-		["Test", "test", ".", "blacksmith-16vcpu-ubuntu-2404"],
-		["Tooling Test", "tooling", "tooling", "blacksmith-16vcpu-ubuntu-2404"],
-		["E2E Test", "e2e", "tooling", "blacksmith-16vcpu-ubuntu-2404"],
+		["Clippy", "clippy", ".", "ubicloud-standard-30-ubuntu-2404"],
+		["Test", "test", ".", "ubicloud-standard-30-ubuntu-2404"],
+		["Tooling Test", "tooling", "tooling", "ubicloud-standard-30-ubuntu-2404"],
+		["E2E Test", "e2e", "tooling", "ubicloud-standard-30-ubuntu-2404"],
 	]) {
 		assert.match(
 			workflow,
 			new RegExp(
-				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}[\\s\\S]*?blacksmith_runner: ${runner}`,
+				`- name: ${name}\\n\\s+task: ${task}\\n\\s+workspace: ${workspace === "." ? "\\." : workspace}[\\s\\S]*?runner: ${runner}`,
 			),
 		);
 	}
@@ -49,11 +49,11 @@ test("Rust test scopes run independently with workspace-specific caches", () => 
 	assert.match(workflow, /name: rust-cargo-timings-\$\{\{ matrix\.task \}\}/);
 	assert.match(
 		workflow,
-		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ inputs\.runner_provider == 'blacksmith' && matrix\.blacksmith_runner \|\| matrix\.default_runner \|\| 'ubuntu-24\.04' \}\}/,
+		/name: Cargo \$\{\{ matrix\.name \}\}[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
 	);
 	assert.match(
 		workflow,
-		/- name: Test\n\s+task: test[\s\S]*?default_runner: blacksmith-8vcpu-ubuntu-2404\n\s+blacksmith_runner: blacksmith-16vcpu-ubuntu-2404/,
+		/- name: Test\n\s+task: test[\s\S]*?runner: ubicloud-standard-30-ubuntu-2404/,
 	);
 });
 
@@ -99,10 +99,10 @@ test("Cargo output directories match the workspace caches and timing uploads", (
 	);
 });
 
-test("short support jobs use free standard runners for the public repository", () => {
-	assert.match(workflow, /name: Changelog[\s\S]*?runs-on: ubuntu-24\.04/);
+test("short Linux support jobs use small Ubicloud runners", () => {
+	assert.match(workflow, /name: Changelog[\s\S]*?runs-on: ubicloud-standard-2-ubuntu-2404/);
 	for (const [name, runner] of [
-		["Linux x64", "ubuntu-24.04"],
+		["Linux x64", "ubicloud-standard-2-ubuntu-2404"],
 		["macOS arm64", "macos-15"],
 		["Windows x64", "windows-2025"],
 	]) {
@@ -115,18 +115,18 @@ test("short support jobs use free standard runners for the public repository", (
 	}
 });
 
-test("SDK CI defaults to free GitHub runners with an explicit Blacksmith fallback", () => {
+test("SDK CI uses large Ubicloud runners for native and browser compilation", () => {
 	assert.match(
 		workflow,
-		/- name: Native\n\s+runtime: native\n\s+blacksmith_runner: blacksmith-16vcpu-ubuntu-2404/,
+		/- name: Native\n\s+runtime: native\n\s+runner: ubicloud-standard-30-ubuntu-2404/,
 	);
 	assert.match(
 		workflow,
-		/- name: Browser\n\s+runtime: browser\n\s+blacksmith_runner: blacksmith-32vcpu-ubuntu-2404/,
+		/- name: Browser\n\s+runtime: browser\n\s+runner: ubicloud-standard-30-ubuntu-2404/,
 	);
 	assert.match(
 		workflow,
-		/name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ inputs\.runner_provider == 'blacksmith' && matrix\.blacksmith_runner \|\| 'ubuntu-24\.04' \}\}/,
+		/name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
 	);
 });
 
@@ -239,10 +239,10 @@ test("SDK binary reuse never skips TypeScript builds or integration tests", () =
 	}
 });
 
-test("server publishing and SDK package tests use free GitHub runners", () => {
+test("server publishing and SDK package tests use appropriately sized Ubicloud runners", () => {
 	assert.match(
 		publishWorkflow,
-		/name: Publish Lix reference server\n\s+runs-on: ubuntu-24\.04/,
+		/name: Publish Lix reference server\n\s+runs-on: ubicloud-standard-30-ubuntu-2404/,
 	);
 	assert.match(
 		publishWorkflow,
@@ -251,7 +251,7 @@ test("server publishing and SDK package tests use free GitHub runners", () => {
 	assert.match(publishWorkflow, /imagetools create --prefer-index=false/);
 	assert.match(
 		publishWorkflow,
-		/name: Test @lix-js\/sdk\n\s+runs-on: ubuntu-24\.04/,
+		/name: Test @lix-js\/sdk\n\s+runs-on: ubicloud-standard-8-ubuntu-2404/,
 	);
 });
 


### PR DESCRIPTION
Linux CI mixed slow standard GitHub runners with Blacksmith, and a recent full validation took about 24 minutes. Move every Linux job to Ubicloud: 30-vCPU runners for Rust, SDK and Docker compilation, 8 vCPU for release SDK tests, and 2 vCPU for coordination. Windows/macOS runners remain unchanged.

Remove the Blacksmith dispatch override and four-job Rust compilation cap. Run default-feature and stable-consumer checks in a parallel Compatibility matrix job, retaining all validation. Keep cache isolation and artifact provenance; CI/build workflow changes also exercise the server image path.

Validation:
- 69 local Node workflow/release tests, actionlint, release metadata and publish-surface validation, and git diff --check pass.
- Full Ubicloud CI passes in 9m40s, including the Release ready gate: https://github.com/opral/lix/actions/runs/34169390442
- Separate native Linux release qualification passes for x64 (7m25s) and ARM64 (18m45s cold), with artifact uploads and no registry publication: https://github.com/opral/lix/actions/runs/34168788805

The account routes x64 jobs to Ubicloud Premium; ARM64 uses standard hardware. The observed PR CI meets the ten-minute target, but cold ARM64 release compilation does not. Runtime remains dependent on cache state and source changes.
