### PR TITLE
fix(csv): preserve cells and dialect through edits and reopen

### DIFF
--- a/.changenotes/csv-edit-roundtrip-preservation.md
+++ b/.changenotes/csv-edit-roundtrip-preservation.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed CSV edits and reopen operations losing cells, formatting, or the stored dialect.
+
+CSV now preserves UTF-8 BOMs, literal quote spelling, empty final cells, and missing final line endings when rows move. Multiline and adjacent file edits reconcile the correct rows, and unsupported NUL bytes are rejected before unreadable state is stored.

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -1161,6 +1161,181 @@ async fn csv_byte_edit_after_semantic_render_uses_successor_row_boundaries() {
 }
 
 #[tokio::test]
+async fn csv_equal_length_multirow_edit_preserves_cells_and_identities() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_csv",
+        &build_csv_plugin_archive(),
+        &["csv_table", "csv_row"],
+    )
+    .await;
+    let path = "/multirow-qa.csv";
+    write_file(&lix, path, b"alpha,one\nbeta,two\n".to_vec())
+        .await
+        .unwrap();
+    let file_id = file_id_at_path(&lix, path).await;
+    let initial = active_csv_rows(&lix, &file_id).await;
+    write_file(&lix, path, b"alpha,ONE\nbeta,TWO\n".to_vec())
+        .await
+        .expect("valid same-length edit spanning two records");
+    let rows = active_csv_rows(&lix, &file_id).await;
+    assert_eq!(
+        csv_row_id(&rows, &["alpha", "ONE"]),
+        csv_row_id(&initial, &["alpha", "one"])
+    );
+    assert_eq!(
+        csv_row_id(&rows, &["beta", "TWO"]),
+        csv_row_id(&initial, &["beta", "two"])
+    );
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"alpha,ONE\nbeta,TWO\n".to_vec())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn csv_quoted_and_empty_cell_edits_survive_reopen() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_csv",
+        &build_csv_plugin_archive(),
+        &["csv_table", "csv_row"],
+    )
+    .await;
+    let path = "/quoted-empty-qa.csv";
+    write_file(&lix, path, b"\"alpha\",one\r\nlast".to_vec())
+        .await
+        .unwrap();
+    let file_id = file_id_at_path(&lix, path).await;
+    let rows = active_csv_rows(&lix, &file_id).await;
+    for (id, cells) in [
+        (
+            csv_row_id(&rows, &["alpha", "one"]),
+            serde_json::json!(["alpha,changed", "one"]),
+        ),
+        (csv_row_id(&rows, &["last"]), serde_json::json!([""])),
+    ] {
+        lix.execute(
+            "UPDATE csv_row SET cells = $1 WHERE id = $2 AND lixcol_file_id = $3",
+            &[
+                Value::Jsonb(cells.into()),
+                Value::Text(id),
+                Value::Text(file_id.clone()),
+            ],
+        )
+        .await
+        .unwrap();
+    }
+    let expected = b"\"alpha,changed\",one\r\n\"\"".to_vec();
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(expected.clone()));
+    lix.close().await.unwrap();
+    let reopened = open_rocksdb_lix(root.path()).await;
+    assert_eq!(read_file(&reopened, path).await.unwrap(), Some(expected));
+    let rows = active_csv_rows(&reopened, &file_id).await;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().any(|row| row.cells == [""]));
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn csv_cross_record_quotes_and_crlf_keep_semantic_rows_consistent() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_csv",
+        &build_csv_plugin_archive(),
+        &["csv_table", "csv_row"],
+    )
+    .await;
+    let path = "/quoted-window-qa.csv";
+    write_file(&lix, path, b"a\nb\nc\"\nd\n".to_vec())
+        .await
+        .unwrap();
+    write_file(&lix, path, b"\"a\nb\nc\"\nd\n".to_vec())
+        .await
+        .unwrap();
+    let file_id = file_id_at_path(&lix, path).await;
+    let rows = active_csv_rows(&lix, &file_id).await;
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].cells, ["a\nb\nc"]);
+    assert_eq!(rows[1].cells, ["d"]);
+    write_file(&lix, path, b"a\nb\rc\r\nd".to_vec())
+        .await
+        .unwrap();
+    let expected = b"a\nb\r\nc\r\nd".to_vec();
+    write_file(&lix, path, expected.clone()).await.unwrap();
+    assert_eq!(active_csv_rows(&lix, &file_id).await.len(), 4);
+    assert!(write_file(&lix, path, b"a\0b\n".to_vec()).await.is_err());
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(expected));
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn csv_bom_stays_a_file_prefix_through_row_edits_and_reopen() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_csv",
+        &build_csv_plugin_archive(),
+        &["csv_table", "csv_row"],
+    )
+    .await;
+    let path = "/bom-qa.csv";
+    write_file(
+        &lix,
+        path,
+        b"\xef\xbb\xbf\"alpha,one\",x\r\nbeta,y".to_vec(),
+    )
+    .await
+    .unwrap();
+    let file_id = file_id_at_path(&lix, path).await;
+    let rows = active_csv_rows(&lix, &file_id).await;
+    let first_id = csv_row_id(&rows, &["alpha,one", "x"]);
+    lix.execute(
+        "UPDATE csv_row SET cells = $1 WHERE id = $2 AND lixcol_file_id = $3",
+        &[
+            Value::Jsonb(serde_json::json!(["alpha,changed", "x"]).into()),
+            Value::Text(first_id.clone()),
+            Value::Text(file_id.clone()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"\xef\xbb\xbf\"alpha,changed\",x\r\nbeta,y".to_vec())
+    );
+    lix.execute(
+        "DELETE FROM csv_row WHERE id = $1 AND lixcol_file_id = $2",
+        &[Value::Text(first_id), Value::Text(file_id.clone())],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"\xef\xbb\xbfbeta,y".to_vec())
+    );
+    lix.close().await.unwrap();
+    let reopened = open_rocksdb_lix(root.path()).await;
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(b"\xef\xbb\xbfbeta,y".to_vec())
+    );
+    write_file(&reopened, path, b"beta,UPDATED\n".to_vec())
+        .await
+        .unwrap();
+    let rows = active_csv_rows(&reopened, &file_id).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].cells, ["beta", "UPDATED"]);
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn csv_row_structure_edits_use_full_reconciliation() {
     let lix = open_lix().await.unwrap();
     install_reference_plugin_in_blank_registry(

--- a/plugins/csv/src/core.rs
+++ b/plugins/csv/src/core.rs
@@ -14,6 +14,7 @@ const ROWS_PER_CHUNK: usize = 512;
 const IDENTITIES_PER_CHUNK: usize = 64;
 const QUOTED_FIELD: u32 = 1 << 31;
 const FIELD_LENGTH_MASK: u32 = !QUOTED_FIELD;
+const UTF8_BOM: &[u8] = b"\xef\xbb\xbf";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IdNamespace(pub [u8; 16]);
@@ -81,6 +82,7 @@ pub struct Dialect {
     pub delimiter: u8,
     pub quote: Option<u8>,
     pub terminator: Terminator,
+    pub bom: bool,
 }
 
 impl Dialect {
@@ -94,6 +96,7 @@ impl Dialect {
             delimiter,
             quote: Some(b'"'),
             terminator: Terminator::Lf,
+            bom: false,
         }
     }
 
@@ -121,6 +124,8 @@ pub struct RowLayout {
     /// Base64url bitset, decoded into one bit per field. A set bit forces
     /// quoting even when the field's decoded value does not require it.
     force_quote: Vec<u8>,
+    /// Preserve accepted literal quotes inside otherwise-unquoted fields.
+    unquoted_quote: Vec<u8>,
     /// `None` inherits the table terminator, `Some(None)` is an unterminated
     /// row, and `Some(Some(_))` selects an exceptional row terminator.
     terminator: Option<Option<Terminator>>,
@@ -128,11 +133,17 @@ pub struct RowLayout {
 
 impl RowLayout {
     fn is_default(&self) -> bool {
-        self.force_quote.is_empty() && self.terminator.is_none()
+        self.force_quote.is_empty() && self.unquoted_quote.is_empty() && self.terminator.is_none()
     }
 
     fn force_quotes(&self, field: usize) -> bool {
         self.force_quote
+            .get(field / 8)
+            .is_some_and(|byte| byte & (1 << (field % 8)) != 0)
+    }
+
+    fn leaves_quotes_unquoted(&self, field: usize) -> bool {
+        self.unquoted_quote
             .get(field / 8)
             .is_some_and(|byte| byte & (1 << (field % 8)) != 0)
     }
@@ -1629,11 +1640,12 @@ impl RowImportBuilder {
                 .cmp(right.order_key.bytes(order_key_bytes))
                 .then_with(|| left.id.bytes(id_bytes).cmp(right.id.bytes(id_bytes)))
         });
-        let layouts = self
+        let mut layouts = self
             .layout_overrides
             .iter()
-            .map(|value| ((value.id.start, value.id.len), &value.layout))
+            .map(|value| ((value.id.start, value.id.len), value.layout.clone()))
             .collect::<HashMap<_, _>>();
+        let mut moved_unterminated_ending = false;
         for (index, row) in self.rows.iter().enumerate() {
             let ending = layouts
                 .get(&(row.id.start, row.id.len))
@@ -1641,12 +1653,24 @@ impl RowImportBuilder {
                     layout.ending(self.dialect)
                 });
             if ending.is_none() && index + 1 != self.rows.len() {
-                return Err("only the final CSV row may be unterminated".to_owned());
+                layouts
+                    .get_mut(&(row.id.start, row.id.len))
+                    .expect("an unterminated row has a layout override")
+                    .terminator = None;
+                moved_unterminated_ending = true;
             }
         }
+        if moved_unterminated_ending {
+            let last = self.rows.last().expect("a moved final ending has rows");
+            layouts
+                .entry((last.id.start, last.id.len))
+                .or_default()
+                .terminator = Some(None);
+        }
 
-        let rendered_len = self.rows.iter().try_fold(0usize, |total, row| {
-            let layout = layouts.get(&(row.id.start, row.id.len)).copied();
+        let prefix_len = if self.dialect.bom { UTF8_BOM.len() } else { 0 };
+        let rendered_len = self.rows.iter().try_fold(prefix_len, |total, row| {
+            let layout = layouts.get(&(row.id.start, row.id.len));
             let ending = layout.map_or(Some(self.dialect.terminator), |layout| {
                 layout.ending(self.dialect)
             });
@@ -1663,7 +1687,9 @@ impl RowImportBuilder {
                     .checked_add(rendered_cell_len(
                         cell,
                         self.dialect,
-                        layout.is_some_and(|layout| layout.force_quotes(index)),
+                        layout.is_some_and(|layout| layout.force_quotes(index))
+                            || (row.cell_count == 1 && ending.is_none() && cell.is_empty()),
+                        layout.is_some_and(|layout| layout.leaves_quotes_unquoted(index)),
                     )?)
                     .ok_or_else(|| "CSV rendered length overflowed".to_owned())?;
             }
@@ -1678,10 +1704,13 @@ impl RowImportBuilder {
         let row_count =
             u32::try_from(self.rows.len()).map_err(|_| "CSV has too many rows".to_owned())?;
         let mut blob = Vec::with_capacity(rendered_len);
+        if self.dialect.bom {
+            blob.extend_from_slice(UTF8_BOM);
+        }
         let mut chunks = Vec::with_capacity(self.rows.len().div_ceil(ROWS_PER_CHUNK));
         let mut chunk_rows = Vec::with_capacity(ROWS_PER_CHUNK);
         let mut chunk_fields = Vec::new();
-        let mut chunk_start = 0u32;
+        let mut chunk_start = prefix_len as u32;
         let mut field_count = 0u32;
         let mut chunk_key_cursor = 0u32;
         let mut noncompact_ranges = Vec::with_capacity(self.rows.len());
@@ -1706,7 +1735,7 @@ impl RowImportBuilder {
             let first_field = u32::try_from(chunk_fields.len())
                 .map_err(|_| "CSV chunk has too many fields".to_owned())?;
             let mut cursor = usize::try_from(row.cell_start).expect("u32 fits usize");
-            let layout = layouts.get(&(row.id.start, row.id.len)).copied();
+            let layout = layouts.get(&(row.id.start, row.id.len));
             for cell_index in 0..usize::from(row.cell_count) {
                 if cell_index > 0 {
                     blob.push(self.dialect.delimiter);
@@ -1718,7 +1747,11 @@ impl RowImportBuilder {
                     &mut blob,
                     cell,
                     self.dialect,
-                    layout.is_some_and(|layout| layout.force_quotes(cell_index)),
+                    layout.is_some_and(|layout| layout.force_quotes(cell_index))
+                        || (row.cell_count == 1
+                            && layout.is_some_and(|layout| layout.ending(self.dialect).is_none())
+                            && cell.is_empty()),
+                    layout.is_some_and(|layout| layout.leaves_quotes_unquoted(cell_index)),
                 )?;
                 let field_len = blob.len()
                     - usize::try_from(row_start).expect("validated rendered offset")
@@ -1856,11 +1889,25 @@ fn imported_cell_needs_quotes(cell: &[u8], dialect: Dialect) -> Result<bool, Str
     Ok(structural || cell.contains(&quote))
 }
 
-fn rendered_cell_len(cell: &[u8], dialect: Dialect, force_quote: bool) -> Result<usize, String> {
-    let canonical_quote = imported_cell_needs_quotes(cell, dialect)?;
-    if force_quote && canonical_quote {
-        return Err("CSV force_quote may select only otherwise-unnecessary quotes".to_owned());
+fn cell_needs_quotes(cell: &[u8], dialect: Dialect, unquoted_quote: bool) -> Result<bool, String> {
+    if unquoted_quote
+        && cell.first().copied() != dialect.quote
+        && !cell
+            .iter()
+            .any(|byte| *byte == dialect.delimiter || matches!(byte, b'\r' | b'\n'))
+    {
+        return Ok(false);
     }
+    imported_cell_needs_quotes(cell, dialect)
+}
+
+fn rendered_cell_len(
+    cell: &[u8],
+    dialect: Dialect,
+    force_quote: bool,
+    unquoted_quote: bool,
+) -> Result<usize, String> {
+    let canonical_quote = cell_needs_quotes(cell, dialect, unquoted_quote)?;
     if !force_quote && !canonical_quote {
         return Ok(cell.len());
     }
@@ -1881,11 +1928,9 @@ fn render_import_cell(
     cell: &[u8],
     dialect: Dialect,
     force_quote: bool,
+    unquoted_quote: bool,
 ) -> Result<bool, String> {
-    let canonical_quote = imported_cell_needs_quotes(cell, dialect)?;
-    if force_quote && canonical_quote {
-        return Err("CSV force_quote may select only otherwise-unnecessary quotes".to_owned());
-    }
+    let canonical_quote = cell_needs_quotes(cell, dialect, unquoted_quote)?;
     let quoted = force_quote || canonical_quote;
     if !quoted {
         output.extend_from_slice(cell);
@@ -1916,17 +1961,42 @@ impl Document {
 
     pub fn open_file_with_dialect(
         bytes: Vec<u8>,
+        dialect: Dialect,
+        namespace: IdNamespace,
+    ) -> Result<(Self, InitialChanges), String> {
+        Self::open_file_internal(bytes, dialect, namespace, true)
+    }
+
+    pub fn open_file_with_stored_dialect(
+        bytes: Vec<u8>,
+        dialect: Dialect,
+        namespace: IdNamespace,
+    ) -> Result<(Self, InitialChanges), String> {
+        Self::open_file_internal(bytes, dialect, namespace, false)
+    }
+
+    fn open_file_internal(
+        bytes: Vec<u8>,
         mut dialect: Dialect,
         namespace: IdNamespace,
+        infer_terminator: bool,
     ) -> Result<(Self, InitialChanges), String> {
         if bytes.len() > u32::MAX as usize {
             return Err("CSV supports files smaller than 4GiB".to_owned());
         }
         std::str::from_utf8(&bytes).map_err(|error| format!("CSV must be UTF-8: {error}"))?;
         dialect = dialect.validate_row()?;
-        let mut drafts = scan_rows(&bytes, 0, bytes.len(), dialect)?;
-        dialect.terminator =
-            preferred_terminator(drafts.iter().map(|row| row.ending), Terminator::Lf);
+        if infer_terminator {
+            dialect.bom = bytes.starts_with(UTF8_BOM);
+        } else if dialect.bom != bytes.starts_with(UTF8_BOM) {
+            return Err("CSV stored BOM metadata does not match accepted bytes".to_owned());
+        }
+        let prefix_len = if dialect.bom { UTF8_BOM.len() } else { 0 };
+        let mut drafts = scan_rows(&bytes, prefix_len, bytes.len(), dialect)?;
+        if infer_terminator {
+            dialect.terminator =
+                preferred_terminator(drafts.iter().map(|row| row.ending), Terminator::Lf);
+        }
         let identities = IdentityStore::initial(namespace, drafts.len())?;
         assign_initial_rows(&mut drafts);
         let document = Self(Arc::new(DocumentInner {
@@ -1951,7 +2021,7 @@ impl Document {
         namespace: IdNamespace,
         identities: &[RowIdentity],
     ) -> Result<Self, String> {
-        let document = Self::open_file_with_dialect(bytes, dialect, namespace)?.0;
+        let document = Self::open_file_with_stored_dialect(bytes, dialect, namespace)?.0;
         let mut records = document.row_records()?;
         if records.len() != identities.len() + 1 {
             return Err("CSV identity checkpoint row count does not match the file".to_owned());
@@ -2040,7 +2110,7 @@ impl Document {
             Terminator::CrLf => 2,
             Terminator::Cr => 3,
         });
-        output.push(0);
+        output.push(u8::from(self.0.dialect.bom));
         output.extend_from_slice(&row_count.to_le_bytes());
         for start in starts {
             output.extend_from_slice(&start.to_le_bytes());
@@ -2099,8 +2169,22 @@ impl Document {
         if descriptor_dialect_changed {
             return self.reparse_after_descriptor_change(after, after_path, namespace);
         }
+        if self.0.dialect.bom || after.range(0, after.len().min(UTF8_BOM.len()))? == UTF8_BOM {
+            return self.reparse_with_dialect(after, self.0.dialect, namespace, false);
+        }
 
-        let (first_old, last_old) = affected_row_window(&self.0.index, splices)?;
+        let (mut first_old, mut last_old) = affected_row_window(&self.0.index, splices)?;
+        if let Some(first) = first_old {
+            let start = self.0.index.row_start(first);
+            if start > 0 && self.0.blob.byte(start as usize - 1) == Some(b'\r') {
+                first_old = self
+                    .0
+                    .index
+                    .ordinal_of(first)
+                    .checked_sub(1)
+                    .and_then(|ordinal| self.0.index.ordinal_location(ordinal));
+            }
+        }
         let old_start = first_old.map_or(0, |location| self.0.index.row_start(location));
         let old_end = last_old.map_or(0, |location| self.0.index.row_end(location));
         let new_start = map_offset(old_start, splices, false)?;
@@ -2110,6 +2194,21 @@ impl Document {
         }
 
         let mut new_drafts = loop {
+            if new_end < after.len()
+                && new_end > 0
+                && after.byte(new_end - 1) == Some(b'\r')
+                && after.byte(new_end) == Some(b'\n')
+            {
+                let next_ordinal = last_old.map_or(0, |last| self.0.index.ordinal_of(last) + 1);
+                let next = self
+                    .0
+                    .index
+                    .ordinal_location(next_ordinal)
+                    .ok_or_else(|| "CSV CRLF extends beyond the indexed rows".to_owned())?;
+                last_old = Some(next);
+                new_end = map_offset(self.0.index.row_end(next), splices, true)?;
+                continue;
+            }
             let window = after.range(new_start, new_end)?;
             match scan_rows(&window, 0, window.len(), self.0.dialect) {
                 Ok(mut rows) => {
@@ -2124,7 +2223,15 @@ impl Document {
                 Err(error)
                     if new_end < after.len() && error.contains("unterminated quoted field") =>
                 {
-                    new_end = extend_to_next_record_boundary(&after, new_end);
+                    // Expanding a quoted field consumes predecessor records as
+                    // well as bytes. Include those records in reconciliation
+                    // and replacement so their old index entries cannot survive.
+                    let next_ordinal = last_old.map_or(0, |last| self.0.index.ordinal_of(last) + 1);
+                    let next = self.0.index.ordinal_location(next_ordinal).ok_or_else(|| {
+                        "CSV quoted field extends beyond the indexed rows".to_owned()
+                    })?;
+                    last_old = Some(next);
+                    new_end = map_offset(self.0.index.row_end(next), splices, true)?;
                 }
                 Err(error) => return Err(error),
             }
@@ -2187,12 +2294,25 @@ impl Document {
         after_path: Option<&str>,
         namespace: IdNamespace,
     ) -> Result<(Self, Vec<RowChange>), String> {
+        self.reparse_with_dialect(after, Dialect::for_path(after_path), namespace, true)
+    }
+
+    fn reparse_with_dialect(
+        &self,
+        after: PersistentBlob,
+        mut dialect: Dialect,
+        namespace: IdNamespace,
+        infer_terminator: bool,
+    ) -> Result<(Self, Vec<RowChange>), String> {
         let bytes = after.materialize();
         std::str::from_utf8(&bytes).map_err(|error| format!("CSV must be UTF-8: {error}"))?;
-        let mut dialect = Dialect::for_path(after_path);
-        let mut drafts = scan_rows(&bytes, 0, bytes.len(), dialect)?;
-        dialect.terminator =
-            preferred_terminator(drafts.iter().map(|row| row.ending), Terminator::Lf);
+        dialect.bom = bytes.starts_with(UTF8_BOM);
+        let prefix_len = if dialect.bom { UTF8_BOM.len() } else { 0 };
+        let mut drafts = scan_rows(&bytes, prefix_len, bytes.len(), dialect)?;
+        if infer_terminator {
+            dialect.terminator =
+                preferred_terminator(drafts.iter().map(|row| row.ending), Terminator::Lf);
+        }
         let old_locations = self.0.index.locations().collect::<Vec<_>>();
         let mut identities = self.0.identities.clone();
         match_rows(
@@ -2416,6 +2536,7 @@ impl Document {
             self.0.dialect,
             desired_ending,
             &semantic.layout.force_quote,
+            &semantic.layout.unquoted_quote,
         )?;
         let source_start = source_chunk.byte_start + source_row.relative_start;
         let source_len = source_row.byte_len;
@@ -2527,6 +2648,7 @@ impl Document {
             self.0.dialect,
             ending,
             &semantic.layout.force_quote,
+            &semantic.layout.unquoted_quote,
         )?;
         let splice = FileEdit {
             offset: u64::from(start),
@@ -2587,6 +2709,7 @@ impl Document {
             self.0.dialect,
             ending,
             &semantic.layout.force_quote,
+            &semantic.layout.unquoted_quote,
         )?;
         let mut replacement_drafts = Vec::with_capacity(2);
         let offset = if target_ordinal < self.row_count() {
@@ -2815,6 +2938,7 @@ impl ColdInitialImport {
         }
         std::str::from_utf8(&bytes).map_err(|error| format!("CSV must be UTF-8: {error}"))?;
         let mut dialect = Dialect::for_path(path);
+        dialect.bom = bytes.starts_with(UTF8_BOM);
         let (rows, fields) = scan_cold_rows(&bytes, dialect)?;
         dialect.terminator =
             preferred_terminator(rows.iter().map(|row| row.ending), Terminator::Lf);
@@ -2860,7 +2984,7 @@ impl ColdInitialImport {
             Terminator::CrLf => 2,
             Terminator::Cr => 3,
         });
-        output.push(0);
+        output.push(u8::from(self.dialect.bom));
         output.extend_from_slice(
             &u32::try_from(self.rows.len())
                 .expect("CSV row count fits u32")
@@ -2914,6 +3038,9 @@ pub struct ArenaRowIndex {
 
 #[allow(dead_code)]
 impl ArenaRowIndex {
+    pub fn dialect(&self) -> Dialect {
+        self.dialect
+    }
     pub fn decode(bytes: &[u8]) -> Result<Self, String> {
         const HEADER_BYTES: usize = 36;
         if bytes.len() < HEADER_BYTES || &bytes[..8] != b"LIXCSV3\0" {
@@ -2955,7 +3082,10 @@ impl ArenaRowIndex {
             .chunks_exact(4)
             .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("four-byte CSV row offset")))
             .collect::<Vec<_>>();
-        if starts.first().copied() != Some(0)
+        if bytes[31] > 1
+            || file_len < u64::from(bytes[31]) * 3
+            || (file_len == u64::from(bytes[31]) * 3) != (row_count == 0)
+            || (!starts.is_empty() && starts.first().copied() != Some(u32::from(bytes[31]) * 3))
             || !starts.windows(2).all(|pair| pair[0] < pair[1])
             || starts
                 .last()
@@ -2970,7 +3100,9 @@ impl ArenaRowIndex {
                 delimiter,
                 quote,
                 terminator,
-            },
+                bom: bytes[31] != 0,
+            }
+            .validate_row()?,
             row_count: u32::try_from(row_count).expect("decoded CSV row count came from u32"),
             starts,
         })
@@ -3005,7 +3137,11 @@ impl ArenaRowIndex {
             .expect("header size fits u64")
             .checked_add(u64::from(row_count).saturating_mul(4))
             .ok_or_else(|| "CSV arena state size overflowed".to_owned())?;
-        if state_len != expected || row_count == 0 {
+        if state_len != expected
+            || bytes[31] > 1
+            || file_len < u64::from(bytes[31]) * 3
+            || (file_len == u64::from(bytes[31]) * 3) != (row_count == 0)
+        {
             return Err("CSV arena state row index is truncated".to_owned());
         }
         Ok(Self {
@@ -3015,7 +3151,9 @@ impl ArenaRowIndex {
                 delimiter,
                 quote,
                 terminator,
-            },
+                bom: bytes[31] != 0,
+            }
+            .validate_row()?,
             row_count,
             starts: Vec::new(),
         })
@@ -3195,19 +3333,21 @@ fn scan_cold_rows(
     bytes: &[u8],
     dialect: Dialect,
 ) -> Result<(Vec<ColdRowDraft>, Vec<FieldRange>), String> {
+    validate_csv_text(bytes)?;
     if bytes.is_empty() {
         return Ok((Vec::new(), Vec::new()));
     }
     let mut rows = Vec::new();
     let mut fields = Vec::new();
-    let mut row_start = 0usize;
-    let mut field_start = 0usize;
+    let prefix_len = if dialect.bom { UTF8_BOM.len() } else { 0 };
+    let mut row_start = prefix_len;
+    let mut field_start = prefix_len;
     let mut row_first_field = 0usize;
     let mut row_has_quoted_fields = false;
     let mut quoted = false;
     let mut field_was_quoted = false;
     let mut just_closed_quote = false;
-    let mut cursor = 0usize;
+    let mut cursor = prefix_len;
 
     let push_row = |rows: &mut Vec<ColdRowDraft>,
                     fields: &Vec<FieldRange>,
@@ -3353,6 +3493,7 @@ fn scan_rows(
     if start > end || end > bytes.len() {
         return Err("invalid CSV scan range".to_owned());
     }
+    validate_csv_text(&bytes[start..end])?;
     if start == end {
         return Ok(Vec::new());
     }
@@ -3768,9 +3909,21 @@ mod cold_scan_tests {
     }
 }
 
+fn validate_csv_text(bytes: &[u8]) -> Result<(), String> {
+    std::str::from_utf8(bytes).map_err(|error| format!("CSV must be UTF-8: {error}"))?;
+    if bytes.contains(&0) {
+        return Err(
+            "CSV cells cannot contain NUL bytes because typed JSONB strings cannot represent them"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
 fn validate_splices(file_len: usize, splices: &[FileEdit<'_>]) -> Result<(), String> {
     let mut previous_end = 0u64;
-    for (index, splice) in splices.iter().enumerate() {
+    let mut previous_start = None;
+    for splice in splices {
         let end = splice
             .offset
             .checked_add(splice.delete_len)
@@ -3778,11 +3931,12 @@ fn validate_splices(file_len: usize, splices: &[FileEdit<'_>]) -> Result<(), Str
         if end > u64::try_from(file_len).expect("usize fits u64") {
             return Err("CSV splice exceeds accepted file".to_owned());
         }
-        if index > 0 && splice.offset <= previous_end {
+        if previous_start == Some(splice.offset) || splice.offset < previous_end {
             return Err(
                 "CSV splices must have strictly increasing, non-overlapping starts".to_owned(),
             );
         }
+        previous_start = Some(splice.offset);
         previous_end = end;
     }
     Ok(())
@@ -4520,6 +4674,7 @@ fn typed_row_from_index(
     let end = first + usize::from(row.field_count);
     let mut cells = Vec::with_capacity(usize::from(row.field_count));
     let mut force_quote = Vec::new();
+    let mut unquoted_quote = Vec::new();
     for (index, field) in chunk.data.fields[first..end].iter().copied().enumerate() {
         if field_has_unnecessary_quotes(&row_bytes, 0, field, dialect)? {
             if force_quote.len() <= index / 8 {
@@ -4527,7 +4682,16 @@ fn typed_row_from_index(
             }
             force_quote[index / 8] |= 1 << (index % 8);
         }
-        cells.push(decoded_field(&row_bytes, 0, field, dialect.quote)?);
+        let cell = decoded_field(&row_bytes, 0, field, dialect.quote)?;
+        if !field.quoted()
+            && dialect
+                .quote
+                .is_some_and(|quote| cell.as_bytes().contains(&quote))
+        {
+            unquoted_quote.resize(index / 8 + 1, 0);
+            unquoted_quote[index / 8] |= 1 << (index % 8);
+        }
+        cells.push(cell);
     }
     let exceptional_ending = (row.ending() != Some(dialect.terminator)).then_some(row.ending());
     csv_typed_row(CsvRow {
@@ -4536,6 +4700,7 @@ fn typed_row_from_index(
         cells,
         layout: RowLayout {
             force_quote,
+            unquoted_quote,
             terminator: exceptional_ending,
         },
     })
@@ -4555,6 +4720,7 @@ fn typed_row_from_cold(
     let end = first + usize::from(row.field_count);
     let mut cells = Vec::with_capacity(usize::from(row.field_count));
     let mut force_quote = Vec::new();
+    let mut unquoted_quote = Vec::new();
     for (index, field) in fields[first..end].iter().copied().enumerate() {
         if row.has_quoted_fields && field_has_unnecessary_quotes(row_bytes, 0, field, dialect)? {
             if force_quote.len() <= index / 8 {
@@ -4562,7 +4728,16 @@ fn typed_row_from_cold(
             }
             force_quote[index / 8] |= 1 << (index % 8);
         }
-        cells.push(decoded_field(row_bytes, 0, field, dialect.quote)?);
+        let cell = decoded_field(row_bytes, 0, field, dialect.quote)?;
+        if !field.quoted()
+            && dialect
+                .quote
+                .is_some_and(|quote| cell.as_bytes().contains(&quote))
+        {
+            unquoted_quote.resize(index / 8 + 1, 0);
+            unquoted_quote[index / 8] |= 1 << (index % 8);
+        }
+        cells.push(cell);
     }
     let exceptional_ending = (row.ending != Some(dialect.terminator)).then_some(row.ending);
     csv_typed_row(CsvRow {
@@ -4571,6 +4746,7 @@ fn typed_row_from_cold(
         cells,
         layout: RowLayout {
             force_quote,
+            unquoted_quote,
             terminator: exceptional_ending,
         },
     })
@@ -4592,6 +4768,9 @@ fn table_row(dialect: Dialect) -> TypedRow {
         "terminator".to_owned(),
         JsonValue::String(dialect.terminator.text().to_owned()),
     );
+    if dialect.bom {
+        dialect_value.insert("bom".to_owned(), JsonValue::Bool(true));
+    }
     TypedRow::from([
         (
             "dialect".to_owned(),
@@ -4620,12 +4799,17 @@ fn parse_table_row(row: &TypedRow) -> Result<Dialect, String> {
     let dialect = dialect
         .as_object()
         .ok_or_else(|| "CSV table dialect must be an object".to_owned())?;
-    if dialect.len() != 3
+    if dialect
+        .keys()
+        .any(|key| !matches!(key.as_str(), "delimiter" | "quote" | "terminator" | "bom"))
         || !dialect.contains_key("delimiter")
         || !dialect.contains_key("quote")
         || !dialect.contains_key("terminator")
     {
-        return Err("CSV dialect must contain only delimiter, quote, and terminator".to_owned());
+        return Err(
+            "CSV dialect must contain delimiter, quote, and terminator, with an optional bom flag"
+                .to_owned(),
+        );
     }
     let delimiter = dialect
         .get("delimiter")
@@ -4650,10 +4834,16 @@ fn parse_table_row(row: &TypedRow) -> Result<Dialect, String> {
         Some("\r") => Terminator::Cr,
         _ => return Err("CSV terminator is invalid".to_owned()),
     };
+    let bom = match dialect.get("bom") {
+        None => false,
+        Some(JsonValue::Bool(bom)) => *bom,
+        _ => return Err("CSV BOM flag must be a boolean".to_owned()),
+    };
     Dialect {
         delimiter,
         quote,
         terminator,
+        bom,
     }
     .validate_row()
 }
@@ -4710,6 +4900,12 @@ fn csv_typed_row(row: CsvRow) -> Result<TypedRow, String> {
             layout.insert(
                 "force_quote".to_owned(),
                 JsonValue::String(URL_SAFE_NO_PAD.encode(row.layout.force_quote)),
+            );
+        }
+        if !row.layout.unquoted_quote.is_empty() {
+            layout.insert(
+                "unquoted_quote".to_owned(),
+                JsonValue::String(URL_SAFE_NO_PAD.encode(row.layout.unquoted_quote)),
             );
         }
         if let Some(ending) = row.layout.terminator {
@@ -4782,49 +4978,69 @@ pub fn parse_csv_row(row: &TypedRow) -> Result<CsvRow, String> {
     })
 }
 
+fn parse_quote_bitset(
+    value: Option<&JsonValue>,
+    field_count: usize,
+    name: &str,
+) -> Result<Vec<u8>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let JsonValue::String(value) = value else {
+        return Err(format!("CSV {name} must be a base64url string"));
+    };
+    let mut decoded = URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| format!("CSV {name} must be unpadded base64url"))?;
+    if URL_SAFE_NO_PAD.encode(&decoded) != *value {
+        return Err(format!("CSV {name} must use canonical unpadded base64url"));
+    }
+    let maximum = field_count.div_ceil(8);
+    if decoded.is_empty() || decoded.last().is_some_and(|byte| *byte == 0) {
+        return Err(format!("CSV {name} must be a minimal nonzero bitset"));
+    }
+    // Cell-array edits may remove columns without editing the prior layout.
+    // Discard those stale style bits while retaining strict wire validation.
+    decoded.truncate(maximum);
+    let remainder = field_count % 8;
+    if remainder != 0 && decoded.len() == maximum {
+        if let Some(last) = decoded.last_mut() {
+            *last &= (1 << remainder) - 1;
+        }
+    }
+    while decoded.last() == Some(&0) {
+        decoded.pop();
+    }
+    Ok(decoded)
+}
+
 fn parse_row_layout(value: &JsonValue, field_count: usize) -> Result<RowLayout, String> {
     let object = value
         .as_object()
         .ok_or_else(|| "CSV row layout must be an object".to_owned())?;
     if object.is_empty()
-        || object
-            .keys()
-            .any(|key| !matches!(key.as_str(), "force_quote" | "terminator"))
+        || object.keys().any(|key| {
+            !matches!(
+                key.as_str(),
+                "force_quote" | "unquoted_quote" | "terminator"
+            )
+        })
     {
-        return Err("CSV row layout must contain force_quote and/or terminator only".to_owned());
+        return Err(
+            "CSV row layout must contain force_quote, unquoted_quote, and/or terminator only"
+                .to_owned(),
+        );
     }
-    let force_quote = match object.get("force_quote") {
-        None => Vec::new(),
-        Some(JsonValue::String(value)) => {
-            let decoded = URL_SAFE_NO_PAD
-                .decode(value)
-                .map_err(|_| "CSV force_quote must be unpadded base64url".to_owned())?;
-            if URL_SAFE_NO_PAD.encode(&decoded) != *value {
-                return Err("CSV force_quote must use canonical unpadded base64url".to_owned());
-            }
-            let maximum = field_count.div_ceil(8);
-            if decoded.is_empty()
-                || decoded.len() > maximum
-                || decoded.last().is_some_and(|byte| *byte == 0)
-            {
-                return Err(
-                    "CSV force_quote must be a minimal nonzero bitset within the field count"
-                        .to_owned(),
-                );
-            }
-            let remainder = field_count % 8;
-            if remainder != 0
-                && decoded.len() == maximum
-                && decoded
-                    .last()
-                    .is_some_and(|byte| byte & !((1 << remainder) - 1) != 0)
-            {
-                return Err("CSV force_quote has bits beyond the final field".to_owned());
-            }
-            decoded
-        }
-        Some(_) => return Err("CSV force_quote must be a base64url string".to_owned()),
-    };
+    let force_quote = parse_quote_bitset(object.get("force_quote"), field_count, "force_quote")?;
+    let unquoted_quote =
+        parse_quote_bitset(object.get("unquoted_quote"), field_count, "unquoted_quote")?;
+    if force_quote
+        .iter()
+        .zip(&unquoted_quote)
+        .any(|(quoted, unquoted)| quoted & unquoted != 0)
+    {
+        return Err("CSV force_quote and unquoted_quote must not overlap".to_owned());
+    }
     let terminator = match object.get("terminator") {
         None => None,
         Some(JsonValue::String(value)) => Some(match value.as_str() {
@@ -4838,6 +5054,7 @@ fn parse_row_layout(value: &JsonValue, field_count: usize) -> Result<RowLayout, 
     };
     Ok(RowLayout {
         force_quote,
+        unquoted_quote,
         terminator,
     })
 }
@@ -4866,7 +5083,7 @@ pub fn render_row(
     dialect: Dialect,
     ending: Option<Terminator>,
 ) -> Result<Vec<u8>, String> {
-    render_row_with_layout(cells, dialect, ending, &[])
+    render_row_with_layout(cells, dialect, ending, &[], &[])
 }
 
 fn render_row_with_layout(
@@ -4874,6 +5091,7 @@ fn render_row_with_layout(
     dialect: Dialect,
     ending: Option<Terminator>,
     force_quote: &[u8],
+    unquoted_quote: &[u8],
 ) -> Result<Vec<u8>, String> {
     if cells.is_empty() {
         return Err("CSV rows require at least one cell".to_owned());
@@ -4885,11 +5103,12 @@ fn render_row_with_layout(
         }
         let force_quote = force_quote
             .get(index / 8)
+            .is_some_and(|byte| byte & (1 << (index % 8)) != 0)
+            || (cells.len() == 1 && ending.is_none() && cell.is_empty());
+        let unquoted_quote = unquoted_quote
+            .get(index / 8)
             .is_some_and(|byte| byte & (1 << (index % 8)) != 0);
-        let canonical_quote = imported_cell_needs_quotes(cell.as_bytes(), dialect)?;
-        if force_quote && canonical_quote {
-            return Err("CSV force_quote may select only otherwise-unnecessary quotes".to_owned());
-        }
+        let canonical_quote = cell_needs_quotes(cell.as_bytes(), dialect, unquoted_quote)?;
         let needs_quote = force_quote || canonical_quote;
         if needs_quote {
             let quote = dialect.quote.ok_or_else(|| {
@@ -4926,3 +5145,7 @@ pub fn describe_memory(document: &Document) -> String {
     );
     description
 }
+
+#[cfg(test)]
+#[path = "core_qa_tests.rs"]
+mod core_qa_tests;

--- a/plugins/csv/src/core.rs
+++ b/plugins/csv/src/core.rs
@@ -2169,7 +2169,13 @@ impl Document {
         if descriptor_dialect_changed {
             return self.reparse_after_descriptor_change(after, after_path, namespace);
         }
-        if self.0.dialect.bom || after.range(0, after.len().min(UTF8_BOM.len()))? == UTF8_BOM {
+        let successor_bom = after.range(0, after.len().min(UTF8_BOM.len()))? == UTF8_BOM;
+        if self.0.dialect.bom != successor_bom
+            || (self.0.dialect.bom
+                && splices
+                    .iter()
+                    .any(|edit| edit.offset < UTF8_BOM.len() as u64))
+        {
             return self.reparse_with_dialect(after, self.0.dialect, namespace, false);
         }
 
@@ -2185,8 +2191,13 @@ impl Document {
                     .and_then(|ordinal| self.0.index.ordinal_location(ordinal));
             }
         }
-        let old_start = first_old.map_or(0, |location| self.0.index.row_start(location));
-        let old_end = last_old.map_or(0, |location| self.0.index.row_end(location));
+        let prefix_len = if self.0.dialect.bom {
+            UTF8_BOM.len() as u32
+        } else {
+            0
+        };
+        let old_start = first_old.map_or(prefix_len, |location| self.0.index.row_start(location));
+        let old_end = last_old.map_or(prefix_len, |location| self.0.index.row_end(location));
         let new_start = map_offset(old_start, splices, false)?;
         let mut new_end = map_offset(old_end, splices, true)?;
         if new_end < new_start || new_end > after.len() {

--- a/plugins/csv/src/core_qa_tests.rs
+++ b/plugins/csv/src/core_qa_tests.rs
@@ -1,0 +1,506 @@
+use super::*;
+
+fn open(bytes: &[u8]) -> Document {
+    Document::open_file(
+        bytes.to_vec(),
+        None,
+        IdNamespace::from_namespace_bytes([0x71; 12]),
+    )
+    .unwrap()
+    .0
+}
+
+fn assert_reconstructs(document: &Document) {
+    let records = document.row_records().unwrap();
+    let reconstructed = Document::open_rows(records.clone()).unwrap().0;
+    assert_eq!(reconstructed.bytes(), document.bytes());
+    assert_eq!(reconstructed.row_records().unwrap(), records);
+}
+
+#[test]
+fn qa_roundtrip_csv_syntax_corpus() {
+    for bytes in [
+        b"".as_slice(),
+        b"\n",
+        b"\r\n",
+        b"\r",
+        b",",
+        b",,\n",
+        b"\"\"",
+        b"a\nb\r\nc\rd",
+        b"\"a\",\"b\"\r\n\"x,y\",\"x\"\"y\"\n",
+        "α,雪\n,\n\"line\r\nline\"".as_bytes(),
+        b"\xef\xbb\xbfplain,b\n",
+    ] {
+        assert_reconstructs(&open(bytes));
+    }
+}
+
+#[test]
+fn qa_quoted_field_can_be_changed_to_require_quotes() {
+    let before = open(b"\"a\",b\n");
+    let mut records = before.row_records().unwrap();
+    let mut row = parse_csv_row(&records[1].row).unwrap();
+    row.cells[0] = "a,b".to_owned();
+    records[1].row = csv_typed_row(row).unwrap();
+    let change = RowChange {
+        schema_key: ROW_SCHEMA_KEY.into(),
+        row_pk: records[1].row_pk.clone(),
+        row: Some(records[1].row.clone()),
+        effect: ChangeEffect::Content,
+    };
+    let after = before.rows_changed(&[change]).unwrap().0;
+    assert_eq!(after.bytes(), b"\"a,b\",b\n");
+    assert_reconstructs(&after);
+}
+
+#[test]
+fn qa_single_byte_splices_match_full_parse() {
+    let corpus: &[&[u8]] = &[
+        b"a,b\nc,d\ne,f\n",
+        b"a\nb\nc\"\nd\n",
+        b"a,b\r\nc,d\r\ne,f\r\n",
+        b"\"a\",b\n\"c\",d\n\"e\",f",
+        b"a\nb\rc\r\nd",
+        b"",
+        b"\n\n\n",
+    ];
+    for &bytes in corpus {
+        let before = open(bytes);
+        for offset in 0..=bytes.len() {
+            for delete_len in 0..=usize::from(offset < bytes.len()) {
+                for insert in [
+                    b"".as_slice(),
+                    b"\"",
+                    b"\n",
+                    b"\r",
+                    b",",
+                    b"x",
+                    b"\"\n",
+                    b"\n\"",
+                ] {
+                    let mut expected = bytes.to_vec();
+                    expected.splice(offset..offset + delete_len, insert.iter().copied());
+                    let cold = Document::open_file(
+                        expected.clone(),
+                        None,
+                        IdNamespace::from_namespace_bytes([0x72; 12]),
+                    );
+                    let hot = before.file_changed(
+                        &[FileEdit {
+                            offset: offset as u64,
+                            delete_len: delete_len as u64,
+                            insert,
+                        }],
+                        IdNamespace::from_namespace_bytes([0x73; 12]),
+                    );
+                    let context = format!(
+                        "before={bytes:?}, offset={offset}, delete={delete_len}, insert={insert:?}"
+                    );
+                    assert_eq!(
+                        hot.is_ok(),
+                        cold.is_ok(),
+                        "{context}; hot={:?}, cold={:?}",
+                        hot.as_ref().err(),
+                        cold.as_ref().err()
+                    );
+                    if let (Ok((hot, changes)), Ok((cold, _))) = (hot, cold) {
+                        assert_eq!(hot.bytes(), expected, "{context}");
+                        let cells = |doc: &Document| {
+                            doc.row_records()
+                                .unwrap()
+                                .into_iter()
+                                .skip(1)
+                                .map(|r| parse_csv_row(&r.row).unwrap().cells)
+                                .collect::<Vec<_>>()
+                        };
+                        assert_eq!(cells(&hot), cells(&cold), "{context}");
+                        // Byte preservation for permissive literal quotes is covered separately.
+                        let reconstructed =
+                            Document::open_rows(hot.row_records().unwrap()).unwrap().0;
+                        assert_eq!(cells(&reconstructed), cells(&cold), "{context}");
+                        let persisted =
+                            apply_row_changes(before.row_records().unwrap(), &changes).unwrap();
+                        let replayed = Document::open_rows(persisted).unwrap().0;
+                        assert_eq!(cells(&replayed), cells(&cold), "{context}");
+                        assert_eq!(
+                            replayed.row_records().unwrap(),
+                            hot.row_records().unwrap(),
+                            "{context}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn qa_edit_final_single_cell_to_empty_preserves_row_on_reopen() {
+    let before = open(b"first\nlast");
+    let record = before.row_records().unwrap().pop().unwrap();
+    let mut row = parse_csv_row(&record.row).unwrap();
+    row.cells[0].clear();
+    let change = RowChange {
+        schema_key: ROW_SCHEMA_KEY.into(),
+        row_pk: record.row_pk,
+        row: Some(csv_typed_row(row).unwrap()),
+        effect: ChangeEffect::Content,
+    };
+    let after = before.rows_changed(&[change]).unwrap().0;
+    let reopened = open(&after.bytes());
+    assert_eq!(reopened.row_count(), 2, "bytes={:?}", after.bytes());
+    let row = reopened.row_records().unwrap().pop().unwrap();
+    assert_eq!(parse_csv_row(&row.row).unwrap().cells, [""]);
+}
+
+#[test]
+fn qa_splice_quoted_field_across_existing_rows() {
+    let before = open(b"a\nb\nc\"\nd\n");
+    let after = before
+        .file_changed(
+            &[FileEdit {
+                offset: 0,
+                delete_len: 0,
+                insert: b"\"",
+            }],
+            IdNamespace::from_namespace_bytes([0x74; 12]),
+        )
+        .unwrap()
+        .0;
+    assert_eq!(after.row_count(), 2);
+    assert_reconstructs(&after);
+}
+
+#[test]
+fn qa_unquoted_literal_quote_roundtrip() {
+    assert_reconstructs(&open(b"a\"b,c\n"));
+}
+
+#[test]
+fn qa_rejects_nul_before_constructing_unreadable_rows() {
+    assert!(
+        Document::open_file(
+            b"a\0b,c\n".to_vec(),
+            None,
+            IdNamespace::from_namespace_bytes([0x75; 12])
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn qa_inserting_lf_after_cr_does_not_add_phantom_row() {
+    let before = open(b"a\nb\rc\r\nd");
+    let after = before
+        .file_changed(
+            &[FileEdit {
+                offset: 4,
+                delete_len: 0,
+                insert: b"\n",
+            }],
+            IdNamespace::from_namespace_bytes([0x76; 12]),
+        )
+        .unwrap()
+        .0;
+    assert_eq!(after.bytes(), b"a\nb\r\nc\r\nd");
+    assert_eq!(after.row_count(), 4);
+    assert_reconstructs(&after);
+}
+
+#[test]
+fn qa_cell_edit_matrix_preserves_values_and_emitted_bytes() {
+    for bytes in [
+        b"\"a\",b\r\nc,d".as_slice(),
+        b"a\"b,c\nlast",
+        b"\"a,b\",\"x\"\"y\"\n",
+        b"a",
+        b"\"\"",
+        b"first\nlast",
+    ] {
+        let before = open(bytes);
+        for record in before.row_records().unwrap().into_iter().skip(1) {
+            let original = parse_csv_row(&record.row).unwrap();
+            for index in 0..original.cells.len() {
+                for replacement in [
+                    "",
+                    "normal",
+                    "comma,value",
+                    "\"leading",
+                    "mid\"quote",
+                    "line\r\nline",
+                    "雪",
+                    "\t",
+                ] {
+                    let mut row = original.clone();
+                    row.cells[index] = replacement.to_owned();
+                    let expected_cells = row.cells.clone();
+                    let change = RowChange {
+                        schema_key: ROW_SCHEMA_KEY.into(),
+                        row_pk: record.row_pk.clone(),
+                        row: Some(csv_typed_row(row).unwrap()),
+                        effect: ChangeEffect::Content,
+                    };
+                    let cold = Document::open_rows(
+                        apply_row_changes(
+                            before.row_records().unwrap(),
+                            std::slice::from_ref(&change),
+                        )
+                        .unwrap(),
+                    )
+                    .unwrap()
+                    .0;
+                    let (after, edits) = before.rows_changed(&[change]).unwrap();
+                    assert_eq!(cold.bytes(), after.bytes());
+                    assert_eq!(cold.row_records().unwrap(), after.row_records().unwrap());
+                    let mut replayed_bytes = before.bytes();
+                    for edit in edits.iter().rev() {
+                        replayed_bytes.splice(
+                            edit.offset as usize..(edit.offset + edit.delete_len) as usize,
+                            edit.insert.iter().copied(),
+                        );
+                    }
+                    assert_eq!(replayed_bytes, after.bytes());
+                    let reopened = open(&after.bytes());
+                    assert_eq!(reopened.row_count(), before.row_count());
+                    let actual = after
+                        .row_records()
+                        .unwrap()
+                        .into_iter()
+                        .find(|r| r.row_pk == record.row_pk)
+                        .unwrap();
+                    assert_eq!(parse_csv_row(&actual.row).unwrap().cells, expected_cells);
+                    assert_reconstructs(&after);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn qa_literal_quote_layout_survives_cold_initial_import() {
+    let bytes = b"a\"b,c,d\"e\nlast\n";
+    let expected = open(bytes).row_records().unwrap();
+    let mut cold = ColdInitialImport::open(bytes.to_vec(), None).unwrap();
+    let mut records = vec![RowRecord {
+        schema_key: TABLE_SCHEMA_KEY.into(),
+        row_pk: vec![TypedValue::Text(ROOT_ROW_PK.to_owned())],
+        row: cold.table_change().row.unwrap(),
+    }];
+    for record in expected.iter().skip(1) {
+        let id = parse_csv_row(&record.row).unwrap().id;
+        let (_, row) = cold.next_row(id).unwrap().unwrap();
+        records.push(RowRecord {
+            schema_key: ROW_SCHEMA_KEY.into(),
+            row_pk: record.row_pk.clone(),
+            row,
+        });
+    }
+    assert_eq!(records, expected);
+    assert_eq!(Document::open_rows(records).unwrap().0.bytes(), bytes);
+}
+
+#[test]
+fn qa_truncating_cells_normalizes_stale_quote_layout() {
+    for bytes in [b"\"a\",b,\"c\"\n".as_slice(), b"a\"b,c,d\"e\n"] {
+        let before = open(bytes);
+        let record = before.row_records().unwrap().pop().unwrap();
+        let mut row = parse_csv_row(&record.row).unwrap();
+        row.cells.truncate(1);
+        let change = RowChange {
+            schema_key: ROW_SCHEMA_KEY.into(),
+            row_pk: record.row_pk,
+            row: Some(csv_typed_row(row.clone()).unwrap()),
+            effect: ChangeEffect::Content,
+        };
+        let cold = Document::open_rows(
+            apply_row_changes(before.row_records().unwrap(), std::slice::from_ref(&change))
+                .unwrap(),
+        )
+        .unwrap()
+        .0;
+        let after = before.rows_changed(&[change]).unwrap().0;
+        assert_eq!(after.bytes(), cold.bytes());
+        assert_eq!(
+            parse_csv_row(&after.row_records().unwrap()[1].row)
+                .unwrap()
+                .cells,
+            row.cells
+        );
+        assert_reconstructs(&after);
+    }
+}
+
+#[test]
+fn qa_two_splice_matrix_matches_cold_parse_and_persisted_rows() {
+    let bytes = b"a,b\r\nc,d\re,f\nlast";
+    let before = open(bytes);
+    for left in 0..bytes.len() {
+        for right in left + 1..=bytes.len() {
+            for (a, b) in [
+                (b"\"".as_slice(), b"\"".as_slice()),
+                (b"\n", b"\r"),
+                (b"", b""),
+                (b"x", b","),
+            ] {
+                let edits = [
+                    FileEdit {
+                        offset: left as u64,
+                        delete_len: 1,
+                        insert: a,
+                    },
+                    FileEdit {
+                        offset: right as u64,
+                        delete_len: u64::from(right < bytes.len()),
+                        insert: b,
+                    },
+                ];
+                let mut expected = bytes.to_vec();
+                for edit in edits.iter().rev() {
+                    expected.splice(
+                        edit.offset as usize..(edit.offset + edit.delete_len) as usize,
+                        edit.insert.iter().copied(),
+                    );
+                }
+                let cold = Document::open_file(
+                    expected.clone(),
+                    None,
+                    IdNamespace::from_namespace_bytes([0x78; 12]),
+                );
+                let hot =
+                    before.file_changed(&edits, IdNamespace::from_namespace_bytes([0x79; 12]));
+                assert_eq!(
+                    hot.is_ok(),
+                    cold.is_ok(),
+                    "left={left} right={right} a={a:?} b={b:?}; hot={:?} cold={:?}",
+                    hot.as_ref().err(),
+                    cold.as_ref().err()
+                );
+                if let (Ok((hot, changes)), Ok((cold, _))) = (hot, cold) {
+                    let cells = |doc: &Document| {
+                        doc.row_records()
+                            .unwrap()
+                            .into_iter()
+                            .skip(1)
+                            .map(|r| parse_csv_row(&r.row).unwrap().cells)
+                            .collect::<Vec<_>>()
+                    };
+                    assert_eq!(cells(&hot), cells(&cold));
+                    assert_reconstructs(&hot);
+                    let replayed = Document::open_rows(
+                        apply_row_changes(before.row_records().unwrap(), &changes).unwrap(),
+                    )
+                    .unwrap()
+                    .0;
+                    assert_eq!(replayed.row_records().unwrap(), hot.row_records().unwrap());
+                    assert_eq!(replayed.bytes(), expected);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn qa_reorder_unterminated_final_row_preserves_contents() {
+    let before = open(b"first\nlast");
+    let record = before.row_records().unwrap().pop().unwrap();
+    let mut row = parse_csv_row(&record.row).unwrap();
+    row.order_key = "01".to_owned();
+    let change = RowChange {
+        schema_key: ROW_SCHEMA_KEY.into(),
+        row_pk: record.row_pk,
+        row: Some(csv_typed_row(row).unwrap()),
+        effect: ChangeEffect::Content,
+    };
+    let cold = Document::open_rows(
+        apply_row_changes(before.row_records().unwrap(), std::slice::from_ref(&change)).unwrap(),
+    )
+    .unwrap()
+    .0;
+    let after = before.rows_changed(&[change]).unwrap().0;
+    assert_eq!(after.bytes(), b"last\nfirst");
+    assert_eq!(cold.bytes(), after.bytes());
+    assert_reconstructs(&after);
+}
+
+#[test]
+fn qa_utf8_bom_is_preserved_outside_first_quoted_cell() {
+    for bytes in [
+        b"\xef\xbb\xbf\"a,b\",c\r\nlast,row".as_slice(),
+        b"\xef\xbb\xbfplain,c\n",
+        b"\xef\xbb\xbf",
+    ] {
+        let before = open(bytes);
+        assert_reconstructs(&before);
+        if before.row_count() > 0 {
+            let record = before.row_records().unwrap().remove(1);
+            let mut row = parse_csv_row(&record.row).unwrap();
+            assert_eq!(
+                row.cells[0],
+                if bytes.get(3) == Some(&b'"') {
+                    "a,b"
+                } else {
+                    "plain"
+                }
+            );
+            row.cells[0] = "changed,雪".to_owned();
+            let after = before
+                .rows_changed(&[RowChange {
+                    schema_key: ROW_SCHEMA_KEY.into(),
+                    row_pk: record.row_pk,
+                    row: Some(csv_typed_row(row).unwrap()),
+                    effect: ChangeEffect::Content,
+                }])
+                .unwrap()
+                .0;
+            assert!(after.bytes().starts_with(b"\xef\xbb\xbf\"changed,"));
+            assert_reconstructs(&after);
+        } else {
+            assert_eq!(bytes, b"\xef\xbb\xbf");
+        }
+    }
+}
+
+#[test]
+fn qa_repeated_edits_replay_after_identity_checkpoint_reopen() {
+    let mut document = open(b"a,b\r\n\"c\",d\nlast");
+    for revision in 0..80 {
+        let next = match revision % 4 {
+            0 => b"a\"b,c\ninsert,row\r\nlast".as_slice(),
+            1 => b"\"a,b\",\"c\"\r\nlast\n".as_slice(),
+            2 => b"\n\"\"\nlast\r".as_slice(),
+            _ => b"a,b\r\n\"c\",d\nlast".as_slice(),
+        };
+        let before = document.row_records().unwrap();
+        let (after, changes) = document
+            .file_changed(
+                &[FileEdit {
+                    offset: 0,
+                    delete_len: document.byte_len() as u64,
+                    insert: next,
+                }],
+                IdNamespace::from_halves(0xabc, revision),
+            )
+            .unwrap();
+        let replayed = Document::open_rows(apply_row_changes(before, &changes).unwrap())
+            .unwrap()
+            .0;
+        assert_eq!(replayed.bytes(), next);
+        assert_eq!(
+            replayed.row_records().unwrap(),
+            after.row_records().unwrap()
+        );
+        let (dialect, identities) = after.identity_checkpoint();
+        document = Document::open_file_with_identities(
+            after.bytes(),
+            dialect,
+            IdNamespace::from_halves(0xdef, revision),
+            &identities,
+        )
+        .unwrap();
+        assert_eq!(
+            document.row_records().unwrap(),
+            after.row_records().unwrap()
+        );
+    }
+}

--- a/plugins/csv/src/core_qa_tests.rs
+++ b/plugins/csv/src/core_qa_tests.rs
@@ -462,6 +462,55 @@ fn qa_utf8_bom_is_preserved_outside_first_quoted_cell() {
 }
 
 #[test]
+fn qa_bom_body_edits_keep_the_affected_row_window_local() {
+    let mut source = String::from("\u{feff}");
+    for ordinal in 0..4_096 {
+        use std::fmt::Write as _;
+        writeln!(source, "row{ordinal},value").unwrap();
+    }
+    let before = open(source.as_bytes());
+    let offset = source.find("row2048,value").unwrap() + "row2048,".len();
+    for insert in [b"longer-value".as_slice(), b"\"multiline\nvalue\""] {
+        let (after, changes) = before
+            .file_changed(
+                &[FileEdit {
+                    offset: offset as u64,
+                    delete_len: 5,
+                    insert,
+                }],
+                IdNamespace::from_halves(0xb0, 1),
+            )
+            .unwrap();
+        assert!(
+            after.0.sparse_rows_touched <= 2 * ROWS_PER_CHUNK,
+            "BOM body edit reparsed {} rows",
+            after.0.sparse_rows_touched
+        );
+        assert_reconstructs(&after);
+        let replayed = Document::open_rows(
+            apply_row_changes(before.row_records().unwrap(), &changes).unwrap(),
+        )
+        .unwrap()
+        .0;
+        assert_eq!(replayed.bytes(), after.bytes());
+    }
+    let empty = open(UTF8_BOM);
+    let after = empty
+        .file_changed(
+            &[FileEdit {
+                offset: 3,
+                delete_len: 0,
+                insert: b"first,row\n",
+            }],
+            IdNamespace::from_halves(0xb0, 2),
+        )
+        .unwrap()
+        .0;
+    assert_eq!(after.bytes(), b"\xef\xbb\xbffirst,row\n");
+    assert_reconstructs(&after);
+}
+
+#[test]
 fn qa_repeated_edits_replay_after_identity_checkpoint_reopen() {
     let mut document = open(b"a,b\r\n\"c\",d\nlast");
     for revision in 0..80 {

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -189,7 +189,8 @@ impl sdk::FileProjection for CsvPlugin {
         {
             return cold_parse_changes(&mut update, sink);
         }
-        if update.before.state_len(CSV_IDENTITIES_KEY)?.is_some()
+        if update.before.is_empty()
+            || update.before.state_len(CSV_IDENTITIES_KEY)?.is_some()
             || update.before_path != update.after_path
             || update.file_edits.iter().len() != 1
         {
@@ -210,14 +211,12 @@ impl sdk::FileProjection for CsvPlugin {
                 .before
                 .read_state_range(CSV_INDEX_KEY, 0, CSV_INDEX_HEADER_BYTES)?
                 .ok_or_else(|| sdk::Error::invalid_input("CSV arena root has no row index"))?;
-            let row_count = u32::from_le_bytes(header[32..36].try_into().expect("CSV row count"));
-            let logical_state_len = u64::from(CSV_INDEX_HEADER_BYTES)
-                .checked_add(u64::from(row_count) * 4)
-                .ok_or_else(|| sdk::Error::invalid_input("CSV row index size overflowed"))?;
-            let index = ArenaRowIndex::decode_header(&header, logical_state_len)
-                .map_err(sdk::Error::invalid_input)?;
+            let index = decode_csv_index_header(&header)?;
+            if index.dialect().bom && edit.offset < 3 {
+                return fallback_file_changed(update, sink);
+            }
             let range = index
-                .row_range_for_edit_reader(edit.offset, edit.delete_len, |ordinal| {
+                .row_range_for_edit_reader(edit.offset, 0, |ordinal| {
                     let offsets_per_page = (CSV_INDEX_PAGE_BYTES / 4) as u32;
                     let page = ordinal / offsets_per_page;
                     let offset = u64::from(ordinal % offsets_per_page) * 4;
@@ -239,12 +238,25 @@ impl sdk::FileProjection for CsvPlugin {
                     .map_err(sdk::Error::invalid_input)?;
             let state = import.arena_state(update.creates.namespace_bytes());
             let index = ArenaRowIndex::decode(&state).map_err(sdk::Error::invalid_input)?;
+            if index.dialect().bom && edit.offset < 3 {
+                return fallback_file_changed(update, sink);
+            }
             let range = index
-                .row_range_for_edit(edit.offset, edit.delete_len)
+                .row_range_for_edit(edit.offset, 0)
                 .map_err(sdk::Error::invalid_input)?;
             (index, range, Some(state))
         };
         let (ordinal, row_start, row_end) = range;
+        let delete_end = edit
+            .offset
+            .checked_add(edit.delete_len)
+            .ok_or_else(|| sdk::Error::invalid_input("CSV edit range overflowed"))?;
+        if delete_end > update.before.len() {
+            return Err(sdk::Error::invalid_input("CSV edit exceeds accepted bytes"));
+        }
+        if delete_end > row_end {
+            return fallback_file_changed(update, sink);
+        }
         let mut row = update.before.read_range(row_start, row_end - row_start)?;
         let local_start = usize::try_from(edit.offset - row_start)
             .map_err(|_| sdk::Error::invalid_input("CSV edit offset exceeds guest memory"))?;
@@ -373,6 +385,17 @@ fn split_csv_index(state: &[u8]) -> sdk::Result<(&[u8], Vec<&[u8]>)> {
     Ok((header, pages))
 }
 
+fn decode_csv_index_header(header: &[u8]) -> sdk::Result<ArenaRowIndex> {
+    if header.len() != CSV_INDEX_HEADER_BYTES as usize {
+        return Err(sdk::Error::invalid_input(
+            "CSV row index header is truncated",
+        ));
+    }
+    let row_count = u32::from_le_bytes(header[32..36].try_into().expect("CSV row count"));
+    let logical_state_len = u64::from(CSV_INDEX_HEADER_BYTES) + u64::from(row_count) * 4;
+    ArenaRowIndex::decode_header(header, logical_state_len).map_err(sdk::Error::invalid_input)
+}
+
 fn csv_index_page_count(root: &sdk::Snapshot<'_>) -> sdk::Result<u32> {
     let Some(header) = root.read_state_range(CSV_INDEX_KEY, 0, CSV_INDEX_HEADER_BYTES)? else {
         return Ok(0);
@@ -472,7 +495,7 @@ fn store_identity_checkpoint(
             Terminator::CrLf => 2,
             Terminator::Cr => 3,
         },
-        0,
+        u8::from(dialect.bom),
     ]);
     sink.put_state(CSV_IDENTITIES_KEY, &manifest)?;
     for (ordinal, page) in pages.iter().enumerate() {
@@ -489,6 +512,9 @@ fn decode_identity_manifest(bytes: &[u8]) -> sdk::Result<(u32, u32, Dialect)> {
         return Err(sdk::Error::invalid_input(
             "unsupported CSV identity checkpoint",
         ));
+    }
+    if bytes[15] > 1 {
+        return Err(sdk::Error::invalid_input("invalid CSV checkpoint flags"));
     }
     let terminator = match bytes[14] {
         1 => Terminator::Lf,
@@ -507,6 +533,7 @@ fn decode_identity_manifest(bytes: &[u8]) -> sdk::Result<(u32, u32, Dialect)> {
             delimiter: bytes[12],
             quote: (bytes[13] != 0).then_some(bytes[13]),
             terminator,
+            bom: bytes[15] == 1,
         },
     ))
 }
@@ -571,7 +598,15 @@ fn open_document(
     snapshot: &sdk::Snapshot<'_>,
 ) -> sdk::Result<Document> {
     let Some((dialect, identities)) = read_identity_checkpoint(snapshot)? else {
-        return Document::open_file(bytes, Some(path), namespace)
+        let document = match snapshot.read_state_range(CSV_INDEX_KEY, 0, CSV_INDEX_HEADER_BYTES)? {
+            Some(header) => Document::open_file_with_stored_dialect(
+                bytes,
+                decode_csv_index_header(&header)?.dialect(),
+                namespace,
+            ),
+            None => Document::open_file(bytes, Some(path), namespace),
+        };
+        return document
             .map(|(document, _)| document)
             .map_err(sdk::Error::invalid_input);
     };
@@ -903,5 +938,400 @@ mod tests {
             successor.canonical_arena_state().is_none(),
             "a mixed-namespace structural successor cannot be represented by one dense namespace"
         );
+    }
+}
+
+#[cfg(test)]
+mod adapter_qa_tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct MemoryState(std::collections::BTreeMap<Vec<u8>, Vec<u8>>);
+    impl StateOutput for MemoryState {
+        fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()> {
+            self.0.insert(key.to_vec(), value.to_vec());
+            Ok(())
+        }
+        fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()> {
+            self.0.remove(key);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn sparse_arena_changes_match_full_parse_for_every_nonstructural_byte() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        for (path, source) in [
+            ("a.csv", "name,value\nalpha,one\nbeta,two\n"),
+            (
+                "a.csv",
+                "\"name\",\"value\"\r\n\"a\nline\",\"quoted\"\r\nlast,end",
+            ),
+            ("a.tsv", "name\tvalue\ralpha\tone\rbeta\ttwo\r"),
+            ("a.csv", "\n,\n\"\"\n\"a\"\"b\",x\n"),
+            ("a.csv", "\u{feff}first,value\nlast,tail\n"),
+        ] {
+            let bytes = source.as_bytes();
+            let import = ColdInitialImport::open(bytes.to_vec(), Some(path)).unwrap();
+            let index =
+                ArenaRowIndex::decode(&import.arena_state(namespace.0[..12].try_into().unwrap()))
+                    .unwrap();
+            for offset in 0..bytes.len() {
+                if !bytes[offset].is_ascii_alphabetic()
+                    || index.edit_touches_structure(&bytes[offset..offset + 1], b"Z")
+                {
+                    continue;
+                }
+                let (ordinal, start, end) = index.row_range_for_edit(offset as u64, 1).unwrap();
+                let mut row = bytes[start as usize..end as usize].to_vec();
+                row[offset - start as usize] = b'Z';
+                let sparse = index.row_change(ordinal, row).unwrap();
+                let mut changed = bytes.to_vec();
+                changed[offset] = b'Z';
+                let (full, _) = Document::open_file(changed, Some(path), namespace).unwrap();
+                let records = full.row_records().unwrap();
+                assert_eq!(
+                    sparse.row.as_ref(),
+                    Some(&records[ordinal as usize + 1].row),
+                    "{path} offset {offset}"
+                );
+                assert_eq!(sparse.row_pk, records[ordinal as usize + 1].row_pk);
+            }
+        }
+    }
+
+    #[test]
+    fn identity_checkpoint_preserves_authoritative_table_terminator() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        let (document, _) = Document::open_file(b"a,b\nc,d\n".to_vec(), None, namespace).unwrap();
+        let mut records = document.row_records().unwrap();
+        records[0].row.insert(
+            "dialect",
+            sdk::TypedValue::Jsonb(
+                serde_json::json!({
+                    "delimiter": ",", "quote": "\"", "terminator": "\r\n"
+                })
+                .into(),
+            ),
+        );
+        for record in records.iter_mut().skip(1) {
+            record.row.insert(
+                "layout",
+                sdk::TypedValue::Jsonb(serde_json::json!({"terminator": "\n"}).into()),
+            );
+        }
+        let (document, _) = Document::open_rows(records).unwrap();
+        let (dialect, identities) = document.identity_checkpoint();
+        assert_eq!(dialect.terminator, Terminator::CrLf);
+        assert_eq!(document.bytes(), b"a,b\nc,d\n");
+        let reopened =
+            Document::open_file_with_identities(document.bytes(), dialect, namespace, &identities)
+                .unwrap();
+        assert_eq!(
+            reopened.row_records().unwrap(),
+            document.row_records().unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_import_arena_restores_its_dialect() {
+        let import = ColdInitialImport::open(Vec::new(), Some("a.tsv")).unwrap();
+        let state = import.arena_state([3; 12]);
+        assert_eq!(
+            decode_csv_index_header(&state).unwrap().dialect().delimiter,
+            b'\t'
+        );
+    }
+
+    #[test]
+    fn truncated_index_headers_return_errors_without_panicking() {
+        for length in 0..CSV_INDEX_HEADER_BYTES as usize {
+            assert!(decode_csv_index_header(&vec![0; length]).is_err());
+        }
+    }
+
+    #[test]
+    fn canonical_arena_can_store_a_dialect_different_from_the_path() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        let dialect = Dialect {
+            delimiter: b';',
+            quote: Some(b'\''),
+            terminator: Terminator::CrLf,
+            bom: false,
+        };
+        let (document, _) = Document::open_file_with_dialect(
+            b"'a;b';value\r\nlast;tail\r\n".to_vec(),
+            dialect,
+            namespace,
+        )
+        .unwrap();
+        let (serialized, _) = Document::open_rows(document.row_records().unwrap()).unwrap();
+        let (_, state) = serialized
+            .canonical_arena_state()
+            .expect("custom dialect has compact arena");
+        let restored_dialect = decode_csv_index_header(&state[..CSV_INDEX_HEADER_BYTES as usize])
+            .unwrap()
+            .dialect();
+        let (reopened, _) = Document::open_file_with_stored_dialect(
+            serialized.bytes(),
+            restored_dialect,
+            namespace,
+        )
+        .unwrap();
+        assert_eq!(reopened.bytes(), serialized.bytes());
+        assert_eq!(
+            reopened.row_records().unwrap(),
+            serialized.row_records().unwrap()
+        );
+    }
+
+    #[test]
+    fn identity_checkpoint_reopen_preserves_exact_bytes_and_rows() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        for (path, source) in [
+            (
+                "a.csv",
+                "\"name\",value\r\n\"a\nline\",\"quoted\"\r\nlast,end",
+            ),
+            ("a.tsv", "name\tvalue\ralpha\tone\rbeta\ttwo\r"),
+            ("a.csv", "\u{feff}first,value\n\nlast,tail\n"),
+        ] {
+            let (document, _) =
+                Document::open_file(source.as_bytes().to_vec(), Some(path), namespace).unwrap();
+            let (dialect, identities) = document.identity_checkpoint();
+            let reopened = Document::open_file_with_identities(
+                document.bytes(),
+                dialect,
+                IdNamespace::from_halves(99, 101),
+                &identities,
+            )
+            .unwrap();
+            assert_eq!(reopened.bytes(), source.as_bytes());
+            assert_eq!(
+                reopened.row_records().unwrap(),
+                document.row_records().unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn paged_index_reads_across_page_and_tree_boundaries() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        let rows_per_page = CSV_INDEX_PAGE_BYTES / 4;
+        let import = ColdInitialImport::open(b"x\n".repeat(rows_per_page + 2), None).unwrap();
+        let state = import.arena_state(namespace.0[..12].try_into().unwrap());
+        let (header, pages) = split_csv_index(&state).unwrap();
+        let index = decode_csv_index_header(header).unwrap();
+        assert_eq!(pages.len(), 2);
+        for ordinal in [
+            0,
+            63,
+            64,
+            511,
+            512,
+            rows_per_page - 1,
+            rows_per_page,
+            rows_per_page + 1,
+        ] {
+            let range = index
+                .row_range_for_edit_reader((ordinal * 2) as u64, 1, |row| {
+                    let row = row as usize;
+                    let offset = row % rows_per_page * 4;
+                    Ok(u32::from_le_bytes(
+                        pages[row / rows_per_page][offset..offset + 4]
+                            .try_into()
+                            .unwrap(),
+                    ))
+                })
+                .unwrap();
+            assert_eq!(
+                range,
+                (
+                    ordinal as u32,
+                    (ordinal * 2) as u64,
+                    (ordinal * 2 + 2) as u64
+                )
+            );
+            let change = index.row_change(ordinal as u32, b"y\n".to_vec()).unwrap();
+            assert_eq!(
+                change.row_pk,
+                vec![sdk::TypedValue::Uuid(namespace.encode(ordinal as u64))]
+            );
+        }
+    }
+
+    #[test]
+    fn randomized_checkpoint_roundtrips_across_identity_and_tree_boundaries() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        let mut seed = 0x19af_3921_efe1_8893_u64;
+        let mut next = || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        for _ in 0..12 {
+            let mut bytes = Vec::new();
+            for row in 0..769 {
+                let field = match next() % 5 {
+                    0 => "\"a,b\"",
+                    1 => "\"a\nline\"",
+                    2 => "unquoted\"quote",
+                    3 => "\"\"",
+                    _ => "é漢🙂",
+                };
+                bytes.extend_from_slice(format!("{row},{field}").as_bytes());
+                bytes.extend_from_slice(match next() % 3 {
+                    0 => b"\r\n",
+                    1 => b"\r",
+                    _ => b"\n",
+                });
+            }
+            let (document, _) = Document::open_file(bytes.clone(), None, namespace).unwrap();
+            let (dialect, mut identities) = document.identity_checkpoint();
+            for identity in &mut identities {
+                identity.id =
+                    uuid::Uuid::from_u128((u128::from(next()) << 64) | u128::from(next()));
+            }
+            let reopened =
+                Document::open_file_with_identities(bytes.clone(), dialect, namespace, &identities)
+                    .unwrap();
+            assert_eq!(reopened.bytes(), bytes);
+            assert_eq!(reopened.identity_checkpoint(), (dialect, identities));
+            let (roundtrip, _) = Document::open_rows(reopened.row_records().unwrap()).unwrap();
+            assert_eq!(roundtrip.bytes(), bytes);
+            assert_eq!(
+                roundtrip.row_records().unwrap(),
+                reopened.row_records().unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn cell_merger_composes_disjoint_edits_and_declines_conflicts() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        let (document, _) =
+            Document::open_file(b"a,b,c,d,e,f,g,h\n".to_vec(), None, namespace).unwrap();
+        let base = document.row_records().unwrap()[1].row.clone();
+        let base_cells = serde_json::json!(["a", "b", "c", "d", "e", "f", "g", "h"]);
+        for left in 0..8 {
+            for right in 0..8 {
+                let mut a = base.clone();
+                let mut b = base.clone();
+                let mut a_cells = base_cells.clone();
+                let mut b_cells = base_cells.clone();
+                a_cells[left] = serde_json::json!("LEFT");
+                b_cells[right] = serde_json::json!("RIGHT");
+                a.insert("cells", sdk::TypedValue::Jsonb(a_cells.into()));
+                b.insert("cells", sdk::TypedValue::Jsonb(b_cells.clone().into()));
+                let merged = merge_typed_csv_cells(&base, &a, &b).unwrap();
+                if left == right {
+                    assert!(merged.is_none());
+                } else {
+                    b_cells[left] = serde_json::json!("LEFT");
+                    assert_eq!(serde_json::Value::Array(merged.unwrap()), b_cells);
+                    assert_eq!(
+                        merge_typed_csv_cells(&base, &a, &b).unwrap(),
+                        merge_typed_csv_cells(&base, &b, &a).unwrap()
+                    );
+                }
+                assert!(merge_typed_csv_cells(&base, &base, &b).unwrap().is_none());
+                assert!(merge_typed_csv_cells(&base, &a, &a).unwrap().is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn identity_checkpoint_pages_preserve_records_split_across_page_edges() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        let row_count = CSV_IDENTITY_PAGE_BYTES / 36 + 3;
+        let (document, _) = Document::open_file(b"x\n".repeat(row_count), None, namespace).unwrap();
+        let mut stored = MemoryState::default();
+        store_identity_checkpoint(None, &mut stored, &document).unwrap();
+        let (stored_count, page_count, dialect) =
+            decode_identity_manifest(stored.0.get(CSV_IDENTITIES_KEY).unwrap()).unwrap();
+        assert_eq!(stored_count as usize, row_count);
+        assert_eq!(page_count, 2);
+        assert_eq!(dialect, document.dialect());
+        let payload = (0..page_count)
+            .flat_map(|page| {
+                let bytes = &stored.0[&identity_page_key(page)];
+                assert!(bytes.len() <= CSV_IDENTITY_PAGE_BYTES);
+                bytes.iter().copied()
+            })
+            .collect::<Vec<_>>();
+        let expected = document.identity_checkpoint().1;
+        let mut cursor = payload.as_slice();
+        for identity in expected {
+            assert_eq!(uuid::Uuid::from_slice(&cursor[..16]).unwrap(), identity.id);
+            let length = u32::from_le_bytes(cursor[16..20].try_into().unwrap()) as usize;
+            assert_eq!(&cursor[20..20 + length], identity.order_key.as_bytes());
+            cursor = &cursor[20 + length..];
+        }
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn bom_checkpoint_and_arena_preserve_first_quoted_cell() {
+        let namespace = IdNamespace::from_halves(31, 47);
+        for source in [
+            "\u{feff}\"first,quoted\",value\r\nlast,tail\r\n",
+            "\u{feff}first,value\n",
+            "\u{feff}",
+        ] {
+            let bytes = source.as_bytes().to_vec();
+            let (document, _) = Document::open_file(bytes.clone(), None, namespace).unwrap();
+            assert!(document.dialect().bom);
+            let mut stored = MemoryState::default();
+            store_identity_checkpoint(None, &mut stored, &document).unwrap();
+            let (_, _, dialect) =
+                decode_identity_manifest(stored.0.get(CSV_IDENTITIES_KEY).unwrap()).unwrap();
+            assert!(dialect.bom);
+            let identities = document.identity_checkpoint().1;
+            let checkpoint =
+                Document::open_file_with_identities(bytes.clone(), dialect, namespace, &identities)
+                    .unwrap();
+            assert_eq!(checkpoint.bytes(), bytes);
+            assert_eq!(
+                checkpoint.row_records().unwrap(),
+                document.row_records().unwrap()
+            );
+            let import = ColdInitialImport::open(bytes.clone(), None).unwrap();
+            let state = import.arena_state(namespace.0[..12].try_into().unwrap());
+            let index = decode_csv_index_header(&state[..CSV_INDEX_HEADER_BYTES as usize]).unwrap();
+            assert!(index.dialect().bom);
+            let (arena, _) =
+                Document::open_file_with_stored_dialect(bytes.clone(), index.dialect(), namespace)
+                    .unwrap();
+            assert_eq!(arena.bytes(), bytes);
+            assert_eq!(
+                arena.row_records().unwrap(),
+                document.row_records().unwrap()
+            );
+            if document.row_count() > 0 {
+                assert_eq!(
+                    ArenaRowIndex::decode(&state)
+                        .unwrap()
+                        .row_range_for_edit(3, 0)
+                        .unwrap()
+                        .1,
+                    3
+                );
+                let cells = document.row_records().unwrap()[1]
+                    .row
+                    .get("cells")
+                    .unwrap()
+                    .clone();
+                let expected = if source.contains("quoted") {
+                    "first,quoted"
+                } else {
+                    "first"
+                };
+                let sdk::TypedValue::Jsonb(cells) = cells else {
+                    panic!("expected cells");
+                };
+                assert_eq!(cells.as_value()[0], expected);
+            }
+        }
     }
 }


### PR DESCRIPTION
CSV edits could leave duplicate indexed rows, lose empty final cells or quoted content, and reopen with a different dialect. This change reconciles complete affected rows, preserves lexical formatting and UTF-8 BOMs, and restores the stored delimiter, quote, and line-ending policy.

Also fixes adjacent splices and unterminated-row reordering, and rejects unsupported NUL bytes before storing unreadable typed rows. Adds regressions and a release note.

Validation:
- 37 unit tests passed, including large index/identity pages and merge combinations.
- 23 CSV integration tests passed, including SQL edits and RocksDB reopen.
- 20 repeated full CSV test-suite runs passed with no flakes.
- Clippy with warnings denied and formatting checks passed.
