### PR TITLE
Speed up ARM64 SDK releases with x64 cross-compilation

### DIFF
--- a/.github/workflows/arm64-cross-check.yml
+++ b/.github/workflows/arm64-cross-check.yml
@@ -1,0 +1,72 @@
+name: ARM64 cross-build qualification
+on:
+  push:
+    branches: [ci/arm64-cross-build]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubicloud-standard-30-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cross-toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm-dev libclang-dev clang mold gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: publish-js-sdk-linux-arm64-cross-v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Cross-compile ARM64 native SDK
+        working-directory: packages/js-sdk
+        env:
+          LIX_NATIVE_TARGET: aarch64-unknown-linux-gnu
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+          BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu: --sysroot=/usr/aarch64-linux-gnu
+        run: npm run build:native
+      - name: Verify ARM64 ELF and package
+        working-directory: packages/js-sdk
+        env:
+          LIX_NATIVE_PACKAGE_ALLOW_CROSS: '1'
+        run: |
+          file lix_js_sdk.node
+          readelf -h lix_js_sdk.node | grep -q 'Machine:.*AArch64'
+          readelf --version-info lix_js_sdk.node
+          npm run prepare:native-package -- --suffix=linux-arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: arm64-native
+          path: packages/js-sdk/native-packages/linux-arm64
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: arm64-cargo-timings
+          path: target/cargo-timings/*.html
+  test:
+    needs: build
+    runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/js-sdk/package-lock.json
+      - uses: actions/download-artifact@v4
+        with:
+          name: arm64-native
+          path: packages/js-sdk/native-packages/linux-arm64
+      - name: Test cross-compiled binary on ARM64
+        working-directory: packages/js-sdk
+        run: |
+          test "$(uname -m)" = aarch64
+          cp native-packages/linux-arm64/lix_js_sdk.node lix_js_sdk.node
+          npm ci
+          npx vitest run src/binding.node.test.ts

--- a/.github/workflows/build-js-sdk-arm64.yml
+++ b/.github/workflows/build-js-sdk-arm64.yml
@@ -1,14 +1,21 @@
-name: ARM64 cross-build qualification
+name: Build and test ARM64 SDK
 on:
-  push:
-    branches: [ci/arm64-cross-build]
+  workflow_call:
+    inputs:
+      ref:
+        description: Exact revision to build and test
+        required: true
+        type: string
 permissions:
   contents: read
 jobs:
   build:
     runs-on: ubicloud-standard-30-ubuntu-2404
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install cross-toolchain
         run: |
           sudo apt-get update
@@ -41,7 +48,7 @@ jobs:
           npm run prepare:native-package -- --suffix=linux-arm64
       - uses: actions/upload-artifact@v4
         with:
-          name: arm64-native
+          name: js-sdk-native-linux-arm64
           path: packages/js-sdk/native-packages/linux-arm64
           if-no-files-found: error
       - uses: actions/upload-artifact@v4
@@ -52,8 +59,11 @@ jobs:
   test:
     needs: build
     runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24
@@ -61,7 +71,7 @@ jobs:
           cache-dependency-path: packages/js-sdk/package-lock.json
       - uses: actions/download-artifact@v4
         with:
-          name: arm64-native
+          name: js-sdk-native-linux-arm64
           path: packages/js-sdk/native-packages/linux-arm64
       - name: Test cross-compiled binary on ARM64
         working-directory: packages/js-sdk

--- a/.github/workflows/build-js-sdk-arm64.yml
+++ b/.github/workflows/build-js-sdk-arm64.yml
@@ -20,6 +20,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y llvm-dev libclang-dev clang mold gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          # Cross GCC searches for a target-prefixed linker; mold itself supports ARM64.
+          sudo ln -sf /usr/bin/mold /usr/bin/aarch64-linux-gnu-ld.mold
+          printf 'int main(void) { return 0; }\n' | aarch64-linux-gnu-gcc -x c - -fuse-ld=mold -o /tmp/arm64-link-check
+          readelf -h /tmp/arm64-link-check | grep -q 'Machine:.*AArch64'
           rustup target add aarch64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         run: node scripts/validate-server-protocol-docs.mjs
 
       - name: Validate CI workflow invariants
-        run: node --test scripts/ci-workflow.test.mjs scripts/ci-merge-reuse.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs scripts/release-candidate.test.mjs
+        run: node --test scripts/native-build.test.mjs scripts/ci-workflow.test.mjs scripts/ci-merge-reuse.test.mjs scripts/ci-rust-scope.test.mjs scripts/ci-sdk-cache.test.mjs scripts/ci-server-image.test.mjs scripts/release-candidate.test.mjs
 
   cargo-config:
     name: Cargo config (${{ matrix.name }})

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -219,6 +219,13 @@ jobs:
           docker manifest inspect \
             "ghcr.io/opral/lix-server@$SERVER_DIGEST"
 
+  build-js-sdk-arm64:
+    needs: release-version
+    if: needs.release-version.outputs.has_release == 'true'
+    uses: ./.github/workflows/build-js-sdk-arm64.yml
+    with:
+      ref: ${{ needs.release-version.outputs.release_sha }}
+
   build-js-sdk-native-packages:
     name: Build @lix-js/sdk native package (${{ matrix.suffix }})
     runs-on: ${{ matrix.runner }}
@@ -230,8 +237,6 @@ jobs:
         include:
           - suffix: linux-x64
             runner: ubicloud-standard-30-ubuntu-2404
-          - suffix: linux-arm64
-            runner: ubicloud-standard-30-arm-ubuntu-2404
           - suffix: darwin-arm64
             runner: blacksmith-12vcpu-macos-15
           - suffix: win32-x64
@@ -467,6 +472,7 @@ jobs:
     needs:
       - release-version
       - build-js-sdk-native-packages
+      - build-js-sdk-arm64
       - test-js-sdk
     if: needs.release-version.outputs.has_release == 'true'
 
@@ -527,6 +533,7 @@ jobs:
     needs:
       - release-version
       - build-js-sdk-native-packages
+      - build-js-sdk-arm64
       - test-js-sdk
       - publish-rust-crates
     permissions:
@@ -724,6 +731,7 @@ jobs:
       - publish-lix-server
       - create-github-release
       - build-js-sdk-native-packages
+      - build-js-sdk-arm64
       - build-js-sdk
       - test-js-sdk
       - publish-rust-crates
@@ -736,6 +744,7 @@ jobs:
           echo "release-version: ${{ needs.release-version.result }}"
           echo "publish-lix-server: ${{ needs.publish-lix-server.result }}"
           echo "create-github-release: ${{ needs.create-github-release.result }}"
+          echo "build-js-sdk-arm64: ${{ needs.build-js-sdk-arm64.result }}"
           echo "build-js-sdk-native-packages: ${{ needs.build-js-sdk-native-packages.result }}"
           echo "build-js-sdk: ${{ needs.build-js-sdk.result }}"
           echo "test-js-sdk: ${{ needs.test-js-sdk.result }}"

--- a/packages/js-sdk/scripts/build-native.js
+++ b/packages/js-sdk/scripts/build-native.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageDir = join(__dirname, "..");
 const manifestPath = join(packageDir, "Cargo.toml");
+const target = process.env.LIX_NATIVE_TARGET;
 const requestedProfile = process.env.LIX_NATIVE_PROFILE ?? "release";
 const cargoProfile = requestedProfile === "debug" ? "dev" : requestedProfile;
 const artifactProfile =
@@ -74,9 +75,12 @@ const args = [
 	cargoProfile,
 ];
 
+if (target) args.push("--target", target);
+args.push("--timings");
+
 await run("cargo", args);
 await mkdir(packageDir, { recursive: true });
 await cp(
-	join(await cargoTargetDir(), artifactProfile, artifactName),
+	join(await cargoTargetDir(), target ?? "", artifactProfile, artifactName),
 	destination,
 );

--- a/packages/js-sdk/scripts/build-native.js
+++ b/packages/js-sdk/scripts/build-native.js
@@ -12,7 +12,16 @@ const requestedProfile = process.env.LIX_NATIVE_PROFILE ?? "release";
 const cargoProfile = requestedProfile === "debug" ? "dev" : requestedProfile;
 const artifactProfile =
 	cargoProfile === "dev" || cargoProfile === "test" ? "debug" : cargoProfile;
-const artifactName =
+const targetArtifacts = {
+	"aarch64-unknown-linux-gnu": "liblix_js_sdk.so",
+	"x86_64-unknown-linux-gnu": "liblix_js_sdk.so",
+	"aarch64-apple-darwin": "liblix_js_sdk.dylib",
+	"x86_64-pc-windows-msvc": "lix_js_sdk.dll",
+};
+if (target && !Object.hasOwn(targetArtifacts, target)) {
+	throw new Error(`Unsupported native target: ${target}`);
+}
+const artifactName = target ? targetArtifacts[target] :
 	process.platform === "darwin"
 		? "liblix_js_sdk.dylib"
 		: process.platform === "win32"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -323,3 +323,19 @@ test("tokenless npm publishing retains a GitHub-hosted runner and OIDC permissio
 	assert.match(publish, /npm publish .*--provenance --access public/);
 	assert.doesNotMatch(publish, /secrets\.(?:NPM_TOKEN|NODE_AUTH_TOKEN)/);
 });
+
+test("ARM64 release artifacts are tested on ARM hardware before publishing", () => {
+	const armWorkflow = readFileSync(resolve(repositoryRoot, ".github/workflows/build-js-sdk-arm64.yml"), "utf8");
+	const armRelease = publishWorkflow.split("\n  build-js-sdk-arm64:\n")[1].split("\n  build-js-sdk-native-packages:\n")[0];
+	assert.match(armRelease, /uses: \.\/\.github\/workflows\/build-js-sdk-arm64\.yml/);
+	assert.match(armRelease, /ref: \$\{\{ needs\.release-version\.outputs\.release_sha \}\}/);
+	assert.match(armWorkflow, /LIX_NATIVE_TARGET: aarch64-unknown-linux-gnu/);
+	assert.match(armWorkflow, /readelf -h lix_js_sdk\.node \| grep -q 'Machine:\.\*AArch64'/);
+	const armTest = armWorkflow.split("\n  test:\n")[1];
+	assert.match(armTest, /needs: build/);
+	assert.match(armTest, /runs-on: ubicloud-standard-8-arm-ubuntu-2404/);
+	assert.match(armTest, /name: js-sdk-native-linux-arm64/);
+	assert.match(armTest, /npx vitest run src\/binding\.node\.test\.ts/);
+	const rustPublish = publishWorkflow.split("\n  publish-rust-crates:\n")[1].split("\n  publish-js-sdk:\n")[0];
+	assert.match(rustPublish, /needs:[\s\S]*?- build-js-sdk-arm64/);
+});

--- a/scripts/native-build.test.mjs
+++ b/scripts/native-build.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import test from "node:test";
+
+for (const target of [undefined, "aarch64-unknown-linux-gnu"]) {
+  test(`native build selects the ${target ?? "host"} artifact`, { skip: process.platform === "win32" }, () => {
+    const root = mkdtempSync(join(tmpdir(), "lix-native-build-"));
+    try {
+      mkdirSync(join(root, "scripts"));
+      copyFileSync(new URL("../packages/js-sdk/scripts/build-native.js", import.meta.url), join(root, "scripts/build-native.mjs"));
+      const cargo = join(root, "cargo");
+      writeFileSync(cargo, `#!${process.execPath}
+const fs = require('node:fs');
+const path = require('node:path');
+const root = __dirname;
+const args = process.argv.slice(2);
+if (args[0] === 'metadata') {
+  console.log(JSON.stringify({target_directory: path.join(root, 'target')}));
+} else {
+  fs.writeFileSync(path.join(root, 'args.json'), JSON.stringify(args));
+  const target = args.includes('--target') ? args[args.indexOf('--target') + 1] : '';
+  const dir = path.join(root, 'target', target, 'release');
+  fs.mkdirSync(dir, {recursive: true});
+  const artifact = target || process.platform === 'linux' ? 'liblix_js_sdk.so' : 'liblix_js_sdk.dylib';
+  fs.writeFileSync(path.join(dir, artifact), target || 'host');
+}
+`);
+      chmodSync(cargo, 0o755);
+      // A stale host binary must never be packaged as ARM64.
+      mkdirSync(join(root, "target/release"), { recursive: true });
+      writeFileSync(join(root, "target/release/liblix_js_sdk.so"), "stale host");
+      const env = { ...process.env, PATH: `${root}${delimiter}${process.env.PATH}` };
+      delete env.LIX_NATIVE_TARGET;
+      delete env.LIX_NATIVE_PROFILE;
+      if (target) env.LIX_NATIVE_TARGET = target;
+      const result = spawnSync(process.execPath, [join(root, "scripts/build-native.mjs")], { env, encoding: "utf8" });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(readFileSync(join(root, "lix_js_sdk.node"), "utf8"), target ?? "host");
+      const args = JSON.parse(readFileSync(join(root, "args.json"), "utf8"));
+      assert.equal(args.includes("--target"), Boolean(target));
+      assert.equal(args[args.indexOf("--profile") + 1], "release");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
ARM64 native SDK release builds took 18m45s cold and 12m20s with the dependency cache on Ubicloud ARM. Build the ARM64 binary on Ubicloud x64 using Ubuntu's ARM cross-toolchain, then run the native filesystem and transaction tests against that exact package on a real ARM runner before any crates.io or npm publication.

The release profile is unchanged. The build script selects target-specific artifacts explicitly, and the workflow checks cross-linking and the ELF architecture before packaging. npm trusted publishing remains on GitHub-hosted Ubuntu.

Validation:
- Cold qualification: build 7m24s, including 6m38s compilation; complete build + ARM test workflow 9m05s. All three ARM native tests passed.
- Binary requires the same shared libraries and GLIBC/GLIBCXX symbol versions as the previous native ARM build.
- 73 local regression checks and actionlint passed.
- Cached qualification: exact dependency-cache hit, build 5m31s (4m44s compilation); complete build + ARM test workflow 7m31s. All three ARM tests passed again.
- Full PR CI passed in 10m27s. Post-merge CI passed using verified merge reuse, and the release workflow passed its no-release path.

Qualification: https://github.com/opral/lix/actions/runs/34171725014/attempts/1

Cached qualification: https://github.com/opral/lix/actions/runs/34171725014/attempts/2
