### PR TITLE
Restore GitHub-hosted runner for npm trusted publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -519,7 +519,10 @@ jobs:
 
   publish-js-sdk:
     name: Publish @lix-js/sdk packages
-    runs-on: ubicloud-standard-2-ubuntu-2404
+    # npm trusted publishing rejects self-hosted runners, including Ubicloud.
+    # Keep only the OIDC registry upload on GitHub; builds stay on Ubicloud.
+    # https://docs.npmjs.com/trusted-publishers/#supported-cicd-providers
+    runs-on: ubuntu-24.04
     environment: production
     needs:
       - release-version

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -313,3 +313,13 @@ test("consumer compatibility runs independently without requiring nextest artifa
 		assert.match(step, /if: matrix\.junit && !cancelled\(\)/);
 	}
 });
+
+// npm's OIDC exchange requires a GitHub-hosted runner even when preceding
+// build jobs can run elsewhere. This prevents a failure after crates.io upload.
+test("tokenless npm publishing retains a GitHub-hosted runner and OIDC permission", () => {
+	const publish = publishWorkflow.split("\n  publish-js-sdk:\n")[1].split("\n  create-github-release:\n")[0];
+	assert.match(publish, /runs-on: ubuntu-24\.04/);
+	assert.match(publish, /id-token: write/);
+	assert.match(publish, /npm publish .*--provenance --access public/);
+	assert.doesNotMatch(publish, /secrets\.(?:NPM_TOKEN|NODE_AUTH_TOKEN)/);
+});


### PR DESCRIPTION
The Ubicloud migration moved tokenless npm publication onto a self-hosted runner. npm trusted publishing accepts GitHub-hosted runners only, so a release could publish Rust crates and then fail its npm OIDC exchange.

Restore only `publish-js-sdk` to GitHub-hosted Ubuntu 24.04. Builds, tests and other Linux jobs remain on Ubicloud. Document the exception and add a regression check for the hosted runner, OIDC permission and provenance publication.

Validation: all 70 workflow/release Node tests pass; actionlint and git diff --check pass. The post-migration release run skipped registry publication, so no partial package release was produced. No registry upload was performed for validation.

Addresses the trusted-publishing review on #1698. npm restriction: https://docs.npmjs.com/trusted-publishers/#supported-cicd-providers
