### PR TITLE
fix(markdown): preserve source and content through edits

### DIFF
--- a/.changenotes/markdown-source-preservation.md
+++ b/.changenotes/markdown-source-preservation.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed Markdown edits losing literal content, unrelated formatting, or the original file encoding.
+
+No-op row updates now preserve file bytes, reference-definition edits refresh affected links, and cached block content no longer reappears after subsequent edits.

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -1318,6 +1318,86 @@ async fn v2_markdown_roundtrips_gfm_and_renders_one_direct_row_edit() {
 }
 
 #[tokio::test]
+async fn markdown_equal_length_overlay_is_cleared_after_rebuild() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_markdown",
+        &build_markdown_plugin_archive(),
+        &["markdown_node"],
+    )
+    .await;
+    let path = "/overlay-qa.md";
+    for source in [
+        "Alpha\n\nBravo\n",
+        "Omega\n\nBravo\n",
+        "Delta\n\nBravo\n\nCharlie\n",
+    ] {
+        write_file(&lix, path, source.as_bytes().to_vec())
+            .await
+            .unwrap();
+    }
+    let rows = lix
+        .execute(
+            "SELECT id, payload_json FROM markdown_node WHERE kind = 'paragraph'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let target = rows
+        .rows()
+        .iter()
+        .find(|row| jsonb_column_contains(row, "payload_json", "Bravo"))
+        .unwrap();
+    lix.execute(
+        "UPDATE markdown_node SET payload_json = $1 WHERE id = $2",
+        &[
+            Value::Text(
+                serde_json::json!({"inline": [{"type": "text", "value": "BRAVO"}]}).to_string(),
+            ),
+            Value::Text(target.get::<String>("id").unwrap()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"Delta\n\nBRAVO\n\nCharlie\n".to_vec())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn markdown_semantic_edit_retains_unrelated_literal_source() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_markdown",
+        &build_markdown_plugin_archive(),
+        &["markdown_node"],
+    )
+    .await;
+    let path = "/format-qa.md";
+    let source = "#   Heading ###\r\n\r\n```text\r\n|---\\---|\r\n```\r\n\r\nTarget\r\n";
+    write_file(&lix, path, source.as_bytes().to_vec())
+        .await
+        .unwrap();
+    lix.execute(
+        "UPDATE markdown_node SET payload_json = $1 WHERE kind = 'paragraph'",
+        &[Value::Text(
+            serde_json::json!({"inline": [{"type": "text", "value": "Edited"}]}).to_string(),
+        )],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(source.replace("Target", "Edited").into_bytes())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn v3_markdown_certified_open_sparse_successor_history_and_reopen() {
     let root = tempfile::tempdir().expect("create v3 Markdown directory");
     let lix = open_rocksdb_lix(root.path()).await;

--- a/plugins/markdown/src/core.rs
+++ b/plugins/markdown/src/core.rs
@@ -209,6 +209,9 @@ fn retain_noncanonical_source(
         format.remove(LEXICAL_SOURCE_REQUIRED_FIELD);
         return Ok(());
     }
+    // Canonicalization and decoding can move block offsets. These ranges no
+    // longer address the accepted bytes and must not drive incremental edits.
+    parsed.top_level_ranges.clear();
     format.insert(
         LEXICAL_FALLBACK_FIELD.to_owned(),
         serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(source)),
@@ -1984,38 +1987,88 @@ fn projection_after_detected_changes(
     changes: &[DetectedChange],
 ) -> Result<Projection, PluginError> {
     let mut nodes_by_id = flatten_tree(root);
-    if !changes.is_empty()
-        && let Some(document) = nodes_by_id
-            .values_mut()
-            .find(|node| node.kind == NodeKind::Document)
-    {
-        let format = document.format.as_object_mut().ok_or_else(|| {
-            PluginError::Internal("Markdown document format must be an object".into())
-        })?;
-        // The accepted source is valid only for the unchanged semantic tree.
-        // A semantic successor must render from its derived state instead of
-        // accidentally reusing the predecessor's raw bytes.
-        format.remove(LEXICAL_FALLBACK_FIELD);
-        format.remove(LEXICAL_SOURCE_REQUIRED_FIELD);
-    }
+    let mut changed = false;
     for change in changes {
         let id = change.row_pk.first().ok_or_else(|| {
             PluginError::InvalidInput("Markdown row_pk must contain one id".into())
         })?;
         if let Some(row) = &change.row {
-            let node = node_from_typed_row(row)?;
+            let mut node = node_from_typed_row(row)?;
             if node.id != *id {
                 return Err(PluginError::InvalidInput(format!(
                     "Markdown node id '{}' does not match row_pk '{id}'",
                     node.id
                 )));
             }
+            if node.kind == NodeKind::Document {
+                // Lexical caches are derived from bytes, never from an incoming
+                // row. An identical durable root row is still a no-op.
+                clear_lexical_source(&mut node);
+                if let Some(previous) = nodes_by_id.get(id) {
+                    let mut comparable = previous.clone();
+                    clear_lexical_source(&mut comparable);
+                    if comparable == node {
+                        continue;
+                    }
+                }
+            }
+            changed |= nodes_by_id.get(id) != Some(&node);
             nodes_by_id.insert(*id, node);
         } else {
-            nodes_by_id.remove(id);
+            changed |= nodes_by_id.remove(id).is_some();
+        }
+    }
+    if changed {
+        for document in nodes_by_id
+            .values_mut()
+            .filter(|node| node.kind == NodeKind::Document)
+        {
+            clear_lexical_source(document);
         }
     }
     Ok(Projection { nodes_by_id })
+}
+
+fn clear_lexical_source(node: &mut NodeSnapshot) {
+    if let Some(format) = node.format.as_object_mut() {
+        format.remove(LEXICAL_FALLBACK_FIELD);
+        format.remove(LEXICAL_SOURCE_REQUIRED_FIELD);
+    }
+}
+
+fn render_in_source_encoding(rendered: &[u8], original: &[u8]) -> Result<Vec<u8>, PluginError> {
+    fn encode(
+        source: &str,
+        encoding: &'static encoding_rs::Encoding,
+    ) -> Result<Vec<u8>, PluginError> {
+        if encoding == encoding_rs::UTF_16LE {
+            return Ok(source.encode_utf16().flat_map(u16::to_le_bytes).collect());
+        }
+        if encoding == encoding_rs::UTF_16BE {
+            return Ok(source.encode_utf16().flat_map(u16::to_be_bytes).collect());
+        }
+        let (encoded, _, had_errors) = encoding.encode(source);
+        if had_errors {
+            return Err(PluginError::InvalidInput(format!(
+                "Markdown edit cannot be represented in the original {} encoding",
+                encoding.name()
+            )));
+        }
+        Ok(encoded.into_owned())
+    }
+    let (buffer, encoding) = crate::markdown_file::buffer_with_encoding(original);
+    let (source, had_errors) = encoding.decode_without_bom_handling(buffer);
+    if had_errors || encode(&source, encoding)? != buffer {
+        return Err(PluginError::InvalidInput(
+            "Cannot edit Markdown rows without losing original encoding bytes".into(),
+        ));
+    }
+    let rendered = std::str::from_utf8(rendered).map_err(|error| {
+        PluginError::Internal(format!("Markdown renderer emitted invalid UTF-8: {error}"))
+    })?;
+    let mut output = original[..original.len() - buffer.len()].to_vec();
+    output.extend(encode(rendered, encoding)?);
+    Ok(output)
 }
 
 impl Document {
@@ -2387,8 +2440,22 @@ impl Document {
         }
         let current_root = self.tree.materialize();
         let projection = projection_after_detected_changes(&current_root, &detected)?;
-        let root = projection.to_tree()?;
-        let bytes = render_tree_with_lexical_fallback(&root)?;
+        let mut root = projection.to_tree()?;
+        if root == current_root {
+            return Ok((self.clone(), Vec::new()));
+        }
+        let bytes = match self.render_preserving_source(&current_root, &root)? {
+            Some(bytes) => bytes,
+            None => render_in_source_encoding(
+                &render_tree_with_lexical_fallback(&root)?,
+                &self.bytes.materialize(),
+            )?,
+        };
+        if render_tree(&root)? != bytes {
+            root.node.format[LEXICAL_FALLBACK_FIELD] =
+                serde_json::Value::String(base64::engine::general_purpose::STANDARD.encode(&bytes));
+            root.node.format[LEXICAL_SOURCE_REQUIRED_FIELD] = serde_json::Value::Bool(true);
+        }
         let top_level_ranges = simple_top_level_ranges(&root, &bytes);
         let before = self.bytes.materialize();
         let edits = minimal_byte_edit(&before, bytes.clone());
@@ -2400,6 +2467,115 @@ impl Document {
             },
             edits,
         ))
+    }
+
+    /// Replace changed blocks at verified source spans, retaining untouched
+    /// spelling and whitespace. Canonical parser offsets cannot be used here:
+    /// they may describe a different layout from the accepted source.
+    fn render_preserving_source(
+        &self,
+        before: &NodeTree,
+        after: &NodeTree,
+    ) -> Result<Option<Vec<u8>>, PluginError> {
+        let mut before_root = before.node.clone();
+        clear_lexical_source(&mut before_root);
+        if before_root != after.node {
+            return Ok(None);
+        }
+        let after_by_id = after
+            .children
+            .iter()
+            .map(|node| (node.node.id, node))
+            .collect::<BTreeMap<_, _>>();
+        let surviving = before
+            .children
+            .iter()
+            .filter(|old| after_by_id.contains_key(&old.node.id));
+        if surviving
+            .map(|node| node.node.id)
+            .ne(after.children.iter().map(|node| node.node.id))
+        {
+            return Ok(None);
+        }
+        let bytes = self.bytes.materialize();
+        let (buffer, encoding) = crate::markdown_file::buffer_with_encoding(&bytes);
+        let (source, had_errors) = encoding.decode_without_bom_handling(buffer);
+        if had_errors {
+            return Err(PluginError::InvalidInput(
+                "Cannot edit Markdown rows without losing undecodable source bytes".into(),
+            ));
+        }
+        let parsed = crate::markdown_file::parse_markdown_source_once(&source)?;
+        if parsed.root.children.len() != before.children.len() {
+            return Ok(None);
+        }
+        let mut edits = Vec::new();
+        let mut last_end = 0;
+        for ((original, old), range) in parsed
+            .root
+            .children
+            .iter()
+            .zip(&before.children)
+            .zip(&parsed.top_level_ranges)
+        {
+            let range = range.start..range.end.min(source.len());
+            if range.start < last_end || range.start > range.end {
+                return Ok(None);
+            }
+            last_end = range.end;
+            let Some(raw) = source.get(range.clone()) else {
+                return Ok(None);
+            };
+            if original.subtree_signature() != old.subtree_signature() {
+                // Noncanonical spelling can alter the initial tree. Verify its
+                // stable block representation before trusting the correspondence.
+                let stable = parse_markdown_source(raw)?;
+                if stable.root.children.len() != 1
+                    || stable.root.children[0].subtree_signature() != old.subtree_signature()
+                {
+                    return Ok(None);
+                }
+            }
+            let Some(&new) = after_by_id.get(&old.node.id) else {
+                edits.push((range, Vec::new()));
+                continue;
+            };
+            if old == new {
+                continue;
+            }
+            let mut fragment_root = after.node.clone();
+            fragment_root.format["final_newline"] =
+                serde_json::Value::Bool(raw.ends_with(['\n', '\r']));
+            let rendered = render_tree(&NodeTree {
+                node: fragment_root,
+                children: vec![new.clone()],
+            })?;
+            edits.push((range, rendered));
+        }
+        let splices = edits
+            .iter()
+            .map(|(range, insert)| FileEdit {
+                offset: range.start as u64,
+                delete_len: (range.end - range.start) as u64,
+                insert,
+            })
+            .collect::<Vec<_>>();
+        let rendered = PersistentBytes::from_vec(source.as_bytes().to_vec())
+            .splice(&splices)?
+            .materialize();
+        let rendered_source = std::str::from_utf8(&rendered)
+            .map_err(|error| PluginError::Internal(error.to_string()))?;
+        let canonical = render_tree(after)?;
+        let canonical_source = std::str::from_utf8(&canonical)
+            .map_err(|error| PluginError::Internal(error.to_string()))?;
+        // Block boundaries and reference definitions can change the meaning of
+        // neighboring source. Only retain a layout with the intended full parse.
+        if parse_markdown_source(rendered_source)?.canonical_render
+            != parse_markdown_source(canonical_source)?.canonical_render
+        {
+            return Ok(None);
+        }
+        Ok(Some(render_in_source_encoding(&rendered, &bytes)?))
     }
 
     fn try_paragraph_row_change(
@@ -2449,6 +2625,14 @@ impl Document {
             return Ok(None);
         }
         let new = node_from_typed_row(row)?;
+        if new == *old {
+            return Ok(Some((
+                self.bytes.clone(),
+                Arc::clone(&self.top_level_ranges),
+                Vec::new(),
+                self.tree.clone(),
+            )));
+        }
         if old.kind != NodeKind::Paragraph
             || new.kind != NodeKind::Paragraph
             || new.id != old.id
@@ -2561,6 +2745,9 @@ impl Document {
                 "file.content must be valid UTF-8 for an incremental Markdown edit: {error}"
             ))
         })?;
