### PR TITLE
Keep reads and observers available during explicit transactions

### DIFF
--- a/.changenotes/independent-transactions.md
+++ b/.changenotes/independent-transactions.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Keep ordinary reads and live queries available while an explicit transaction is open.
+
+Transactions now use an independent context on the originating handle's branch and account. Transaction reads see staged writes, while ordinary reads and observers see committed data. Commit publishes the changes; rollback leaves observers unaffected. Each originating handle still allows one explicit transaction at a time and must finish it before closing.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -239,6 +239,8 @@ these reads see its staged writes. Ordinary `lix.execute()` reads and
 `lix.observe()` remain available on the original handle and see committed data.
 Observers publish relevant updates after commit; rolled-back writes are never
 published. Changing the original handle's branch does not retarget the transaction.
+Local transactions retain the caller's previously acknowledged plugin-file view,
+so plugins can merge stale content against the correct base.
 
 Each handle permits one opening or active explicit transaction at a time. Use
 `openAnotherSession()` for another independent handle when needed.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -233,7 +233,19 @@ events.close();
 const tx = await lix.beginTransaction();
 ```
 
-Starts a transaction. While it is open, execute statements on the transaction handle.
+Starts an independent transaction context on this handle's current branch and
+account. Execute statements that belong to the transaction through `tx.execute()`;
+these reads see its staged writes. Ordinary `lix.execute()` reads and
+`lix.observe()` remain available on the original handle and see committed data.
+Observers publish relevant updates after commit; rolled-back writes are never
+published. Changing the original handle's branch does not retarget the transaction.
+
+Each handle permits one opening or active explicit transaction at a time. Use
+`openAnotherSession()` for another independent handle when needed.
+
+Commit or roll back the transaction before closing the original handle. Closing
+with an opening or active transaction still fails with
+`LIX_INVALID_TRANSACTION_STATE`.
 
 SQL `UPDATE` and `DELETE` decisions are protected until commit. If another
 transaction changes active-branch or shared/global state after this transaction

--- a/docs/server-protocol.md
+++ b/docs/server-protocol.md
@@ -132,6 +132,12 @@ provenance shadow state or extra source body fetch.
 
 ## Contract
 
+An explicit transaction owns an independent context on the session's branch and
+account. Requests to `/execute` and `/observe` on the originating session remain
+available and read committed data; `/transaction/execute` reads its staged writes.
+Commit makes those writes visible to observers, while rollback publishes no
+changes. A session still permits only one active explicit transaction at a time.
+
 The machine-readable surface is
 [`packages/lix/server-protocol.openapi.yaml`](https://github.com/opral/lix/blob/main/packages/lix/server-protocol.openapi.yaml).
 

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -4445,6 +4445,119 @@ async fn same_base_json_file_edits_compose_disjoint_semantics_without_resolution
 }
 
 #[tokio::test]
+async fn json_transaction_inherits_parent_acknowledged_file_view() {
+    let parent = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &parent,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/inherited-transaction-view.json";
+    let original = br#"{"mine":"base"}"#.to_vec();
+    write_file(&parent, path, original.clone()).await.unwrap();
+    assert_eq!(read_file(&parent, path).await.unwrap(), Some(original));
+
+    let peer = parent.open_another_session().await.unwrap();
+    write_file(&peer, path, br#"{"mine":"base","peer":"keep"}"#.to_vec())
+        .await
+        .unwrap();
+    // Begin after the peer's commit. The editor still submits bytes derived
+    // from the parent's earlier observation, not the latest repository bytes.
+    let mut transaction = parent.begin_transaction().await.unwrap();
+    transaction
+        .execute(
+            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            &[
+                Value::Blob(br#"{"mine":"transaction"}"#.to_vec().into()),
+                Value::Text(path.to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+    transaction.commit().await.unwrap();
+
+    let bytes = read_file(&peer, path).await.unwrap().unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+        serde_json::json!({ "mine": "transaction", "peer": "keep" }),
+        "starting a transaction must preserve the editor's acknowledged base"
+    );
+    peer.close().await.unwrap();
+    parent.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn json_transaction_rollback_preserves_parent_acknowledged_view() {
+    let parent = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &parent,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/rolled-back-transaction-view.json";
+    let original = br#"{"mine":"base","next":"base"}"#.to_vec();
+    write_file(&parent, path, original.clone()).await.unwrap();
+    assert_eq!(read_file(&parent, path).await.unwrap(), Some(original));
+
+    let mut transaction = parent.begin_transaction().await.unwrap();
+    let submitted = br#"{"mine":"rolled-back","next":"base"}"#.to_vec();
+    transaction
+        .execute(
+            "UPDATE lix_file SET content = $1 WHERE path = $2",
+            &[
+                Value::Blob(submitted.clone().into()),
+                Value::Text(path.to_owned()),
+            ],
+        )
+        .await
+        .unwrap();
+    let staged = transaction
+        .execute(
+            "SELECT content FROM lix_file WHERE path = $1",
+            &[Value::Text(path.to_owned())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        staged.rows()[0].get::<Vec<u8>>("content").unwrap(),
+        submitted
+    );
+    transaction.rollback().await.unwrap();
+
+    let peer = parent.open_another_session().await.unwrap();
+    let persisted = read_file(&peer, path).await.unwrap().unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&persisted).unwrap(),
+        serde_json::json!({ "mine": "base", "next": "base" })
+    );
+    write_file(
+        &peer,
+        path,
+        br#"{"mine":"peer","next":"base","peer":"keep"}"#.to_vec(),
+    )
+    .await
+    .unwrap();
+    // Neither staging nor reading rolled-back bytes may replace the parent's
+    // original acknowledged view. Its unchanged scalar must remain unchanged.
+    write_file(&parent, path, br#"{"mine":"base","next":"saved"}"#.to_vec())
+        .await
+        .unwrap();
+
+    let bytes = read_file(&peer, path).await.unwrap().unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&bytes).unwrap(),
+        serde_json::json!({ "mine": "peer", "peer": "keep", "next": "saved" }),
+        "rolled-back file views must not become the parent's acknowledged base"
+    );
+    peer.close().await.unwrap();
+    parent.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn stale_json_transaction_renders_retained_same_file_edits_with_resolutions() {
     let archive = build_json_plugin_archive();
     let stale_client = open_lix().await.unwrap();

--- a/packages/e2e/tests/rust_sdk_api.rs
+++ b/packages/e2e/tests/rust_sdk_api.rs
@@ -591,7 +591,7 @@ async fn transaction_rollback_discards_staged_writes() {
 }
 
 #[tokio::test]
-async fn transaction_blocks_session_execute_on_same_handle() {
+async fn transaction_keeps_same_handle_reads_and_writes_outside_its_snapshot() {
     let lix = open_lix().await.unwrap();
     register_crm_task_schema(&lix).await;
 
@@ -608,31 +608,37 @@ async fn transaction_blocks_session_execute_on_same_handle() {
     .await
     .unwrap();
 
-    let error = lix
-        .execute(
-            "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, CAST($4 AS JSONB))",
-            &[
-                Value::Text("outside-task".to_string()),
-                Value::Text("Outside tx".to_string()),
-                Value::Boolean(false),
-                Value::Text(r#"{"batch":1}"#.to_string()),
-            ],
-        )
-        .await
-        .expect_err("session writes should be blocked while explicit transaction is active");
-    assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+    lix.execute(
+        "INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, CAST($4 AS JSONB))",
+        &[
+            Value::Text("outside-task".to_string()),
+            Value::Text("Outside tx".to_string()),
+            Value::Boolean(false),
+            Value::Text(r#"{"batch":1}"#.to_string()),
+        ],
+    )
+    .await
+    .expect("parent writes commit independently while the transaction is active");
 
-    let error = lix
-        .execute("SELECT 1 AS ok", &[])
+    let parent_read = lix
+        .execute("SELECT id FROM crm_task ORDER BY id", &[])
         .await
-        .expect_err("session reads should be blocked while explicit transaction is active");
-    assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+        .expect("parent reads see committed data during the transaction");
+    assert_eq!(parent_read.rows().len(), 1);
+    assert_eq!(
+        parent_read.rows()[0].get::<String>("id").unwrap(),
+        "outside-task"
+    );
 
     let tx_read = tx
-        .execute("SELECT 1 AS ok", &[])
+        .execute("SELECT id FROM crm_task ORDER BY id", &[])
         .await
-        .expect("transaction reads should remain available");
-    assert_eq!(tx_read.rows()[0].get::<i64>("ok").unwrap(), 1);
+        .expect("transaction reads retain their own snapshot and staged data");
+    assert_eq!(tx_read.rows().len(), 1);
+    assert_eq!(
+        tx_read.rows()[0].get::<String>("id").unwrap(),
+        "tx-only-task"
+    );
 
     tx.commit().await.unwrap();
 
@@ -646,10 +652,14 @@ async fn transaction_blocks_session_execute_on_same_handle() {
         )
         .await
         .unwrap();
-    assert_eq!(committed.len(), 1);
+    assert_eq!(committed.len(), 2);
     assert_eq!(
-        committed.rows()[0].values(),
-        &[Value::Text("tx-only-task".to_string())]
+        committed.rows()[0].get::<String>("id").unwrap(),
+        "outside-task"
+    );
+    assert_eq!(
+        committed.rows()[1].get::<String>("id").unwrap(),
+        "tx-only-task"
     );
     lix.close().await.unwrap();
 }

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use futures_util::io::Cursor;
 use http::header::CONTENT_TYPE;
 use http::{Method, Request, Response, StatusCode};
-use http_body_util::{BodyExt as _, Full};
+use http_body_util::BodyExt as _;
 use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -681,43 +681,45 @@ async fn connected_api_routes_authority_work_and_hot_reads_need_no_round_trip() 
         Some("committed"),
     );
 
-    let guarded = replica
+    let mut guarded = replica
         .begin_transaction()
         .await
-        .expect("connected transaction reserves the ordinary session state");
-    for (label, result) in [
-        (
-            "read",
-            replica.execute("SELECT 1 AS value", &[]).await.map(|_| ()),
-        ),
-        (
-            "write",
-            replica
-                .execute(
-                    "INSERT INTO lix_key_value (key, value) VALUES ('outside-transaction', 'forbidden')",
-                    &[],
-                )
-                .await
-                .map(|_| ()),
-        ),
-    ] {
-        let error = result.expect_err("same-handle work must be blocked by connected transaction");
-        assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE", "{label}");
-    }
-    let observe_error = match replica.observe("SELECT 1 AS value", &[]) {
-        Err(error) => error,
-        Ok(mut observation) => {
-            observation.close();
-            panic!("same-handle observe must be blocked by connected transaction");
-        }
-    };
-    assert_eq!(observe_error.code, "LIX_INVALID_TRANSACTION_STATE");
+        .expect("connected transaction captures its own context");
+    guarded
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('pending-isolated', 'discarded')",
+            &[],
+        )
+        .await
+        .expect("stage data in the isolated transaction");
+    assert_eq!(read_value(&replica, "pending-isolated").await, None);
+    replica
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('outside-transaction', 'independent')",
+            &[],
+        )
+        .await
+        .expect("parent writes remain independent of the active transaction");
+    let mut observation = replica
+        .observe("SELECT key FROM lix_key_value WHERE key IN ('pending-isolated', 'outside-transaction') ORDER BY key", &[])
+        .expect("parent can register observations during a transaction");
+    let initial = tokio::time::timeout(WAIT_TIMEOUT, observation.next())
+        .await
+        .expect("parent observation must not stall during a transaction")
+        .expect("parent observation remains usable")
+        .expect("parent observation returns committed state");
+    assert_eq!(initial.rows.rows().len(), 1);
+    assert_eq!(
+        initial.rows.rows()[0].get::<String>("key").unwrap(),
+        "outside-transaction"
+    );
+    observation.close();
     let close_error = replica
         .close()
         .await
         .expect_err("close must reject an active connected transaction");
     assert_eq!(close_error.code, "LIX_INVALID_TRANSACTION_STATE");
-    let switch_error = tokio::time::timeout(
+    tokio::time::timeout(
         Duration::from_secs(5),
         replica.switch_branch(SwitchBranchOptions {
             branch_id: race_branch.id.clone(),
@@ -725,12 +727,31 @@ async fn connected_api_routes_authority_work_and_hot_reads_need_no_round_trip() 
     )
     .await
     .expect("switch under connected transaction must not deadlock")
-    .expect_err("switch must reject an active connected transaction");
-    assert_eq!(switch_error.code, "LIX_INVALID_TRANSACTION_STATE");
+    .expect("parent branch can change independently of the transaction");
+    let captured = guarded
+        .execute("SELECT lix_active_branch_id() AS branch_id", &[])
+        .await
+        .expect("transaction retains its captured branch");
+    assert_eq!(
+        captured.rows()[0].get::<String>("branch_id").unwrap(),
+        main_branch_id
+    );
     guarded
         .rollback()
         .await
-        .expect("connected transaction rollback releases session state");
+        .expect("connected transaction rollback releases its lifecycle reservation");
+    assert_eq!(replica.active_branch_id().await.unwrap(), race_branch.id);
+    replica
+        .switch_branch(SwitchBranchOptions {
+            branch_id: main_branch_id.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(read_value(&replica, "pending-isolated").await, None);
+    assert_eq!(
+        read_value(&replica, "outside-transaction").await.as_deref(),
+        Some("independent")
+    );
     replica
         .execute(
             "INSERT INTO lix_key_value (key, value) VALUES ('after-failed-close', 'usable')",
@@ -1767,7 +1788,7 @@ async fn handle_http<S>(
     probe: Arc<HttpProbe>,
     principal: ServerProtocolPrincipal,
     request: Request<Incoming>,
-) -> Result<Response<Full<Bytes>>, Infallible>
+) -> Result<Response<ServerProtocolBody>, Infallible>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
@@ -1776,7 +1797,7 @@ where
         return Ok(Response::builder()
             .status(503)
             .header(CONTENT_TYPE, "application/json")
-            .body(Full::new(Bytes::from_static(
+            .body(ServerProtocolBody::full(Bytes::from_static(
                 br#"{"error":{"code":"LIX_SYNC_TEST_OFFLINE","message":"test server offline"}}"#,
             )))
             .expect("build offline response"));
@@ -1803,7 +1824,7 @@ where
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(CONTENT_TYPE, "application/json")
-                .body(Full::new(Bytes::from(body)))
+                .body(ServerProtocolBody::full(Bytes::from(body)))
                 .expect("build mismatched handshake"));
         }
     }
@@ -1868,13 +1889,10 @@ where
         )
         .await;
     let (parts, body) = response.into_parts();
-    let body = body
-        .collect()
-        .await
-        .expect("collect protocol response")
-        .to_bytes();
+    // Observations are streaming responses. Collecting them here would wait
+    // forever before sending headers and conceal authority-backed observers.
     tokio::time::sleep(one_way_delay).await;
-    Ok(Response::from_parts(parts, Full::new(body)))
+    Ok(Response::from_parts(parts, body))
 }
 
 /// Asserts every file row's `directory_id` resolves among the same tree's

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -161,6 +161,11 @@ const merge = await lix.mergeBranch({ sourceBranchId: draft.id });
 
 ## Transactions
 
+`beginTransaction()` captures the current branch and account in an independent
+transaction context. Use `tx.execute()` for transaction work; its reads see staged
+writes. Ordinary reads and observers on `lix` continue to see committed data while
+the transaction is open. Commit or roll back before closing `lix`.
+
 ```ts
 const tx = await lix.beginTransaction();
 

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -950,7 +950,7 @@ test("observe close reliably resolves pending next calls", async () => {
 	await lix.close();
 });
 
