### PR TITLE
fix(storage-slatedb): keep explicit transaction I/O on adapter runtime

### DIFF
--- a/.changenotes/fix-slatedb-explicit-transactions.md
+++ b/.changenotes/fix-slatedb-explicit-transactions.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed explicit transactions failing on SlateDB-backed servers when reading cached file and directory state.
+
+SlateDB reads, writes, and flushes now also work when called from an executor without a Tokio runtime.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "bytes",
+ "futures-lite",
  "futures-util",
  "lix",
  "object_store 0.14.0",

--- a/packages/storage-slatedb/Cargo.toml
+++ b/packages/storage-slatedb/Cargo.toml
@@ -28,3 +28,6 @@ slatedb = { version = "0.14.1", default-features = false, features = ["moka", "z
 slatedb-common = "0.14.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+
+[dev-dependencies]
+futures-lite = "2"

--- a/packages/storage-slatedb/src/slatedb.rs
+++ b/packages/storage-slatedb/src/slatedb.rs
@@ -2943,8 +2943,13 @@ impl StorageRead for SlateDBRead {
                 }
                 let mut results =
                     vec![value.map(|value| project_value(value, request.opts.projection))];
-                hydrate_immutable_value_gets(&self.immutable_value_store, requests, &mut results)
-                    .await?;
+                hydrate_immutable_value_gets(
+                    &self.worker,
+                    &self.immutable_value_store,
+                    requests,
+                    &mut results,
+                )
+                .await?;
                 return Ok(GetManyResult::new(results));
             }
 
@@ -3027,8 +3032,13 @@ impl StorageRead for SlateDBRead {
             }
             let unexpected_value = values.next();
             debug_assert!(unexpected_value.is_none());
-            hydrate_immutable_value_gets(&self.immutable_value_store, requests, &mut results)
-                .await?;
+            hydrate_immutable_value_gets(
+                &self.worker,
+                &self.immutable_value_store,
+                requests,
+                &mut results,
+            )
+            .await?;
             Ok(GetManyResult::new(results))
         }
     }