+        if fragment.contains(['[', ']']) {
+            return Ok(None);
+        }
         let mut replacement = parse_markdown_source(fragment)?;
         if replacement.root.children.len() != 1
             || replacement.root.children[0].node.kind != NodeKind::Paragraph
@@ -2624,6 +2811,16 @@ impl Document {
         let [splice] = splices else {
             return Ok(None);
         };
+        if self
+            .tree
+            .root_node()
+            .format
+            .get(LEXICAL_FALLBACK_FIELD)
+            .is_some()
+            || !splice.insert.iter().all(u8::is_ascii_alphanumeric)
+        {
+            return Ok(None);
+        }
         let offset = usize::try_from(splice.offset)
             .map_err(|_| PluginError::InvalidInput("Markdown splice offset is too large".into()))?;
         let delete_len = usize::try_from(splice.delete_len).map_err(|_| {
@@ -2649,6 +2846,17 @@ impl Document {
         else {
             return Ok(None);
         };
+        if !matches!(
+            self.tree.top_level_node(block_index).map(|node| node.kind),
+            Some(NodeKind::Paragraph | NodeKind::Heading)
+        ) || !self
+            .bytes
+            .range(offset..delete_end)?
+            .iter()
+            .all(u8::is_ascii_alphanumeric)
+        {
+            return Ok(None);
+        }
         let delta = isize::try_from(splice.insert.len()).expect("usize fits isize")
             - isize::try_from(delete_len).expect("usize fits isize");
         let successor_end = range
@@ -2664,6 +2872,9 @@ impl Document {
                 "file.content must be valid UTF-8 for an incremental Markdown edit: {error}"
             ))
         })?;
+        if fragment.contains(['[', ']']) {
+            return Ok(None);
+        }
         let mut replacement = parse_markdown_source(fragment)?;
         if replacement.root.children.len() != 1
             || render_tree(&replacement.root)? != fragment.as_bytes()
@@ -3116,16 +3327,17 @@ Another paragraph must survive an unrelated semantic edit.
                 assert_eq!(after, before, "unrelated semantic block changed");
             }
         }