-test("observe remains usable after next rejects", async () => {
+test("observe remains usable during a transaction and after rollback", async () => {
 	const lix = await openLix();
 	const events = lix.observe(
 		"SELECT key, value FROM lix_key_value WHERE key = $1",
@@ -961,14 +961,14 @@ test("observe remains usable after next rejects", async () => {
 	await tx.execute(
 		"INSERT INTO lix_key_value (key, value) VALUES ('js-observe-error', 'rolled-back')",
 	);
-	await expect(events.next()).rejects.toMatchObject({ name: "LixError" });
+	expect((await withTimeout(events.next()))?.result.rows).toEqual([]);
 	await tx.rollback();
 
 	await lix.execute(
 		"INSERT INTO lix_key_value (key, value) VALUES ('js-observe-error', 'after-error')",
 	);
 	const update = await events.next();
-	expect(update?.sequence).toBe(0);
+	expect(update?.sequence).toBe(1);
 	expect(update?.result.rows[0]?.value).toBe("after-error");
 
 	events.close();
@@ -1907,7 +1907,7 @@ test("beginTransaction preserves handle after invalid JS parameter", async () =>
 	await lix.close();
 });
 
-test("beginTransaction blocks session reads and writes on the same handle", async () => {
+test("beginTransaction leaves committed session reads available", async () => {
 	const lix = await openLix();
 	await registerCrmTaskSchema(lix);
 
@@ -1917,23 +1917,18 @@ test("beginTransaction blocks session reads and writes on the same handle", asyn
 		["tx-only-task", "Inside tx", false, JSON.stringify({ batch: 1 })],
 	);
 
-	await expect(lix.execute("SELECT 1 AS ok")).rejects.toMatchObject({
-		code: "LIX_INVALID_TRANSACTION_STATE",
-	});
-	await expect(
-		lix.execute(
-			"INSERT INTO crm_task (id, title, done, meta) VALUES ($1, $2, $3, CAST($4 AS JSONB))",
-			["outside-task", "Outside tx", false, JSON.stringify({ batch: 1 })],
-		),
-	).rejects.toMatchObject({ code: "LIX_INVALID_TRANSACTION_STATE" });
+	const committed = await lix.execute("SELECT id FROM crm_task WHERE id = $1", ["tx-only-task"]);
+	expect(committed.rows).toEqual([]);
+	const staged = await tx.execute("SELECT id FROM crm_task WHERE id = $1", ["tx-only-task"]);
+	expect(staged.rows).toEqual([{ id: "tx-only-task" }]);
 
 	await tx.commit();
 
-	const committed = await lix.execute(
+	const afterCommit = await lix.execute(
 		"SELECT id FROM crm_task WHERE id IN ($1, $2) ORDER BY id",
 		["outside-task", "tx-only-task"],
 	);
-	expect(committed.rows.map((row) => row.id)).toEqual(["tx-only-task"]);
+	expect(afterCommit.rows.map((row) => row.id)).toEqual(["tx-only-task"]);
 
 	await lix.close();
 });

--- a/packages/js-sdk/src/open-lix.test.ts
+++ b/packages/js-sdk/src/open-lix.test.ts
@@ -1686,6 +1686,48 @@ test("SQL plugin archive upsert stores the archive and installs schemas", async 
 	await lix.close();
 });
 
+test("transactions preserve acknowledged plugin files when saving stale bytes", async () => {
+	const lix = await openLix();
+	const csvPlugin = (await bundledPluginArchives()).find(
+		(plugin) => plugin.key === "plugin_csv",
+	);
+	if (!csvPlugin) throw new Error("expected bundled CSV plugin");
+	await upsertPluginArchive(lix, csvPlugin.key, csvPlugin.archiveBytes);
+	const path = "/transaction-views.csv";
+	const write =
+		"INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content";
+	const encode = (content: string) => new TextEncoder().encode(content);
+	await lix.execute(write, [path, encode("name,value\nfirst,base\n")]);
+	await lix.execute("SELECT content FROM lix_file WHERE path = $1", [path]);
+	const other = await lix.openAnotherSession();
+	try {
+		await other.execute(write, [
+			path,
+			encode("name,value\nfirst,base\nsecond,peer\n"),
+		]);
+		const tx = await lix.beginTransaction();
+		try {
+			await tx.execute(write, [path, encode("name,value\nfirst,edited\n")]);
+			await tx.commit();
+		} catch (error) {
+			await tx.rollback().catch(() => undefined);
+			throw error;
+		}
+		const result = await lix.execute(
+			"SELECT content FROM lix_file WHERE path = $1",
+			[path],
+		);
+		const content = new TextDecoder().decode(
+			get(result, "content") as Uint8Array,
+		);
+		expect(content).toContain("first,edited");
+		expect(content).toContain("second,peer");
+	} finally {
+		await other.close();
+		await lix.close();
+	}
+});
+
 test("bundled Markdown plugin executes detect-changes and render", async () => {
 	const lix = await openLix();
 	const markdownPlugin = (await bundledPluginArchives()).find(

--- a/packages/js-sdk/tests/memory-storage-contract.ts
+++ b/packages/js-sdk/tests/memory-storage-contract.ts
@@ -119,6 +119,66 @@ export function registerMemoryStorageContract({
 			await lix.close();
 		});
 
+		test("transactions isolate staged writes without interrupting parent reads or observers", async () => {
+			const { openLix } = await loadSdk();
+			const lix = await wait((openStorage ?? openLix)(), "open Lix");
+			const sql = "SELECT key, value FROM lix_key_value WHERE key IN ($1, $2) ORDER BY key";
+			const params = ["isolated-published", "isolated-staged"];
+			const existing = lix.observe(sql, params);
+			let fresh: ReturnType<ContractLix["observe"]> | undefined;
+			let tx: Awaited<ReturnType<ContractLix["beginTransaction"]>> | undefined;
+			let other: ContractLix | undefined;
+			try {
+				expect((await wait(existing.next(), "initial observer"))?.result.rows).toEqual([]);
+				tx = await wait(lix.beginTransaction(), "begin independent transaction");
+				await tx.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
+					params[1],
+					"pending",
+				]);
+				expect((await wait(lix.execute(sql, params), "parent read during transaction")).rows).toEqual(
+					[],
+				);
+				expect((await tx.execute(sql, params)).rows).toEqual([{ key: params[1], value: "pending" }]);
+				fresh = lix.observe(sql, params);
+				expect((await wait(fresh.next(), "new observer during transaction"))?.result.rows).toEqual([]);
+				other = await lix.openAnotherSession();
+				await other.execute("INSERT INTO lix_key_value (key, value) VALUES ($1, $2)", [
+					params[0],
+					"committed",
+				]);
+				expect(
+					(await wait(existing.next(), "existing observer during transaction"))?.result.rows,
+				).toEqual([{ key: params[0], value: "committed" }]);
+				expect((await wait(fresh.next(), "fresh observer external commit"))?.result.rows).toEqual([
+					{ key: params[0], value: "committed" },
+				]);
+				await tx.commit();
+				tx = undefined;
+				const expected = [
+					{ key: params[0], value: "committed" },
+					{ key: params[1], value: "pending" },
+				];
+				expect(
+					(await wait(existing.next(), "existing observer transaction commit"))?.result.rows,
+				).toEqual(expected);
+				expect((await wait(fresh.next(), "fresh observer transaction commit"))?.result.rows).toEqual(
+					expected,
+				);
+				tx = await lix.beginTransaction();
+				await tx.execute("DELETE FROM lix_key_value WHERE key = $1", [params[1]]);
+				expect((await lix.execute(sql, params)).rows).toEqual(expected);
+				await tx.rollback();
+				tx = undefined;
+				expect((await lix.execute(sql, params)).rows).toEqual(expected);
+			} finally {
+				existing.close();
+				fresh?.close();
+				await tx?.rollback().catch(() => undefined);
+				await other?.close();
+				await lix.close();
+			}
+		});
+
 		test("executes ordered atomic batches with per-statement parameters", async () => {
 			const { openLix } = await loadSdk();
 			const lix = await wait((openStorage ?? openLix)(), "open Lix");

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -2026,7 +2026,8 @@ where
                     active_branch_id.clone(),
                     self.active_account_id().to_owned(),
                 )
-                .await?;
+                .await?
+                .with_file_views_from(&self.session);
             let (_, session_state) = session.begin_connected_transaction_state()?;
             let client = authority.open_dedicated_client(active_branch_id).await?;
             // Install the dedicated client in its drop guard before the
@@ -2060,7 +2061,8 @@ where
         let session = Arc::new(
             self.engine
                 .open_session_at_with_account(branch_id, self.active_account_id().to_owned())
-                .await?,
+                .await?
+                .with_file_views_from(&self.session),
         );
         Ok(LixTransaction {
             _lifecycle: lifecycle,

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -676,8 +676,8 @@ where
 
 /// Clonable handle for a Lix repository.
 ///
-/// Clones share the active branch, transaction exclusion, file-view state,
-/// and close lifecycle.
+/// Clones share the active branch, file-view state, and close lifecycle.
+/// Explicit transactions use independent contexts on the captured branch.
 ///
 /// Public operation builders erase their internal future type, so embedding
 /// applications can spawn composed Lix flows without raising rustc's
@@ -690,11 +690,42 @@ where
 {
     engine: Arc<Engine<StorageSession<StorageImpl>>>,
     session: Arc<SessionContext<StorageSession<StorageImpl>>>,
+    transaction_lifecycle: Arc<PublicTransactionLifecycle>,
     primary_switch_gate: Option<Arc<tokio::sync::Mutex<()>>>,
     sync_lease: Option<Arc<SyncSessionLease>>,
     sync_demand_tx: Option<tokio::sync::mpsc::Sender<crate::sync::SyncDemand>>,
     connected_authority: Option<Arc<ConnectedAuthority>>,
     open_report: Arc<OpenReport>,
+}
+
+/// Reserves only the handle's close lifecycle, not its SQL session.
+#[derive(Default)]
+struct PublicTransactionLifecycle {
+    admission: tokio::sync::Mutex<()>,
+    active: AtomicUsize,
+}
+
+struct PublicTransactionLease(Arc<PublicTransactionLifecycle>);
+
+impl PublicTransactionLease {
+    fn acquire(lifecycle: Arc<PublicTransactionLifecycle>) -> Result<Self, LixError> {
+        lifecycle
+            .active
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| {
+                LixError::new(
+                    "LIX_INVALID_TRANSACTION_STATE",
+                    "Lix handle already has an active transaction",
+                )
+            })?;
+        Ok(Self(lifecycle))
+    }
+}
+
+impl Drop for PublicTransactionLease {
+    fn drop(&mut self) {
+        self.0.active.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 type ConnectedProtocolClient = ProtocolClient<crate::sync::AuthorityHttp>;
@@ -1097,6 +1128,7 @@ where
     let mut lix = Lix {
         engine: Arc::new(engine),
         session: Arc::new(session),
+        transaction_lifecycle: Arc::default(),
         primary_switch_gate: Some(Arc::new(tokio::sync::Mutex::new(()))),
         sync_lease: None,
         sync_demand_tx: None,
@@ -1219,6 +1251,7 @@ where
         Ok(Self {
             engine,
             session: Arc::new(session),
+            transaction_lifecycle: Arc::default(),
             primary_switch_gate: None,
             sync_lease: None,
             sync_demand_tx: None,
@@ -1488,6 +1521,7 @@ where
         Ok(Self {
             engine: self.engine.clone(),
             session: Arc::new(session),
+            transaction_lifecycle: Arc::default(),
             primary_switch_gate: None,
             sync_lease: None,
             sync_demand_tx: self.sync_demand_tx.clone(),
@@ -1965,7 +1999,18 @@ where
             })
     }
 
+    /// Starts an atomic transaction on the current branch and account.
+    ///
+    /// The transaction owns an independent context. Reads, observations, and
+    /// writes through this handle remain outside it, and later branch switches
+    /// do not retarget it. Finish or drop the transaction before closing this
+    /// handle (or one of its clones).
     pub async fn begin_transaction(&self) -> Result<LixTransaction<StorageImpl>, LixError> {
+        // Reserve before awaiting admission so close also notices an opening
+        // transaction. The mutex coordinates only begin/close, never SQL work.
+        let lifecycle = PublicTransactionLease::acquire(Arc::clone(&self.transaction_lifecycle))?;
+        let _admission = self.transaction_lifecycle.admission.lock().await;
+        self.session.ensure_open()?;
         if let Some(authority) = &self.connected_authority {
             let _operation = authority.begin_operation().await?;
             let demand_tx = self.sync_demand_tx.clone().ok_or_else(|| {
@@ -1974,29 +2019,52 @@ where
                     "connected authority transaction has no publication worker",
                 )
             })?;
-            let (active_branch_id, session_state) =
-                self.session.begin_connected_transaction_state()?;
-            let client = authority
-                .open_dedicated_client(active_branch_id)
+            let active_branch_id = Arc::clone(&self.session).active_branch_id_owned().await?;
+            let session = self
+                .engine
+                .open_session_at_with_account(
+                    active_branch_id.clone(),
+                    self.active_account_id().to_owned(),
+                )
                 .await?;
-            let transaction = match client.begin_transaction().await {
-                Ok(transaction) => transaction,
-                Err(error) => {
-                    let _ = client.close().await;
-                    return Err(error);
-                }
-            };
-            return Ok(LixTransaction {
+            let (_, session_state) = session.begin_connected_transaction_state()?;
+            let client = authority.open_dedicated_client(active_branch_id).await?;
+            // Install the dedicated client in its drop guard before the
+            // network await, so a cancelled/failed begin closes that session.
+            let mut opened = LixTransaction {
+                _lifecycle: lifecycle,
                 inner: LixTransactionInner::Authority {
-                    transaction: Some(transaction),
+                    transaction: None,
                     client: Some(client),
                     demand_tx,
                     session_state: Some(session_state),
                 },
-            });
+            };
+            if let LixTransactionInner::Authority {
+                transaction,
+                client,
+                ..
+            } = &mut opened.inner
+            {
+                *transaction = Some(
+                    client
+                        .as_ref()
+                        .ok_or_else(closed_transaction_error)?
+                        .begin_transaction()
+                        .await?,
+                );
+            }
+            return Ok(opened);
         }
+        let branch_id = Arc::clone(&self.session).active_branch_id_owned().await?;
+        let session = Arc::new(
+            self.engine
+                .open_session_at_with_account(branch_id, self.active_account_id().to_owned())
+                .await?,
+        );
         Ok(LixTransaction {
-            inner: LixTransactionInner::Local(Some(self.session.begin_transaction().await?)),
+            _lifecycle: lifecycle,
+            inner: LixTransactionInner::Local(Some(session.begin_transaction().await?)),
         })
     }
 
@@ -2317,10 +2385,22 @@ where
     }
 
     pub async fn close(&self) -> Result<(), LixError> {
-        // Preserve the ordinary session contract before mutating any remote
-        // lifecycle. In particular, an active connected transaction must make
-        // close fail without closing the shared authority client underneath
-        // the still-live handle.
+        // A begin awaiting network I/O must not make close wait for admission.
+        if self.transaction_lifecycle.active.load(Ordering::Acquire) > 0 {
+            return Err(LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                "cannot close Lix while an explicit transaction is active",
+            ));
+        }
+        let _admission = self.transaction_lifecycle.admission.lock().await;
+        if self.transaction_lifecycle.active.load(Ordering::Acquire) > 0 {
+            return Err(LixError::new(
+                "LIX_INVALID_TRANSACTION_STATE",
+                "cannot close Lix while an explicit transaction is active",
+            ));
+        }
+        // Check the independent transactions before mutating any session or
+        // remote lifecycle, including their shared publication worker.
         self.session.close().await?;
         let authority_result = match &self.connected_authority {
             Some(authority) => {
@@ -2431,6 +2511,7 @@ where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
     inner: LixTransactionInner<StorageImpl>,
+    _lifecycle: PublicTransactionLease,
 }
 
 enum LixTransactionInner<StorageImpl>
@@ -2787,6 +2868,53 @@ mod tests {
         Mutex,
         atomic::{AtomicUsize, Ordering},
     };
+
+    #[tokio::test]
+    async fn opening_transaction_rejects_close_and_cancellation_releases_reservation() {
+        let lix = open_lix().await.expect("open Lix");
+        let admission = lix.transaction_lifecycle.admission.lock().await;
+        let mut opening = Box::pin(lix.begin_transaction());
+        std::future::poll_fn(|cx| {
+            assert!(opening.as_mut().poll(cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+
+        let mut closing = Box::pin(lix.close());
+        std::future::poll_fn(|cx| {
+            let std::task::Poll::Ready(Err(error)) = closing.as_mut().poll(cx) else {
+                panic!("close must reject immediately while a transaction is opening");
+            };
+            assert_eq!(error.code, "LIX_INVALID_TRANSACTION_STATE");
+            std::task::Poll::Ready(())
+        })
+        .await;
+        drop(closing);
+        lix.execute("SELECT 1", &[])
+            .await
+            .expect("opening reservation does not block parent SQL");
+
+        drop(opening);
+        assert_eq!(lix.transaction_lifecycle.active.load(Ordering::Acquire), 0);
+        drop(admission);
+        lix.begin_transaction()
+            .await
+            .expect("cancelled begin releases reservation")
+            .rollback()
+            .await
+            .expect("replacement transaction rolls back");
+        lix.close().await.expect("parent closes after cancellation");
+    }
+
+    #[tokio::test]
+    async fn failed_transaction_begin_releases_lifecycle_reservation() {
+        let lix = open_lix().await.expect("open Lix");
+        lix.close().await.expect("close Lix");
+        assert!(lix.begin_transaction().await.is_err());
+        assert_eq!(lix.transaction_lifecycle.active.load(Ordering::Acquire), 0);
+        assert!(lix.begin_transaction().await.is_err());
+        assert_eq!(lix.transaction_lifecycle.active.load(Ordering::Acquire), 0);
+    }
 
     fn opened_spans(spans: &[CompletedTelemetrySpan]) -> Vec<&CompletedTelemetrySpan> {
         spans

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -10564,9 +10564,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remote_transaction_commit_and_rollback_preserve_one_session_snapshot() {
+    async fn remote_transaction_commit_and_rollback_keep_parent_reads_and_observers_available() {
         let app = app().await;
         let (session_id, _) = new_session(&app.router).await;
+
+        const COUNT_SQL: &str = "SELECT COUNT(*) AS count FROM lix_key_value WHERE key IN ('remote-tx', 'remote-rollback')";
+        let existing = request(
+            &app.router,
+            "POST",
+            "/lix/v1/observe",
+            Some(&session_id),
+            Some(json!({"sql": COUNT_SQL})),
+        )
+        .await;
+        assert_eq!(existing.status(), StatusCode::OK);
+        let mut existing = TestSseStream::new(existing);
+        let initial = existing.next().await;
+        assert_eq!(
+            initial["result"]["rows"][0][0],
+            json!({"kind": "int", "value": 0})
+        );
 
         let transaction_id = begin_remote_transaction(&app.router, &session_id).await;
         let staged = remote_transaction_request(
@@ -10586,12 +10603,45 @@ mod tests {
             "POST",
             "/lix/v1/execute",
             Some(&session_id),
-            Some(json!({ "sql": "SELECT 1" })),
+            Some(json!({ "sql": COUNT_SQL })),
         )
         .await;
-        assert_eq!(outside.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(outside.status(), StatusCode::OK);
         assert_eq!(
-            response_json(outside).await["error"]["code"],
+            response_json(outside).await["rows"][0][0],
+            json!({"kind": "int", "value": 0})
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), existing.next())
+                .await
+                .is_err(),
+            "existing observation must wait without seeing staged data or a transaction error"
+        );
+        let during = request(
+            &app.router,
+            "POST",
+            "/lix/v1/observe",
+            Some(&session_id),
+            Some(json!({"sql": COUNT_SQL})),
+        )
+        .await;
+        assert_eq!(during.status(), StatusCode::OK);
+        let mut during = TestSseStream::new(during);
+        assert_eq!(
+            during.next().await["result"]["rows"],
+            initial["result"]["rows"]
+        );
+        let duplicate = request(
+            &app.router,
+            "POST",
+            "/lix/v1/transaction/begin",
+            Some(&session_id),
+            None,
+        )
+        .await;
+        assert_eq!(duplicate.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response_json(duplicate).await["error"]["code"],
             "LIX_INVALID_TRANSACTION_STATE"
         );
         let committed = remote_transaction_request(
@@ -10604,6 +10654,12 @@ mod tests {
         )
         .await;
         assert_eq!(committed.status(), StatusCode::NO_CONTENT);
+        for body in [&mut existing, &mut during] {
+            assert_eq!(
+                body.next().await["result"]["rows"][0][0],
+                json!({"kind": "int", "value": 1})
+            );
+        }
         let replayed_commit = remote_transaction_request(
             &app.router,
             "POST",
@@ -10638,6 +10694,16 @@ mod tests {
         )
         .await;
         assert_eq!(rolled_back.status(), StatusCode::NO_CONTENT);
+        for body in [&mut existing, &mut during] {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), body.next())
+                    .await
+                    .is_err(),
+                "rollback must not publish staged data or terminate either observer"
+            );
+        }
+        drop(existing);
+        drop(during);
 
         let visible = request(
             &app.router,

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -279,6 +279,15 @@ where
         }
     }
 
+    /// Retains the caller's acknowledged plugin-file bases in a fresh
+    /// transaction context. Sharing also returns committed file-view updates
+    /// to the caller; the transaction's staged mutations stay private until
+    /// commit. Branch selection and transaction ownership remain independent.
+    pub(crate) fn with_file_views_from(mut self, origin: &Self) -> Self {
+        self.file_views = origin.file_views.clone();
+        self
+    }
+
     /// Releases this logical session handle. This is a lifecycle boundary only:
     /// successful writes are committed before their operation returns.
     pub async fn close(&self) -> Result<(), LixError> {

--- a/packages/lix/tests/integration/independent_transactions.rs
+++ b/packages/lix/tests/integration/independent_transactions.rs
@@ -1,0 +1,312 @@
+use std::time::Duration;
+
+use lix::{CreateBranchOptions, ObserveEvent, ObserveEvents, SwitchBranchOptions, Value, open_lix};
+
+const FILES_SQL: &str = "SELECT path, content FROM lix_file ORDER BY path";
+
+async fn next_event(events: &mut ObserveEvents) -> ObserveEvent {
+    tokio::time::timeout(Duration::from_secs(2), events.next())
+        .await
+        .expect("observation must not stall")
+        .expect("observation must remain usable during a transaction")
+        .expect("observation must remain open")
+}
+
+async fn expect_no_event(events: &mut ObserveEvents) {
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), events.next())
+            .await
+            .is_err(),
+        "uncommitted changes must neither publish nor invalidate an observer"
+    );
+}
+
+#[tokio::test]
+async fn public_transaction_keeps_parent_reads_and_observers_on_committed_state() {
+    let lix = open_lix().await.unwrap();
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ('/source/note.txt', CAST('keep me' AS BYTEA))",
+        &[],
+    )
+    .await
+    .unwrap();
+    let mut existing = lix.observe(FILES_SQL, &[]).unwrap();
+    let initial = next_event(&mut existing).await;
+
+    let mut transaction = lix.begin_transaction().await.unwrap();
+    transaction
+        .execute(
+            "UPDATE lix_file SET path = '/target/source/note.txt' WHERE path = '/source/note.txt'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let staged = transaction.execute(FILES_SQL, &[]).await.unwrap();
+    assert_eq!(
+        staged.rows()[0].get::<String>("path").unwrap(),
+        "/target/source/note.txt"
+    );
+
+    let committed = lix.execute(FILES_SQL, &[]).await.unwrap();
+    assert_eq!(
+        committed.rows()[0].values(),
+        initial.rows.rows()[0].values()
+    );
+    expect_no_event(&mut existing).await;
+    let mut registered_during_transaction = lix.observe(FILES_SQL, &[]).unwrap();
+    let fresh_initial = next_event(&mut registered_during_transaction).await;
+    assert_eq!(
+        fresh_initial.rows.rows()[0].values(),
+        initial.rows.rows()[0].values()
+    );
+
+    transaction.commit().await.unwrap();
+    for events in [&mut existing, &mut registered_during_transaction] {
+        let moved = next_event(events).await;
+        assert_eq!(moved.rows.len(), 1);
+        assert_eq!(moved.rows.rows()[0].values(), staged.rows()[0].values());
+        expect_no_event(events).await;
+        events.close();
+    }
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn public_transaction_rollback_publishes_no_partial_changes_and_observer_recovers() {
+    let lix = open_lix().await.unwrap();
+    lix.execute(
+        "INSERT INTO lix_file (path, content) VALUES ('/one.txt', CAST('one' AS BYTEA)), ('/two.txt', CAST('two' AS BYTEA))",
+        &[],
+    )
+    .await
+    .unwrap();
+    let mut events = lix.observe(FILES_SQL, &[]).unwrap();
+    let initial = next_event(&mut events).await;
+    let mut transaction = lix.begin_transaction().await.unwrap();
+    transaction
+        .execute("DELETE FROM lix_file WHERE path = '/one.txt'", &[])
+        .await
+        .unwrap();
+    transaction
+        .execute(
+            "UPDATE lix_file SET path = '/moved/two.txt' WHERE path = '/two.txt'",
+            &[],
+        )
+        .await
+        .unwrap();
+    expect_no_event(&mut events).await;
+    transaction.rollback().await.unwrap();
+    let committed = lix.execute(FILES_SQL, &[]).await.unwrap();
+    assert_eq!(committed.rows().len(), 2);
+    for (actual, expected) in committed.rows().iter().zip(initial.rows.rows()) {
+        assert_eq!(actual.values(), expected.values());
+    }
+    expect_no_event(&mut events).await;
+    lix.execute("DELETE FROM lix_file WHERE path = '/one.txt'", &[])
+        .await
+        .unwrap();
+    let changed = next_event(&mut events).await;
+    assert_eq!(changed.rows.len(), 1);
+    assert_eq!(
+        changed.rows.rows()[0].get::<String>("path").unwrap(),
+        "/two.txt"
+    );
+    events.close();
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn public_transaction_and_parent_writes_have_independent_overlays() {
+    let lix = open_lix().await.unwrap();
+    let mut first = lix.begin_transaction().await.unwrap();
+    assert!(
+        lix.clone().begin_transaction().await.is_err(),
+        "aliases share one explicit transaction slot"
+    );
+    let other = lix.open_another_session().await.unwrap();
+    let mut second = other.begin_transaction().await.unwrap();
+    first
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('first', 'first')",
+            &[],
+        )
+        .await
+        .unwrap();
+    second
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('second', 'second')",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert!(
+        second
+            .execute("SELECT key FROM lix_key_value WHERE key = 'first'", &[])
+            .await
+            .unwrap()
+            .rows()
+            .is_empty()
+    );
+    lix.execute(
+        "INSERT INTO lix_key_value (key, value) VALUES ('parent', 'parent')",
+        &[],
+    )
+    .await
+    .unwrap();
+    first.commit().await.unwrap();
+    second.commit().await.unwrap();
+    let result = lix
+        .execute(
+            "SELECT key FROM lix_key_value WHERE key IN ('first', 'second', 'parent') ORDER BY key",
+            &[],
+        )
+        .await
+        .unwrap();
+    let keys: Vec<String> = result
+        .rows()
+        .iter()
+        .map(|row| row.get("key").unwrap())
+        .collect();
+    assert_eq!(keys, ["first", "parent", "second"]);
+    lix.begin_transaction()
+        .await
+        .unwrap()
+        .rollback()
+        .await
+        .unwrap();
+    other.close().await.unwrap();
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn public_transaction_retains_origin_branch_and_account_when_parent_switches() {
+    const AUTHOR: &str = "01920000-0000-7000-8000-000000000691";
+    let root = open_lix().await.unwrap();
+    root.ensure_account(AUTHOR, "Transaction author", "human")
+        .await
+        .unwrap();
+    let lix = root
+        .open_another_session()
+        .with_account(AUTHOR)
+        .await
+        .unwrap();
+    let origin = lix.active_branch_id().await.unwrap();
+    let other = lix
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "Other branch".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .unwrap();
+    let mut transaction = lix.begin_transaction().await.unwrap();
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: other.id.clone(),
+    })
+    .await
+    .unwrap();
+    let context = transaction
+        .execute(
+            "SELECT lix_active_branch_id() AS branch_id, lix_active_account_id() AS account_id",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        context.rows()[0].get::<String>("branch_id").unwrap(),
+        origin
+    );
+    assert_eq!(
+        context.rows()[0].get::<String>("account_id").unwrap(),
+        AUTHOR
+    );
+    transaction
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('origin-only', 'value')",
+            &[],
+        )
+        .await
+        .unwrap();
+    transaction.commit().await.unwrap();
+    assert_eq!(lix.active_branch_id().await.unwrap(), other.id);
+    assert!(
+        lix.execute(
+            "SELECT key FROM lix_key_value WHERE key = 'origin-only'",
+            &[]
+        )
+        .await
+        .unwrap()
+        .rows()
+        .is_empty()
+    );
+    lix.switch_branch(SwitchBranchOptions { branch_id: origin })
+        .await
+        .unwrap();
+    assert_eq!(
+        lix.execute(
+            "SELECT key FROM lix_key_value WHERE key = 'origin-only'",
+            &[]
+        )
+        .await
+        .unwrap()
+        .rows()
+        .len(),
+        1
+    );
+    let attribution = lix
+        .execute(
+            "SELECT account_id FROM lix_change WHERE schema_key = 'lix_key_value'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        attribution.rows().last().unwrap().values(),
+        &[Value::Text(AUTHOR.to_owned())]
+    );
+    lix.close().await.unwrap();
+    root.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn public_transaction_blocks_parent_close_until_commit_rollback_or_drop() {
+    for completion in ["commit", "rollback", "drop"] {
+        let lix = open_lix().await.unwrap();
+        let alias = lix.clone();
+        let mut transaction = lix.begin_transaction().await.unwrap();
+        transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('pending', 'value')",
+                &[],
+            )
+            .await
+            .unwrap();
+        alias
+            .close()
+            .await
+            .expect_err("a parent alias must not close a live transaction");
+        lix.execute("SELECT 1", &[])
+            .await
+            .expect("rejected close must leave parent usable");
+        match completion {
+            "commit" => transaction.commit().await.unwrap(),
+            "rollback" => transaction.rollback().await.unwrap(),
+            _ => drop(transaction),
+        }
+        let committed = lix
+            .execute("SELECT key FROM lix_key_value WHERE key = 'pending'", &[])
+            .await
+            .unwrap();
+        assert_eq!(committed.rows().len(), usize::from(completion == "commit"));
+        lix.begin_transaction()
+            .await
+            .unwrap()
+            .rollback()
+            .await
+            .unwrap();
+        alias.close().await.unwrap();
+        lix.execute("SELECT 1", &[])
+            .await
+            .expect_err("parent aliases must share close state");
+    }
+}

--- a/packages/lix/tests/integration/main.rs
+++ b/packages/lix/tests/integration/main.rs
@@ -10,6 +10,7 @@ mod engine;
 mod execute_batch_benchmark;
 mod filesystem_fuzz;
 mod fs_api;
+mod independent_transactions;
 mod json_pointer_crud_storage;
 // Imports `lix::storage_bench` at module scope, which exists only under
 // `storage-benches`; the `integration` target itself carries no required-features.


### PR DESCRIPTION
Opening an explicit transaction on a public Lix handle currently makes ordinary reads and live queries on that handle fail with `LIX_INVALID_TRANSACTION_STATE`. A folder move in LixRay therefore crashes the UI when Atelier refreshes a live query during the move.

Make `begin_transaction()` use an independent transaction context on the originating handle’s captured branch and account. `tx.execute()` sees staged writes; ordinary handle reads and observations continue seeing committed data. Commit publishes the changes, and rollback publishes nothing. This applies to native and browser SDKs and the server protocol without adding a new API.

The independent context shares the originating session’s acknowledged plugin-file views. This preserves the base used to merge stale content; staged updates remain private through rollback. JSON and CSV regressions cover inheritance and rollback.

Preserve one opening/active explicit transaction per originating handle (including clones), and reject closing that handle until the transaction finishes. A shared lifecycle reservation covers failed/cancelled begin and begin/close races. Low-level `SessionContext` transaction guards remain unchanged.

Validation:
- Targeted plugin, native SDK and connected-mode E2E suites: 124 passed, 8 skipped.
- `cargo nextest run -p lix --features all-simulations,server-protocol`: 3,647 passed, 78 skipped.
- `cargo test -p lix --doc`: 10 passed.
- Rust integration coverage for file moves with existing/new observers, rollback, independent writes, branch/account capture, and transaction lifecycle.
- Server protocol coverage for reads and SSE observation through commit/rollback, duplicate begin, and commit replay.
- Native JavaScript SDK: 206 tests passed, including a CSV stale-save regression that fails on the previous PR build.
- Browser/WASM contract suite: 19 passed, 1 existing skip.
- SDK TypeScript build and typecheck passed.
- Independent sub-agent review completed.

Separate from the SlateDB transaction runtime fix in #1702.

The E2E HTTP harness now streams protocol responses instead of collecting infinite SSE bodies before sending headers. Updated the native and connected E2E assertions that required the previous transaction exclusion behavior.

Known preexisting limitation found during review: explicit plugin-file transactions release actor leases after each statement and publish an uncached view on commit. A later stale save without a fresh read can still lose concurrent changes. That behavior predates this PR; restoring the submitted observation at commit requires a separate change that preserves transaction concurrency. This PR fixes the loss of an already acknowledged view when starting an independent transaction.