@@ -3132,6 +3142,7 @@ impl StorageScanSource for SlateDBScanSource {
             }
             let (mut entries, has_more) = chunk.into_parts();
             hydrate_immutable_value_scan(
+                &self.worker,
                 &self.immutable_value_store,
                 self.space,
                 self.projection,
@@ -3373,6 +3384,7 @@ enum StreamingMergeDecision {
 }
 
 async fn hydrate_immutable_value_gets(
+    worker: &SlateDBWorker,
     immutable_value_store: &ImmutableValueStore,
     requests: &[GetManyRequest<'_>],
     results: &mut [Option<ProjectedValue>],
@@ -3393,8 +3405,12 @@ async fn hydrate_immutable_value_gets(
     if targets.is_empty() {
         return Ok(());
     }
-    let values = immutable_value_store
-        .get_many(targets.iter().map(|(_, marker)| marker.clone()).collect())
+    let store = immutable_value_store.clone();
+    let markers = targets.iter().map(|(_, marker)| marker.clone()).collect();
+    // Commit coordination may run without a caller Tokio runtime. Dispatch
+    // both cache I/O and object-store misses through the adapter's worker.
+    let values = worker
+        .call_read(move |_db| async move { store.get_many(markers).await })
         .await?;
     for ((result_index, _), value) in targets.into_iter().zip(values) {
         results[result_index] = Some(ProjectedValue::FullValue(value));
@@ -3403,6 +3419,7 @@ async fn hydrate_immutable_value_gets(
 }
 
 async fn hydrate_immutable_value_scan(
+    worker: &SlateDBWorker,
     immutable_value_store: &ImmutableValueStore,
     space: StorageSpace,
     projection: CoreProjection,
@@ -3412,18 +3429,18 @@ async fn hydrate_immutable_value_scan(
     {
         return Ok(());
     }
-    let values = immutable_value_store
-        .get_many(
-            entries
-                .iter()
-                .map(|entry| match &entry.value {
-                    ProjectedValue::FullValue(marker) => Ok(marker.clone()),
-                    ProjectedValue::KeyOnly => Err(StorageError::Corruption(
-                        "immutable full-value scan returned a key-only marker".to_string(),
-                    )),
-                })
-                .collect::<Result<Vec<_>, _>>()?,
-        )
+    let markers = entries
+        .iter()
+        .map(|entry| match &entry.value {
+            ProjectedValue::FullValue(marker) => Ok(marker.clone()),
+            ProjectedValue::KeyOnly => Err(StorageError::Corruption(
+                "immutable full-value scan returned a key-only marker".to_string(),
+            )),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let store = immutable_value_store.clone();
+    let values = worker
+        .call_read(move |_db| async move { store.get_many(markers).await })
         .await?;
     for (entry, value) in entries.iter_mut().zip(values) {
         entry.value = ProjectedValue::FullValue(value);
@@ -3617,8 +3634,9 @@ impl StorageWrite for SlateDBWrite {
                         .immutable_locator_rows
                         .fetch_add(immutable_locators.len() as u64, Ordering::Relaxed);
                 }
-                self.immutable_value_store
-                    .put_segments(immutable_segments)
+                let store = self.immutable_value_store.clone();
+                self.worker
+                    .call(move |_db| async move { store.put_segments(immutable_segments).await })
                     .await?;
                 for (physical_key, locator) in immutable_locators {
                     self.overlay.insert(physical_key, Some(locator));
@@ -3704,8 +3722,9 @@ impl StorageWrite for SlateDBWrite {
                     .immutable_locator_rows
                     .fetch_add(immutable_locators.len() as u64, Ordering::Relaxed);
             }
-            self.immutable_value_store
-                .put_segments(immutable_segments)
+            let store = self.immutable_value_store.clone();
+            self.worker
+                .call(move |_db| async move { store.put_segments(immutable_segments).await })
                 .await?;
             for (physical_key, locator) in immutable_locators {
                 self.overlay.insert(physical_key, Some(locator));
@@ -4259,7 +4278,9 @@ impl SlateDBWorker {
 
     async fn wait_for_reclamation(&self) -> Result<(), StorageError> {
         let reclamation = self.inner.reclamation.clone();
-        tokio::task::spawn_blocking(move || reclamation.wait_until_idle())
+        self.inner
+            .runtime
+            .spawn_blocking(move || reclamation.wait_until_idle())
             .await
             .map_err(|error| StorageError::Io(format!("join SlateDB reclamation task: {error}")))
     }

--- a/packages/storage-slatedb/tests/storage.rs
+++ b/packages/storage-slatedb/tests/storage.rs
@@ -54,6 +54,210 @@ async fn cached_slatedb_passes_storage_conformance() {
 }
 
 #[tokio::test]
+async fn cached_explicit_directory_transaction_commits_and_reopens() {
+    Box::pin(assert_cached_explicit_directory_transaction()).await;
+}
+
+#[test]
+fn cached_explicit_directory_transaction_works_without_caller_tokio_runtime() {
+    assert!(tokio::runtime::Handle::try_current().is_err());
+    futures_lite::future::block_on(Box::pin(assert_cached_explicit_directory_transaction()));
+}
+
+async fn assert_cached_explicit_directory_transaction() {
+    let directory = tempfile::tempdir().expect("create cached transaction fixture");
+    let cache_path = directory.path().join("cache");
+    let mut backend = FaultStore::new(Arc::new(InMemory::new()));
+    // S3 and other async stores need a Tokio context even when the engine's
+    // executor does not. Require it on cache misses as well as cache hits.
+    backend.require_runtime = true;
+    let backend = Arc::new(backend);
+    let open_storage = || {
+        SlateDB::open_object_store_with_options(
+            "cached-explicit-transaction",
+            backend.clone(),
+            SlateDBObjectStoreOptions {
+                cache: Some(cache_options(cache_path.clone())),
+            },
+        )
+        .expect("open cached transaction storage")
+    };
+    let storage = open_storage();
+    let lix = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("open cached transaction repository");
+    lix.execute(
+        "INSERT INTO lix_directory (path) VALUES ('/source/empty')",
+        &[],
+    )
+    .await
+    .expect("create directory and empty descendant");
+    let content = vec![0x61_u8; 128 * 1024];
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ('/source/note.bin', $1)",
+        &[Value::Blob(content.clone().into())],
+    )
+    .await
+    .expect("create file before explicit transaction");
+
+    let mut transaction = lix
+        .begin_transaction()
+        .await
+        .expect("begin explicit transaction");
+    transaction
+        .execute(
+            "UPDATE lix_directory SET path = '/target' WHERE path = '/source'",
+            &[],
+        )
+        .await
+        .expect("stage directory move");
+    transaction
+        .commit()
+        .await
+        .expect("commit cached directory move");
+
+    let mut rollback = lix
+        .begin_transaction()
+        .await
+        .expect("begin rollback transaction");
+    rollback
+        .execute("DELETE FROM lix_directory WHERE path = '/target'", &[])
+        .await
+        .expect("stage directory deletion");
+    rollback
+        .rollback()
+        .await
+        .expect("rollback directory deletion");
+    drop(lix);
+    storage
+        .flush()
+        .await
+        .expect("flush without borrowing caller runtime");
+    drop(storage);
+    // Force immutable content to hydrate from the object store on reopen.
+    std::fs::remove_dir_all(&cache_path).expect("clear disk cache before cold reopen");
+    let storage = open_storage();
+    let reopened = open_lix()
+        .with_storage(storage.clone())
+        .await
+        .expect("cold reopen cached transaction repository");
+    let file = reopened
+        .execute("SELECT path, content FROM lix_file", &[])
+        .await
+        .expect("read moved file after cold reopen");
+    assert_eq!(file.len(), 1);
+    assert_eq!(
+        file.rows()[0].get::<String>("path").unwrap(),
+        "/target/note.bin"
+    );
+    assert_eq!(file.rows()[0].get::<Vec<u8>>("content").unwrap(), content);
+    let directories = reopened
+        .execute("SELECT path FROM lix_directory ORDER BY path", &[])
+        .await
+        .expect("read empty descendant after cold reopen");
+    assert_eq!(directories.len(), 2);
+    assert_eq!(
+        directories.rows()[0].get::<String>("path").unwrap(),
+        "/target"
+    );
+    assert_eq!(
+        directories.rows()[1].get::<String>("path").unwrap(),
+        "/target/empty"
+    );
+    drop(reopened);
+    storage
+        .flush()
+        .await
+        .expect("flush reopened cached repository");
+}
+
+#[test]
+fn cached_immutable_replacement_works_without_caller_tokio_runtime() {
+    assert!(tokio::runtime::Handle::try_current().is_err());
+    futures_lite::future::block_on(async {
+        let directory = tempfile::tempdir().expect("create cached replacement fixture");
+        let mut backend = FaultStore::new(Arc::new(InMemory::new()));
+        backend.require_runtime = true;
+        let storage = SlateDB::open_object_store_with_options(
+            "cached-immutable-replacement",
+            Arc::new(backend),
+            SlateDBObjectStoreOptions {
+                cache: Some(cache_options(directory.path().join("cache"))),
+            },
+        )
+        .expect("open cached replacement storage");
+        let space = StorageSpace::immutable(SpaceId(0x00ff_0001), "test.immutable");
+        let key = Key(Bytes::from_static(b"replacement-key"));
+        let batch = |value: &'static [u8]| PutBatch {
+            entries: vec![PutEntry {
+                key: key.clone(),
+                value: StoredValue {
+                    bytes: Bytes::from_static(value),
+                },
+            }],
+        };
+        let mut initial = storage.begin_write(WriteOptions::default()).await.unwrap();
+        initial.put_many(space, batch(b"before")).await.unwrap();
+        initial.commit().await.unwrap();
+        let mut replacement = storage.begin_write(WriteOptions::default()).await.unwrap();
+        replacement
+            .replace_many(space, batch(b"after"))
+            .await
+            .unwrap();
+        replacement.commit().await.unwrap();
+        let read = storage.begin_read(ReadOptions::default()).await.unwrap();
+        let actual = read
+            .get_many(&[GetManyRequest {
+                space,
+                keys: std::slice::from_ref(&key),
+                opts: GetOptions {
+                    projection: CoreProjection::FullValue,
+                },
+            }])
+            .await
+            .expect("hydrate replacement point read outside Tokio");
+        assert_eq!(
+            actual.values,
+            vec![Some(ProjectedValue::FullValue(Bytes::from_static(
+                b"after"
+            )))]
+        );
+        let mut scan = read
+            .begin_scan(
+                space,
+                KeyRange {
+                    lower: Bound::Unbounded,
+                    upper: Bound::Unbounded,
+                },
+                BeginScanOptions {
+                    projection: CoreProjection::FullValue,
+                    ..BeginScanOptions::default()
+                },
+            )
+            .await
+            .unwrap();
+        let (entries, has_more) = scan
+            .next_page(10)
+            .await
+            .expect("hydrate replacement scan outside Tokio")
+            .into_parts();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].value,
+            ProjectedValue::FullValue(Bytes::from_static(b"after"))
+        );
+        assert!(!has_more);
+        drop(scan);
+        drop(read);
+        storage
+            .flush()
+            .await
+            .expect("flush replacement outside Tokio");
+    });
+}
+
+#[tokio::test]
 async fn file_sql_bytea_hard_cut_roundtrips_after_slatedb_reopen() {
     let temp_dir = tempfile::tempdir().expect("create SlateDB temp directory");
     let path = temp_dir.path().join("file-sql.slatedb");
@@ -623,6 +827,7 @@ struct FaultStore {
     inner: Arc<InMemory>,
     fail_writes: Arc<AtomicBool>,
     write_ops: Arc<AtomicU64>,
+    require_runtime: bool,
 }
 
 impl FaultStore {
@@ -631,6 +836,7 @@ impl FaultStore {
             inner,
             fail_writes: Arc::new(AtomicBool::new(false)),
             write_ops: Arc::new(AtomicU64::new(0)),
+            require_runtime: false,
         }
     }
 
@@ -661,6 +867,12 @@ impl ObjectStore for FaultStore {
         payload: PutPayload,
         options: PutOptions,
     ) -> ObjectStoreResult<PutResult> {
+        if self.require_runtime {
+            assert!(
+                tokio::runtime::Handle::try_current().is_ok(),
+                "object-store put requires its adapter runtime"
+            );
+        }
         self.write_ops.fetch_add(1, Ordering::Relaxed);
         if self.should_fail_writes() {
             return Err(fault_error());
@@ -685,6 +897,12 @@ impl ObjectStore for FaultStore {
         location: &Path,
         options: ObjectStoreGetOptions,
     ) -> ObjectStoreResult<GetResult> {
+        if self.require_runtime {
+            assert!(
+                tokio::runtime::Handle::try_current().is_ok(),
+                "object-store get requires its adapter runtime"
+            );
+        }
         self.inner.get_opts(location, options).await
     }
 
@@ -693,6 +911,12 @@ impl ObjectStore for FaultStore {
         location: &Path,
         ranges: &[Range<u64>],
     ) -> ObjectStoreResult<Vec<Bytes>> {
+        if self.require_runtime {
+            assert!(
+                tokio::runtime::Handle::try_current().is_ok(),
+                "object-store range read requires its adapter runtime"
+            );
+        }
         self.inner.get_ranges(location, ranges).await
     }
 


### PR DESCRIPTION
Explicit transactions on SlateDB-backed servers can fail at commit with `transaction commit coordinator closed unexpectedly`. Immutable-value cache reads were running on the engine’s runtime-independent commit thread; Tokio-dependent cache and object-store operations panic there.

Route immutable point/scan hydration and both insert/replacement uploads through the adapter’s existing worker. Flush reclamation uses that worker’s blocking pool. Normal multithreaded reads retain their direct execution path, and the engine remains usable without a caller-provided Tokio runtime.

Validation:
- All 85 SlateDB unit, integration, and conformance tests pass.
- Three new regressions fail against unpatched main and pass with this fix: cached explicit directory transactions on Tokio and plain executors, and immutable replacement/point/scan/flush without Tokio.
- Actual server + MinIO: cold-cache directory commit, bulk moves/deletes, explicit rollback, batch collision rollback, and data persistence across two server restarts pass with no coordinator panic.
- Clippy with warnings denied, Rust formatting, and changenote validation pass.