-        assert!(
-            successor_tree
-                .node
-                .format
-                .get(LEXICAL_FALLBACK_FIELD)
-                .is_none(),
-            "semantic successor must clear the lexical fallback"
+        assert_eq!(
+            render_tree_with_lexical_fallback(&successor_tree).expect("render successor"),
+            successor.bytes(),
+            "the lexical fallback must describe the successor, never the predecessor"
         );
         let rendered = String::from_utf8(successor.bytes()).expect("rendered Markdown is UTF-8");
         assert!(rendered.contains("retained document"));
         assert!(rendered.contains("Another paragraph must survive"));
     }
 }
+
+#[cfg(test)]
+#[path = "core_qa_tests.rs"]
+mod qa_tests;

--- a/plugins/markdown/src/core_qa_tests.rs
+++ b/plugins/markdown/src/core_qa_tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+
+fn edit_target(document: &Document) -> Document {
+    let tree = document.tree.materialize();
+    let mut node = tree
+        .children
+        .iter()
+        .find(|child| {
+            serde_json::to_string(&child.node.payload)
+                .unwrap()
+                .contains("QA_TARGET")
+        })
+        .expect("target paragraph")
+        .node
+        .clone();
+    node.payload = serde_json::from_str(
+        &serde_json::to_string(&node.payload)
+            .unwrap()
+            .replace("QA_TARGET", "QA_EDITED"),
+    )
+    .unwrap();
+    document
+        .rows_changed(vec![RowChange {
+            schema_key: NODE_SCHEMA_KEY.into(),
+            row_pk: vec![node.id],
+            row: Some(node_to_typed_row(&node).unwrap()),
+            effect: ChangeEffect::Content,
+        }])
+        .expect("edit target")
+        .0
+}
+
+#[test]
+fn qa_semantic_edit_preserves_unrelated_source_format() {
+    let cases = [
+        "#   Unusual heading  ###\n\nQA_TARGET\n",
+        "*Counter:\n\nQA_TARGET\n",
+        "Title\n=====\n\nQA_TARGET\n",
+        "first  \nsecond\n\nQA_TARGET\n",
+        "\n\n# Heading\n\n\nQA_TARGET\n\n\n",
+        "> a\n>\n> b\n\nQA_TARGET\n",
+        "#   Header ###\n\n[x]: /url\n\nUse [x].\n\nQA_TARGET\n",
+        "---\nkey: value\n---\n\n#   Header ###\n\nQA_TARGET\n",
+        "| a | b |\n|---|---|\n| c | d |\n\n#   Header ###\n\nQA_TARGET\n",
+    ];
+    let mut failures = Vec::new();
+    for source in cases {
+        let (document, _) = Document::open_file(
+            source.as_bytes().to_vec(),
+            Some("qa.md"),
+            IdNamespace::from_halves(21, 1),
+        )
+        .unwrap();
+        let actual = edit_target(&document).bytes();
+        let expected = source.replace("QA_TARGET", "QA_EDITED").into_bytes();
+        if actual != expected {
+            failures.push(format!(
+                "source={source:?} actual={:?}",
+                String::from_utf8_lossy(&actual)
+            ));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn qa_replayed_unchanged_row_preserves_source_bytes() {
+    let source = b"#   Unusual heading  ###\n\n*Counter:\n\nQA_TARGET\n".to_vec();
+    let (document, _) = Document::open_file(
+        source.clone(),
+        Some("qa.md"),
+        IdNamespace::from_halves(21, 2),
+    )
+    .unwrap();
+    let node = document
+        .tree
+        .materialize()
+        .children
+        .last()
+        .unwrap()
+        .node
+        .clone();
+    let (successor, edits) = document
+        .rows_changed(vec![RowChange {
+            schema_key: NODE_SCHEMA_KEY.into(),
+            row_pk: vec![node.id],
+            row: Some(node_to_typed_row(&node).unwrap()),
+            effect: ChangeEffect::Content,
+        }])
+        .unwrap();
+    assert_eq!(successor.bytes(), source);
+    assert!(edits.is_empty());
+}
+
+#[test]
+fn qa_file_edits_and_reopen_preserve_bytes_deterministically() {
+    let mut source =
+        b"# Header\n\nSame paragraph\n\nSame paragraph\n\n- [ ] task\n\n```rs\nfn main() {}\n```\n"
+            .to_vec();
+    let (mut document, _) = Document::open_file(
+        source.clone(),
+        Some("qa.md"),
+        IdNamespace::from_halves(21, 3),
+    )
+    .unwrap();
+    for index in 0..80 {
+        let offset = (index * 17) % (source.len() + 1);
+        let insert = [b'x', b'\n', b'*', b' ', b'`', b'\r', b'|'][index % 7];
+        let edit = FileEdit {
+            offset: offset as u64,
+            delete_len: 0,
+            insert: &[insert],
+        };
+        let namespace = IdNamespace::from_halves(22, index as u32);
+        let (next, changes) = document.file_changed(&[edit], namespace).unwrap();
+        let (repeated, repeated_changes) = document.file_changed(&[edit], namespace).unwrap();
+        assert_eq!(
+            changes, repeated_changes,
+            "nondeterministic changes at {index}"
+        );
+        assert_eq!(next.bytes(), repeated.bytes());
+        source.insert(offset, insert);
+        assert_eq!(next.bytes(), source, "edit {index}");
+        let (cold, _) = Document::open_file(source.clone(), Some("qa.md"), namespace).unwrap();
+        assert_eq!(
+            render_tree(&next.tree.materialize()).unwrap(),
+            render_tree(&cold.tree.materialize()).unwrap(),
+            "incremental semantic divergence at edit {index}"
+        );
+        let (root, blocks) = next.arena_state().unwrap();
+        document = Document::open_arena(source.clone(), &root, blocks).unwrap();
+        assert_eq!(document.bytes(), source);
+    }
+}
+
+#[test]
+fn qa_incremental_context_edits_match_full_parse() {
+    let cases = [
+        ("[name]: /old\n\nUse [name].\n", "/old", "/new"),
+        ("[name]: /url\n\nUse [name].\n", "name", "other"),
+        (
+            "```\ninside\n```\n\noutside\n",
+            "```\n\noutside",
+            "``\n\noutside",
+        ),
+        ("#   Header  ###\n\nfirst\n\nsecond\n", "second", "changed"),
+    ];
+    let mut failures = Vec::new();
+    for (source, before, after) in cases {
+        let (document, _) = Document::open_file(
+            source.as_bytes().to_vec(),
+            Some("qa.md"),
+            IdNamespace::from_halves(23, 1),
+        )
+        .unwrap();
+        let edit = FileEdit {
+            offset: source.find(before).unwrap() as u64,
+            delete_len: before.len() as u64,
+            insert: after.as_bytes(),
+        };
+        let expected = source.replacen(before, after, 1);
+        let (incremental, _) = document
+            .file_changed(&[edit], IdNamespace::from_halves(23, 2))
+            .unwrap();
+        let (cold, _) = Document::open_file(
+            expected.as_bytes().to_vec(),
+            Some("qa.md"),
+            IdNamespace::from_halves(23, 2),
+        )
+        .unwrap();
+        let actual = render_tree(&incremental.tree.materialize()).unwrap();
+        let expected_render = render_tree(&cold.tree.materialize()).unwrap();
+        if actual != expected_render {
+            failures.push(format!(
+                "source={source:?} incremental={:?} cold={:?}",
+                String::from_utf8_lossy(&actual),
+                String::from_utf8_lossy(&expected_render)
+            ));
+        }
+        assert_eq!(incremental.bytes(), expected.as_bytes());
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn qa_semantic_edits_preserve_bom_crlf_and_legacy_encoding() {
+    let utf8 = "\u{feff}#   Header ###\r\n\r\nQA_TARGET\r\n";
+    let mut utf16 = vec![0xff, 0xfe];
+    for unit in "#   Header ###\r\n\r\nQA_TARGET\r\n".encode_utf16() {
+        utf16.extend(unit.to_le_bytes());
+    }
+    let cases = [
+        utf8.as_bytes().to_vec(),
+        utf16,
+        b"#   Caf\xe9 ###\r\n\r\nQA_TARGET\r\n".to_vec(),
+    ];
+    let mut failures = Vec::new();
+    for source in cases {
+        let (document, _) = Document::open_file(
+            source.clone(),
+            Some("qa.md"),
+            IdNamespace::from_halves(25, 1),
+        )
+        .unwrap();
+        let mut expected = source.clone();
+        let (before, after) = if source.starts_with(&[0xff, 0xfe]) {
+            (
+                "QA_TARGET"
+                    .encode_utf16()
+                    .flat_map(u16::to_le_bytes)
+                    .collect::<Vec<_>>(),
+                "QA_EDITED"
+                    .encode_utf16()
+                    .flat_map(u16::to_le_bytes)
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            (b"QA_TARGET".to_vec(), b"QA_EDITED".to_vec())
+        };
+        let offset = source
+            .windows(before.len())
+            .position(|window| window == before)
+            .unwrap();
+        expected.splice(offset..offset + before.len(), after);
+        let actual = edit_target(&document).bytes();
+        if actual != expected {
+            failures.push(format!("source={source:?} actual={actual:?}"));
+        }
+    }
+    assert!(failures.is_empty(), "{}", failures.join("\n"));
+}
+
+#[test]
+fn qa_semantic_edit_then_reopen_remains_source_preserving() {
+    let mut source = "\n#   Header ###\n\nQA_TARGET\n\n*untouched:\n\n".to_owned();
+    let (mut document, _) = Document::open_file(
+        source.as_bytes().to_vec(),
+        Some("qa.md"),
+        IdNamespace::from_halves(25, 2),
+    )
+    .unwrap();
+    for _ in 0..12 {
+        document = edit_target(&document);
+        source = source.replace("QA_TARGET", "QA_EDITED");
+        assert_eq!(document.bytes(), source.as_bytes());
+        let (root, blocks) = document.arena_state().unwrap();
+        document = Document::open_arena(document.bytes(), &root, blocks).unwrap();
+        let offset = source.find("QA_EDITED").unwrap();
+        let edit = FileEdit {
+            offset: offset as u64,
+            delete_len: 9,
+            insert: b"QA_TARGET",
+        };
+        document = document
+            .file_changed(&[edit], IdNamespace::from_halves(25, 3))
+            .unwrap()
+            .0;
+        source = source.replace("QA_EDITED", "QA_TARGET");
+        assert_eq!(document.bytes(), source.as_bytes());
+    }
+}
+
+#[test]
+fn qa_deleting_paragraph_preserves_unrelated_format() {
+    let source = "#   Header ###\n\nQA_TARGET\n\n*untouched:\n";
+    let (document, _) = Document::open_file(
+        source.as_bytes().to_vec(),
+        Some("qa.md"),
+        IdNamespace::from_halves(25, 4),
+    )
+    .unwrap();
+    let node = document.tree.materialize().children[1].node.clone();
+    let (result, _) = document
+        .rows_changed(vec![RowChange {
+            schema_key: NODE_SCHEMA_KEY.into(),
+            row_pk: vec![node.id],
+            row: None,
+            effect: ChangeEffect::Content,
+        }])
+        .unwrap();
+    let actual = String::from_utf8(result.bytes()).unwrap();
+    assert!(!actual.contains("QA_TARGET"));
+    assert!(actual.contains("#   Header ###"), "{actual:?}");
+    assert!(actual.contains("\n*untouched:"), "{actual:?}");
+}
+
+#[test]
+fn qa_legacy_encoded_file_edit_matches_cold_parse() {
+    let source = b"Caf\xe9 plain text\n\nSecond paragraph\n";
+    let (document, _) = Document::open_file(
+        source.to_vec(),
+        Some("qa.md"),
+        IdNamespace::from_halves(25, 5),
+    )
+    .unwrap();
+    let offset = source
+        .windows(5)
+        .position(|window| window == b"plain")
+        .unwrap();
+    let (next, _) = document
+        .file_changed(
+            &[FileEdit {
+                offset: offset as u64,
+                delete_len: 5,
+                insert: b"edited",
+            }],
+            IdNamespace::from_halves(25, 6),
+        )
+        .unwrap();
+    let mut expected = source.to_vec();
+    expected.splice(offset..offset + 5, b"edited".iter().copied());
+    assert_eq!(next.bytes(), expected);
+    let (cold, _) =
+        Document::open_file(expected, Some("qa.md"), IdNamespace::from_halves(25, 6)).unwrap();
+    assert_eq!(
+        render_tree(&next.tree.materialize()).unwrap(),
+        render_tree(&cold.tree.materialize()).unwrap()
+    );
+}

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -672,30 +672,21 @@ fn decode_block_shifts(bytes: &[u8]) -> sdk::Result<Vec<(u32, i64)>> {
             .unwrap_or_default()
             .checked_add(delta)
             .ok_or_else(|| sdk::Error::invalid_input("Markdown block shift overflowed"))?;
-        if total == 0 {
-            compact.remove(&ordinal);
-        } else {
-            compact.insert(ordinal, total);
-        }
+        // Zero shifts still identify persisted block overlays for rebuild cleanup.
+        compact.insert(ordinal, total);
     }
     Ok(compact.into_iter().collect())
 }
 
 fn add_block_shift(shifts: &mut Vec<(u32, i64)>, ordinal: u32, delta: i64) -> sdk::Result<bool> {
-    if delta == 0 {
-        return Ok(true);
-    }
+    // Every sparse edit writes an overlay, including equal-length edits.
     match shifts.binary_search_by_key(&ordinal, |(ordinal, _)| *ordinal) {
         Ok(index) => {
             let total = shifts[index]
                 .1
                 .checked_add(delta)
                 .ok_or_else(|| sdk::Error::invalid_input("Markdown block shift overflowed"))?;
-            if total == 0 {
-                shifts.remove(index);
-            } else {
-                shifts[index].1 = total;
-            }
+            shifts[index].1 = total;
             Ok(true)
         }
         Err(index) if shifts.len() < MAX_BLOCK_SHIFT_RECORDS => {
@@ -999,7 +990,8 @@ mod tests {
         }
         assert_eq!(shifts, [(7, 100_000)]);
         assert!(add_block_shift(&mut shifts, 7, -100_000).expect("cancel shift"));
-        assert!(shifts.is_empty());
+        assert_eq!(shifts, [(7, 0)]);
+        shifts.clear();
 
         for ordinal in 0..MAX_BLOCK_SHIFT_RECORDS as u32 {
             assert!(add_block_shift(&mut shifts, ordinal, 1).expect("insert bounded shift"));
@@ -1009,6 +1001,58 @@ mod tests {
             encode_block_shifts(&shifts).len(),
             MAX_BLOCK_SHIFT_RECORDS * 12
         );
+    }
+
+    #[test]
+    fn qa_sparse_overlays_remain_discoverable_without_net_length_changes() {
+        // A successful sparse edit always persists a block overlay. Rebuilds use
+        // this persisted index to delete those overlays before loading new blocks.
+        for deltas in [&[0_i64][..], &[3, -3][..]] {
+            let mut shifts = Vec::new();
+            for delta in deltas {
+                assert!(add_block_shift(&mut shifts, 7, *delta).expect("track edit"));
+            }
+            let persisted =
+                decode_block_shifts(&encode_block_shifts(&shifts)).expect("reopen overlay index");
+            assert!(
+                persisted.iter().any(|(ordinal, _)| *ordinal == 7),
+                "rebuild cleanup must discover overlay 7 after {deltas:?}"
+            );
+            assert_eq!(effective_block_position(100, 8, &persisted).unwrap(), 100);
+        }
+    }
+
+    #[test]
+    fn qa_sparse_positions_match_edited_blocks_across_repeated_reopens() {
+        let mut shifts = Vec::new();
+        let mut lengths = [100_i64; 64];
+        let mut seed = 0x1234_5678_u64;
+        for iteration in 0..4096 {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            let ordinal = (seed % lengths.len() as u64) as usize;
+            let delta = ((seed >> 8) % 7) as i64 - 3;
+            lengths[ordinal] += delta;
+            assert!(add_block_shift(&mut shifts, ordinal as u32, delta).unwrap());
+            if iteration % 17 == 0 {
+                shifts = decode_block_shifts(&encode_block_shifts(&shifts)).unwrap();
+                let mut expected = 0_u64;
+                for (ordinal, length) in lengths.iter().enumerate() {
+                    let base = ordinal as u64 * 102;
+                    assert_eq!(
+                        effective_block_position(base, ordinal as u32, &shifts).unwrap(),
+                        expected
+                    );
+                    expected += *length as u64;
+                    assert_eq!(
+                        effective_block_position(base + 100, ordinal as u32 + 1, &shifts).unwrap(),
+                        expected
+                    );
+                    expected += 2;
+                }
+            }
+        }
     }
 
     #[test]

--- a/plugins/markdown/src/markdown_file.rs
+++ b/plugins/markdown/src/markdown_file.rs
@@ -41,7 +41,7 @@ pub(crate) fn parse_file_with_literal_fast_path(
     parse_markdown_source_with_literal_fast_path(&decoded, allow_literal_fast_path)
 }
 
-fn buffer_with_encoding(buf: &[u8]) -> (&[u8], &'static Encoding) {
+pub(crate) fn buffer_with_encoding(buf: &[u8]) -> (&[u8], &'static Encoding) {
     if let Some((encoding, skip)) = Encoding::for_bom(buf) {
         (&buf[skip..], encoding)
     } else {
@@ -88,41 +88,104 @@ fn parse_markdown_source_with_literal_fast_path(
 }
 
 fn fully_escape_orphan_table_delimiters(rendered: Vec<u8>) -> Vec<u8> {
-    let mut output = Vec::with_capacity(rendered.len());
+    let mut candidates = Vec::new();
+    let mut offset = 0;
     for line in rendered.split_inclusive(|byte| *byte == b'\n') {
-        let content = line
-            .strip_suffix(b"\n")
-            .unwrap_or(line)
-            .strip_suffix(b"\r")
-            .unwrap_or_else(|| line.strip_suffix(b"\n").unwrap_or(line));
+        let content = line.strip_suffix(b"\n").unwrap_or(line);
+        let content = content.strip_suffix(b"\r").unwrap_or(content);
         let leading_whitespace = content
             .iter()
             .position(|byte| !byte.is_ascii_whitespace())
             .unwrap_or(content.len());
         let trimmed = &content[leading_whitespace..];
-        let candidate = trimmed.starts_with(b"|")
+        if trimmed.starts_with(b"|")
             && trimmed.ends_with(b"|")
             && trimmed.contains(&b'\\')
             && trimmed
                 .iter()
-                .all(|byte| matches!(byte, b'|' | b'-' | b':' | b'\\' | b' ' | b'\t'));
-        if !candidate {
-            output.extend_from_slice(line);
-            continue;
+                .all(|byte| matches!(byte, b'|' | b'-' | b':' | b'\\' | b' ' | b'\t'))
+        {
+            candidates.push(offset + leading_whitespace..offset + content.len());
         }
+        offset += line.len();
+    }
+    if candidates.is_empty() {
+        return rendered;
+    }
+
+    // Delimiter repair only applies to Markdown prose. In code, HTML, and
+    // frontmatter these same bytes are literal data, so escaping corrupts them.
+    let Ok(source) = std::str::from_utf8(&rendered) else {
+        return rendered;
+    };
+    let mut options = SyntaxOptions::gfm();
+    options.constructs.frontmatter = true;
+    let parsed = options.parse(source);
+    let mut paragraphs = Vec::new();
+    let mut literals = Vec::new();
+    collect_paragraph_spans(&parsed.document.children, &mut paragraphs, &mut literals);
+    paragraphs.sort_unstable_by_key(|span| span.start);
+    literals.sort_unstable_by_key(|span| span.start);
+    candidates.retain(|candidate| {
+        let paragraph = paragraphs.partition_point(|span| span.start <= candidate.start);
+        let literal = literals.partition_point(|span| span.end <= candidate.start);
+        paragraph > 0
+            && candidate.end <= paragraphs[paragraph - 1].end
+            && literals
+                .get(literal)
+                .is_none_or(|span| span.start >= candidate.end)
+    });
+    let mut output = Vec::with_capacity(rendered.len());
+    let mut cursor = 0;
+    for candidate in candidates {
+        output.extend_from_slice(&rendered[cursor..candidate.start]);
         let mut previous = None;
-        for byte in line {
-            if *byte == b'-' && previous != Some(b'\\') {
+        for &byte in &rendered[candidate.clone()] {
+            if byte == b'-' && previous != Some(b'\\') {
                 output.push(b'\\');
             }
-            output.push(*byte);
-            previous = Some(*byte);
+            output.push(byte);
+            previous = Some(byte);
         }
+        cursor = candidate.end;
     }
+    output.extend_from_slice(&rendered[cursor..]);
     output
 }
 
-fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginError> {
+fn collect_paragraph_spans(blocks: &[md::Block], spans: &mut Vec<Span>, literals: &mut Vec<Span>) {
+    for block in blocks {
+        match block {
+            md::Block::Paragraph(node) => {
+                spans.extend(node.meta.span);
+                collect_inline_literal_spans(&node.children, literals);
+            }
+            md::Block::BlockQuote(node) => collect_paragraph_spans(&node.children, spans, literals),
+            md::Block::Alert(node) => collect_paragraph_spans(&node.children, spans, literals),
+            md::Block::List(node) => {
+                for item in &node.children {
+                    collect_paragraph_spans(&item.children, spans, literals);
+                }
+            }
+            md::Block::FootnoteDefinition(node) => {
+                collect_paragraph_spans(&node.children, spans, literals)
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_inline_literal_spans(inlines: &[md::Inline], spans: &mut Vec<Span>) {
+    for inline in inlines {
+        match inline {
+            md::Inline::Code(node) => spans.extend(node.meta.span),
+            md::Inline::Html(node) => spans.extend(node.meta.span),
+            _ => collect_inline_literal_spans(inline.children(), spans),
+        }
+    }
+}
+
+pub(crate) fn parse_markdown_source_once(source: &str) -> Result<ParsedMarkdown, PluginError> {
     let mut options = SyntaxOptions::gfm();
     options.constructs.frontmatter = true;
     options.parse.preserve_character_escapes = true;
@@ -965,6 +1028,99 @@ mod tests {
             serde_json::to_vec(&third.root).expect("serialize third AST"),
             "{label} AST serialization must be deterministic"
         );
+    }
+
+    #[test]
+    fn qa_code_block_table_like_content_is_not_rewritten() {
+        for source in [
+            "```text\n|---\\---|\n```\n",
+            "    |---\\---|\n",
+            "`start\n|---\\---|\nend`\n",
+            "<pre>\n|---\\---|\n</pre>\n",
+            "---\n|---\\---|\n---\n",
+            "~~~text\r\n|---\\---|\r\n~~~\r\n",
+        ] {
+            let initial = parse_markdown_source_once(source).expect("initial parse");
+            let stable = parse_markdown_source(source).expect("stable parse");
+            assert_eq!(
+                stable.root.children[0].node.payload, initial.root.children[0].node.payload,
+                "verbatim content must survive canonicalization: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn qa_generated_verbatim_contexts_preserve_payloads_and_are_deterministic() {
+        fn literals(tree: &NodeTree, output: &mut Vec<Value>) {
+            if matches!(
+                tree.node.kind,
+                NodeKind::CodeBlock | NodeKind::HtmlBlock | NodeKind::Frontmatter
+            ) {
+                output.push(tree.node.payload.clone());
+            }
+            fn inline_codes(value: &Value, output: &mut Vec<Value>) {
+                match value {
+                    Value::Object(object)
+                        if object.get("type").and_then(Value::as_str) == Some("code") =>
+                    {
+                        output.push(object.get("value").unwrap().clone());
+                    }
+                    Value::Object(object) => {
+                        for value in object.values() {
+                            inline_codes(value, output);
+                        }
+                    }
+                    Value::Array(values) => {
+                        for value in values {
+                            inline_codes(value, output);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            inline_codes(&tree.node.payload, output);
+            for child in &tree.children {
+                literals(child, output);
+            }
+        }
+        for body in [
+            "|---\\---|",
+            "|:--\\--:|",
+            "|\\--|--|",
+            "|--\\\\--|",
+            "|---|",
+            "é 😀 |---\\---|",
+        ] {
+            // A bare table delimiter would end the paragraph before its code
+            // span closes. Keep that control case inside a real inline span.
+            let inline_body = if body == "|---|" { "x |---|" } else { body };
+            let sources = [
+                format!("```text\n{body}\n```\n"),
+                format!("~~~\n{body}\n~~~\n"),
+                format!("    {body}\n"),
+                format!("- item\n\n  ```\n  {body}\n  ```\n"),
+                format!("> ```\n> {body}\n> ```\n"),
+                format!("<pre>\n{body}\n</pre>\n"),
+                format!("---\n{body}\n---\n"),
+                format!("`start\n{inline_body}\nend`\n"),
+                format!("**`start\n{inline_body}\nend`**\n"),
+                format!("[`start\n{inline_body}\nend`](url)\n"),
+            ];
+            for source in sources {
+                let initial = parse_markdown_source_once(&source).unwrap();
+                let stable = parse_markdown_source(&source).unwrap();
+                let mut before = Vec::new();
+                let mut after = Vec::new();
+                literals(&initial.root, &mut before);
+                literals(&stable.root, &mut after);
+                assert!(
+                    !before.is_empty(),
+                    "fixture must exercise literal data: {source:?}"
+                );
+                assert_eq!(before, after, "verbatim payload changed: {source:?}");
+                assert_parse_serialize_fixpoint("generated verbatim context", &source);
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Markdown row edits could rewrite unrelated source formatting, corrupt literal code content, or resurrect stale cached blocks. This change preserves unchanged source and its encoding, keeps no-op updates byte-exact, and reparses reference-sensitive edits with full document context.

Adds regressions for multiline literals, BOM/legacy encodings, repeated edit/reopen cycles, and equal-length cache overlays, plus a release note.

Validation:
- 182 unit tests passed; one manual profile test ignored.
- 15 Markdown integration tests passed through the compiled plugin.
- 20 repeated QA runs passed with no flakes.
- Clippy and formatting checks passed.
