### PR TITLE
feat(lix): attach branch metadata to descriptors

### DIFF
--- a/docs/branching.md
+++ b/docs/branching.md
@@ -108,3 +108,19 @@ Lix creates a built-in branch named `global` when it opens a repository. You
 cannot delete that branch, and you cannot delete the active branch.
 
 `hidden` only marks a branch for UIs. It does not change what SQL queries can see.
+
+## Branch metadata
+
+Use `lix_branch.lixcol_metadata` to attach a JSON object to a branch:
+
+```ts
+await lix.execute(
+  "UPDATE lix_branch SET lixcol_metadata = $1 WHERE id = $2",
+  [JSON.stringify({ owner: "design" }), draft.id],
+);
+```
+
+Metadata belongs to the tracked `lix_branch_descriptor` row, just as file and
+directory metadata belongs to their descriptors. Branch descriptors are global,
+so the metadata is visible from every branch. Renaming, hiding, or moving the
+branch head preserves it. Set `lixcol_metadata = NULL` to clear it.

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -150,6 +150,7 @@ impl PublicCatalog {
                 Field::new("name", DataType::Utf8, false),
                 Field::new("hidden", DataType::Boolean, false),
                 Field::new("commit_id", DataType::Utf8, false),
+                json_field("lixcol_metadata", true),
             ])),
             PublicSurfaceKind::HistoryFunction
             | PublicSurfaceKind::DiffFunction
@@ -252,6 +253,7 @@ impl PublicCatalog {
                 PublicColumn::public("hidden", false).with_default("FALSE"),
                 PublicColumn::public("commit_id", false)
                     .with_default("lix_active_branch_commit_id()"),
+                PublicColumn::public("lixcol_metadata", true).optional_on_insert(),
             ],
             SurfaceCapabilities::read_write(),
         ))?;
@@ -714,6 +716,11 @@ mod tests {
                     lixcol_names, tracked,
                     "tracked relation '{}' must expose exactly the canonical bookkeeping set",
                     surface.name
+                ),
+                PublicSurfaceKind::Branch => assert_eq!(
+                    lixcol_names,
+                    BTreeSet::from(["lixcol_metadata"]),
+                    "branches expose descriptor metadata without other tracked-row columns"
                 ),
                 _ => assert!(
                     lixcol_names.is_empty(),

--- a/packages/lix/src/sql2/providers/branch.rs
+++ b/packages/lix/src/sql2/providers/branch.rs
@@ -33,7 +33,7 @@ use crate::sql2::write_normalization::{
 };
 use crate::sql2::{SqlWriteContext, WriteAccess, WriteContextHotStateReader};
 use crate::transaction_types::{
-    LogicalPrimaryKey, RawWriteBatch, TransactionWrite, TransactionWriteMode,
+    LogicalPrimaryKey, RawWriteBatch, TransactionJson, TransactionWrite, TransactionWriteMode,
     TransactionWriteOperation, TransactionWriteOrigin, TransactionWriteRow,
 };
 
@@ -43,7 +43,11 @@ use super::spec::{
     register_spec_table, row_source, scan_row_source, take_record_batch_rows,
 };
 use super::upsert::{StagedUpsert, UpsertReturningRow, UpsertSupport, materialize_omitted_column};
-use super::values::{required_bool_value, required_string_value};
+use super::values::{
+    optional_metadata_value, required_bool_value, required_string_value,
+    update_optional_metadata_value,
+};
+use crate::sql2::result_metadata::json_field;
 
 pub(super) async fn register_lix_branch_read_provider(
     session: &datafusion::prelude::SessionContext,
@@ -503,6 +507,7 @@ impl UpsertSupport for BranchSpec {
 
     fn validate_proposed_batch(&self, batch: &RecordBatch) -> Result<()> {
         for row_index in 0..batch.num_rows() {
+            optional_metadata_value(batch, row_index, "lixcol_metadata", "lix_branch")?;
             defaultable_bool_insert_value(batch, row_index, "hidden", "INSERT into lix_branch")?;
             defaultable_text_insert_value(batch, row_index, "commit_id", "INSERT into lix_branch")?;
         }
@@ -656,6 +661,7 @@ impl UpsertSupport for BranchSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BranchRow {
+    metadata: Option<TransactionJson>,
     id: String,
     name: String,
     hidden: bool,
@@ -667,6 +673,10 @@ static LIX_BRANCH_COLS: ColumnTable<BranchRow> = ColumnTable {
         ("id", Col::Utf8(|row| Some(row.id.as_str()))),
         ("name", Col::Utf8(|row| Some(row.name.as_str()))),
         ("hidden", Col::Bool(|row| Some(row.hidden))),
+        (
+            "lixcol_metadata",
+            Col::Utf8(|row| row.metadata.as_ref().map(TransactionJson::normalized)),
+        ),
         (
             "commit_id",
             Col::Utf8Owned(|row| Some(row.commit_id.to_string())),
@@ -892,6 +902,7 @@ async fn load_branch_rows_with_point_lookups(
             id: descriptor.id,
             name: descriptor.name,
             hidden: descriptor.hidden,
+            metadata: descriptor.metadata,
         });
     }
     Ok(out)
@@ -914,6 +925,7 @@ fn join_branch_descriptors_with_heads(
                 id: descriptor.id,
                 name: descriptor.name,
                 hidden: descriptor.hidden,
+                metadata: descriptor.metadata,
             })
         })
         .collect()
@@ -921,6 +933,7 @@ fn join_branch_descriptors_with_heads(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct BranchDescriptor {
+    metadata: Option<TransactionJson>,
     id: String,
     name: String,
     hidden: bool,
@@ -942,7 +955,15 @@ fn parse_descriptor(row: MaterializedHotStateRowRef<'_>) -> Result<BranchDescrip
         .get("hidden")
         .and_then(JsonValue::as_bool)
         .unwrap_or(false);
-    Ok(BranchDescriptor { id, name, hidden })
+    Ok(BranchDescriptor {
+        id,
+        name,
+        hidden,
+        metadata: row
+            .metadata()
+            .cloned()
+            .map(TransactionJson::from_certified_shared_normalized_metadata),
+    })
 }
 
 fn parse_snapshot(
@@ -963,7 +984,7 @@ fn parse_snapshot(
 fn validate_lix_branch_update_assignments(assignments: &[(String, Expr)]) -> Result<()> {
     for (column_name, _) in assignments {
         match column_name.as_str() {
-            "name" | "hidden" | "commit_id" => {}
+            "name" | "hidden" | "commit_id" | "lixcol_metadata" => {}
             "id" => {
                 return Err(DataFusionError::Execution(
                     "UPDATE lix_branch cannot change immutable column 'id'".to_string(),
@@ -1006,6 +1027,12 @@ fn branch_insert_rows_from_batch(
             .transpose()?
             .unwrap_or(*default_commit_id);
             Ok(BranchRow {
+                metadata: optional_metadata_value(
+                    batch,
+                    row_index,
+                    "lixcol_metadata",
+                    "lix_branch",
+                )?,
                 id,
                 name,
                 hidden,
@@ -1020,6 +1047,12 @@ fn branch_rows_from_batch(batch: &RecordBatch) -> Result<Vec<BranchRow>> {
         .map(|row_index| {
             Ok(BranchRow {
                 id: required_string_value(batch, row_index, "id", "DELETE lix_branch")?,
+                metadata: optional_metadata_value(
+                    batch,
+                    row_index,
+                    "lixcol_metadata",
+                    "lix_branch",
+                )?,
                 name: required_string_value(batch, row_index, "name", "DELETE lix_branch")?,
                 hidden: required_bool_value(batch, row_index, "hidden", "DELETE lix_branch")?,
                 commit_id: parse_branch_row_commit_id(
@@ -1117,6 +1150,13 @@ fn branch_update_rows_from_batch(
         .map(|row_index| {
             Ok(BranchRow {
                 id: required_string_value(batch, row_index, "id", "UPDATE lix_branch")?,
+                metadata: update_optional_metadata_value(
+                    batch,
+                    &assignment_values,
+                    row_index,
+                    "lixcol_metadata",
+                    "lix_branch",
+                )?,
                 name: update_string_value(
                     batch,
                     &assignment_values,
@@ -1177,10 +1217,9 @@ fn push_branch_stage_rows(
         ));
         rows.push(with_origin(branch_ref_tombstone_row(&row.id), origin));
     } else {
-        rows.push(with_origin(
-            branch_descriptor_stage_row(&row.id, &row.name, row.hidden),
-            origin.clone(),
-        ));
+        let mut descriptor = branch_descriptor_stage_row(&row.id, &row.name, row.hidden);
+        descriptor.metadata = row.metadata;
+        rows.push(with_origin(descriptor, origin.clone()));
         rows.push(with_origin(
             branch_ref_stage_row(&row.id, &row.commit_id),
             origin,
@@ -1276,6 +1315,7 @@ pub(super) fn lix_branch_schema() -> SchemaRef {
         Field::new("name", DataType::Utf8, false),
         Field::new("hidden", DataType::Boolean, false),
         Field::new("commit_id", DataType::Utf8, false),
+        json_field("lixcol_metadata", true),
     ]))
 }
 
@@ -1443,6 +1483,7 @@ mod tests {
             push_branch_stage_rows(
                 &mut rows,
                 BranchRow {
+                    metadata: None,
                     name: format!("Branch {index}"),
                     commit_id: CommitId::for_test_label(&format!("commit-{index}")),
                     id,
@@ -1509,6 +1550,28 @@ mod tests {
             head_read_strategy: BranchHeadReadStrategy::Point,
         };
         (spec, hot_state, branch_ref)
+    }
+
+    #[test]
+    fn branch_metadata_is_staged_only_on_descriptor() {
+        let metadata = TransactionJson::from_value_for_test(serde_json::json!({"owner": "team"}));
+        let mut rows = RawWriteBatch::default();
+        push_branch_stage_rows(
+            &mut rows,
+            BranchRow {
+                id: "01920000-0000-7000-8000-0000000000a1".into(),
+                name: "branch".into(),
+                hidden: false,
+                commit_id: CommitId::for_test_label("head"),
+                metadata: Some(metadata.clone()),
+            },
+            TransactionWriteOperation::Update,
+            false,
+        );
+        assert_eq!(rows.row(0).schema_key, "lix_branch_descriptor");
+        assert_eq!(rows.row(0).metadata, Some(&metadata));
+        assert_eq!(rows.row(1).schema_key, "lix_branch_ref");
+        assert_eq!(rows.row(1).metadata, None);
     }
 
     #[tokio::test]
@@ -1681,12 +1744,14 @@ mod tests {
             rows,
             vec![
                 BranchRow {
+                    metadata: None,
                     id: "01920000-0000-7000-8000-0000000000a1".to_string(),
                     name: "Branch A".to_string(),
                     hidden: false,
                     commit_id: head("01920000-0000-7000-8000-0000000000a1").commit_id,
                 },
                 BranchRow {
+                    metadata: None,
                     id: "01920000-0000-7000-8000-0000000000b1".to_string(),
                     name: "Branch B".to_string(),
                     hidden: false,

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -6,6 +6,7 @@
     clippy::unnecessary_wraps
 )]
 
+use super::values::{optional_metadata_value, update_optional_metadata_value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
@@ -46,10 +47,10 @@ use crate::sql2::write_normalization::{
 #[cfg(test)]
 use crate::transaction_types::TransactionWriteRow;
 use crate::transaction_types::{
-    LogicalPrimaryKey, RawWriteBatch, RawWriteRowRef, TransactionJson, TransactionWriteOperation,
+    LogicalPrimaryKey, RawWriteBatch, RawWriteRowRef, TransactionWriteOperation,
     TransactionWriteOrigin,
 };
-use crate::{LixError, SqlQueryResult, Value, parse_row_metadata_value, serialize_row_metadata};
+use crate::{LixError, SqlQueryResult, Value, serialize_row_metadata};
 
 use crate::filesystem::{
     DirectoryDescriptorWriteIntent, DirectoryPathRecord, DirectoryPathResolver,
@@ -2135,23 +2136,6 @@ fn update_optional_string_value(
     }
 }
 
-fn update_optional_metadata_value(
-    batch: &RecordBatch,
-    assignment_values: &UpdateAssignmentValues,
-    row_index: usize,
-    column_name: &str,
-    context: &str,
-) -> Result<Option<TransactionJson>> {
-    update_optional_string_value(batch, assignment_values, row_index, column_name)?
-        .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
-            TransactionJson::from_value(metadata, &format!("{context} metadata"))
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)
-        })
-        .transpose()
-}
-
 fn optional_string_value(
     batch: &RecordBatch,
     row_index: usize,
@@ -2174,22 +2158,6 @@ fn optional_string_value(
             "INSERT into lix_directory expected text-compatible column '{column_name}', got {other:?}"
         ))),
     }
-}
-
-fn optional_metadata_value(
-    batch: &RecordBatch,
-    row_index: usize,
-    column_name: &str,
-    context: &str,
-) -> Result<Option<TransactionJson>> {
-    optional_string_value(batch, row_index, column_name)?
-        .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
-            TransactionJson::from_value(metadata, &format!("{context} metadata"))
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)
-        })
-        .transpose()
 }
 
 fn optional_bool_value(

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -10,6 +10,7 @@
     clippy::useless_let_if_seq
 )]
 
+use super::values::{optional_metadata_value, update_optional_metadata_value};
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
@@ -6712,22 +6713,6 @@ fn update_optional_string_value(
     }
 }
 
-fn update_optional_metadata_value(
-    batch: &RecordBatch,
-    assignment_values: &UpdateAssignmentValues,
-    row_index: usize,
-    column_name: &str,
-    context: &str,
-) -> Result<Option<TransactionJson>> {
-    update_optional_string_value(batch, assignment_values, row_index, column_name)?
-        .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
-            TransactionJson::from_value(metadata, &format!("{context} metadata"))
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)
-        })
-        .transpose()
-}
 
 fn update_required_binary_value(
     _batch: &RecordBatch,
@@ -6802,21 +6787,6 @@ fn optional_string_value(
     }
 }
 
-fn optional_metadata_value(
-    batch: &RecordBatch,
-    row_index: usize,
-    column_name: &str,
-    context: &str,
-) -> Result<Option<TransactionJson>> {
-    optional_string_value(batch, row_index, column_name)?
-        .map(|value| {
-            let metadata = parse_row_metadata_value(&value, context)
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
-            TransactionJson::from_value(metadata, &format!("{context} metadata"))
-                .map_err(crate::sql2::error::lix_error_to_datafusion_error)
-        })
-        .transpose()
-}
 
 fn optional_bool_value(
     batch: &RecordBatch,

--- a/packages/lix/src/sql2/providers/values.rs
+++ b/packages/lix/src/sql2/providers/values.rs
@@ -99,3 +99,57 @@ pub(super) fn string_expr_literal(expr: &datafusion::logical_expr::Expr) -> Opti
         _ => None,
     }
 }
+
+/// Parse row metadata consistently across descriptor-backed SQL surfaces.
+pub(super) fn optional_metadata_value(
+    batch: &RecordBatch,
+    row_index: usize,
+    column_name: &str,
+    context: &str,
+) -> Result<Option<crate::transaction_types::TransactionJson>> {
+    parse_metadata(
+        optional_string_value(batch, row_index, column_name, context)?,
+        context,
+    )
+}
+
+pub(super) fn update_optional_metadata_value(
+    batch: &RecordBatch,
+    assignments: &crate::sql2::write_normalization::UpdateAssignmentValues,
+    row_index: usize,
+    column_name: &str,
+    context: &str,
+) -> Result<Option<crate::transaction_types::TransactionJson>> {
+    use crate::sql2::write_normalization::{InsertCell, SqlCell};
+    let value = match assignments.assigned_or_existing_cell(batch, row_index, column_name)? {
+        InsertCell::Omitted | InsertCell::Provided(SqlCell::Null) => None,
+        InsertCell::Provided(SqlCell::Value(
+            ScalarValue::Utf8(Some(value))
+            | ScalarValue::Utf8View(Some(value))
+            | ScalarValue::LargeUtf8(Some(value)),
+        )) => Some(value),
+        InsertCell::Provided(SqlCell::Value(other)) => {
+            return Err(DataFusionError::Execution(format!(
+                "UPDATE {context} expected text-compatible column '{column_name}', got {other:?}"
+            )));
+        }
+    };
+    parse_metadata(value, context)
+}
+
+fn parse_metadata(
+    value: Option<String>,
+    context: &str,
+) -> Result<Option<crate::transaction_types::TransactionJson>> {
+    value
+        .map(|value| {
+            let metadata = crate::parse_row_metadata_value(&value, context)
+                .map_err(crate::sql2::error::lix_error_to_datafusion_error)?;
+            crate::transaction_types::TransactionJson::from_value(
+                metadata,
+                &format!("{context} metadata"),
+            )
+            .map_err(crate::sql2::error::lix_error_to_datafusion_error)
+        })
+        .transpose()
+}

--- a/packages/lix/tests/integration/sql/metadata.rs
+++ b/packages/lix/tests/integration/sql/metadata.rs
@@ -583,6 +583,130 @@ simulation_test!(
     }
 );
 
+simulation_test!(metadata_on_lix_branch_uses_descriptor, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+    let id = "6d657461-6461-8461-8d62-72616e636800";
+    let initial = json!({"owner": "team", "nested": {"enabled": true}});
+    assert_metadata_value(
+        session.execute(
+            "INSERT INTO lix_branch (id, name, lixcol_metadata) VALUES ($1, 'metadata-branch', $2) RETURNING lixcol_metadata",
+            &[Value::Text(id.into()), Value::Text(initial.to_string())],
+        ).await.unwrap(),
+        "lixcol_metadata", &initial,
+    );
+    // Unrelated descriptor and ref updates must retain metadata.
+    assert_metadata_value(
+        session.execute(
+            "UPDATE lix_branch SET name = 'renamed', hidden = true, commit_id = commit_id WHERE id = $1 RETURNING lixcol_metadata",
+            &[Value::Text(id.into())],
+        ).await.unwrap(), "lixcol_metadata", &initial,
+    );
+    assert_metadata_value(
+        session
+            .execute(
+                "SELECT lixcol_metadata FROM lix_branch WHERE id = $1",
+                &[Value::Text(id.into())],
+            )
+            .await
+            .unwrap(),
+        "lixcol_metadata",
+        &initial,
+    );
+    // Filtering by name exercises the descriptor/head batch join.
+    assert_metadata_value(
+        session
+            .execute(
+                "SELECT lixcol_metadata FROM lix_branch WHERE name = 'renamed'",
+                &[],
+            )
+            .await
+            .unwrap(),
+        "lixcol_metadata",
+        &initial,
+    );
+    let updated = json!({"owner": "other"});
+    assert_metadata_value(
+        session.execute(
+            "INSERT INTO lix_branch (id, name, lixcol_metadata) VALUES ($1, 'ignored', $2) ON CONFLICT (id) DO UPDATE SET lixcol_metadata = excluded.lixcol_metadata RETURNING lixcol_metadata",
+            &[Value::Text(id.into()), Value::Jsonb(updated.clone().into())],
+        ).await.unwrap(), "lixcol_metadata", &updated,
+    );
+    assert_metadata_value(
+        session.execute(
+            "INSERT INTO lix_branch (id, name) VALUES ($1, 'upsert-renamed') ON CONFLICT (id) DO UPDATE SET name = excluded.name RETURNING lixcol_metadata",
+            &[Value::Text(id.into())],
+        ).await.unwrap(), "lixcol_metadata", &updated,
+    );
+    session.execute(
+        "UPDATE lix_branch SET lixcol_metadata = CAST('{\"owner\":\"direct\"}' AS JSONB) WHERE id = $1",
+        &[Value::Text(id.into())],
+    ).await.unwrap();
+    assert_metadata_value(
+        session
+            .execute(
+                "SELECT lixcol_metadata FROM lix_branch WHERE id = $1",
+                &[Value::Text(id.into())],
+            )
+            .await
+            .unwrap(),
+        "lixcol_metadata",
+        &json!({"owner": "direct"}),
+    );
+    assert_metadata_null(
+        session.execute("UPDATE lix_branch SET lixcol_metadata = NULL WHERE id = $1 RETURNING lixcol_metadata", &[Value::Text(id.into())]).await.unwrap(),
+        "lixcol_metadata",
+    );
+    assert_metadata_null(
+        session
+            .execute(
+                "SELECT lixcol_metadata FROM lix_branch WHERE id = $1",
+                &[Value::Text(id.into())],
+            )
+            .await
+            .unwrap(),
+        "lixcol_metadata",
+    );
+});
+
+simulation_test!(metadata_on_lix_branch_validates_json, |sim| async move {
+    let engine = sim.boot_engine().await;
+    let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+    let id = "6d657461-6461-8461-8d62-72616e636801";
+    for invalid in ["{bad", "null", "[]", "42", "\"text\""] {
+        assert_invalid_metadata_error(
+            session
+                .execute(
+                    "INSERT INTO lix_branch (id, name, lixcol_metadata) VALUES ($1, 'invalid', $2)",
+                    &[Value::Text(id.into()), Value::Text(invalid.into())],
+                )
+                .await
+                .expect_err("invalid metadata must fail"),
+        );
+    }
+    assert_metadata_null(
+        session
+            .execute(
+                "INSERT INTO lix_branch (id, name) VALUES ($1, 'valid') RETURNING lixcol_metadata",
+                &[Value::Text(id.into())],
+            )
+            .await
+            .unwrap(),
+        "lixcol_metadata",
+    );
+    for invalid in ["{bad", "null", "[]"] {
+        assert_invalid_metadata_error(
+            session
+                .execute(
+                    "UPDATE lix_branch SET lixcol_metadata = $2 WHERE id = $1",
+                    &[Value::Text(id.into()), Value::Text(invalid.into())],
+                )
+                .await
+                .expect_err("invalid update metadata must fail"),
+        );
+    }
+});
+
 fn assert_invalid_metadata_error(error: LixError) {
     assert!(
         matches!(


### PR DESCRIPTION
`lix_branch` now accepts and returns `lixcol_metadata`, stored on the tracked, global `lix_branch_descriptor` row. Inserts, updates, and upserts accept JSON objects; SQL NULL clears metadata, and unrelated name, visibility, or head updates preserve it. The branch ref receives no metadata.

Files, directories, and branches share metadata parsing and validation helpers. The SQL catalog exposes the nullable JSON column, and the branching guide documents its scope and usage.

Validation covers descriptor-only routing, point and batch reads, RETURNING, upserts, preservation, clearing, and invalid JSON in both the base and tracked-state-rebuild simulations.

Checks passed:
- `cargo nextest run -p lix --features all-simulations` — 3,508 passed, 76 skipped.
- `cargo test -p lix --doc`.
- `git diff --check`.
