### PR TITLE
Add native plugin lifecycle testing and shared edit helpers

### DIFF
--- a/.changenotes/plugin-authoring-helpers.md
+++ b/.changenotes/plugin-authoring-helpers.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Simplified plugin development with native lifecycle testing, validated file edits, and scoped state cleanup.
+
+Plugin authors can test projection hooks without compiling WebAssembly, read edited file ranges without rebuilding the whole file, and clear related private state in one operation. Markdown and CSV use the shared helpers to reduce duplicated edit and cache bookkeeping. Rebuild plugin components against the updated SDK to use the new state cleanup host operation.

--- a/docs/plugin-testing.md
+++ b/docs/plugin-testing.md
@@ -1,0 +1,117 @@
+# Testing and maintaining file plugins
+
+The SDK provides helpers through `lix::plugin`. Plugins still implement the four
+`FileProjection` hooks explicitly. Incremental fallback remains a plugin decision:
+a full rebuild must preserve existing row identities, and warm calls intentionally
+avoid loading all accepted rows.
+
+## Validated edits
+
+`EditSet` validates all edits against the length of the accepted file before any
+bytes are read or changed. Offsets refer to that original file, starts must be
+strictly increasing, and deletion ranges must not overlap. Adjacent edits are
+allowed; multiple insertions at the same offset must be combined by the caller.
+
+```rust,ignore
+let edits = input.file_edits.validated(input.before.len())?;
+let first_bytes = edits.read_range(&input.before, 0, edits.len().min(128))?;
+```
+
+`read_range` uses coordinates in the resulting file and reads only intersecting
+unchanged bytes from the snapshot. Inserted bytes come directly from the edits.
+`apply(&bytes)` materializes the complete resulting file when that is appropriate.
+The helper handles binary bytes; encoding, record boundaries, and syntax are
+still the plugin's responsibility. Use the same accepted snapshot used to
+validate the edit set; matching lengths alone cannot establish file identity.
+
+## Private state cleanup
+
+All four output types implement `StateOutput`. Shared helpers can accept
+`&mut impl StateOutput` without repeating an adapter trait in each plugin.
+
+```rust,ignore
+fn replace_index(output: &mut impl lix::plugin::StateOutput) -> lix::plugin::Result<()> {
+    output.delete_state_prefix(b"my-plugin/index/")?;
+    output.put_state(b"my-plugin/index/root", b"new index")
+}
+```
+
+Prefix deletion includes accepted keys and writes staged earlier in the same
+transition. Later writes recreate keys. Like other state writes, deletion commits
+with the successful transition and rolls back on failure. Empty prefixes and
+prefixes overlapping the host's reserved state namespace are rejected. Include a
+separator in your namespace to avoid unintentionally matching similarly named
+keys. This is a cleanup operation for rebuilds, not a replacement for sparse
+updates on every edit.
+
+## Conformance expectations
+
+For a plugin that promises lossless editing, test these properties:
+
+- Replaying unchanged rows retains exact bytes, including encoding, BOM,
+  whitespace, quoting, and line endings.
+- Incremental edits and full parsing agree on semantic content.
+- Untouched rows keep their identities through editing and reopening.
+- Evicting disposable indexes does not change the result of the next edit.
+- Invalid or unrepresentable edits leave accepted bytes, rows, and state intact.
+- Repeated identical inputs produce identical outputs.
+
+Formatting hints can become stale after row edits. Normalize hints such as CSV
+quote flags against the new content before rendering. Preserve authoritative
+formatting information in durable rows or recover it from accepted bytes; do not
+depend on an index surviving cache eviction.
+
+Keep compiled-component integration tests as well: native tests do not verify
+the Wasm boundary, host schema validation, identity reconciliation, or SQL
+transactions.
+
+## Native projection driver
+
+`lix::plugin::testing::Harness<MyPlugin>` calls the four real `FileProjection`
+hooks with in-memory snapshots, typed row pages, and staged outputs. It is
+available on native targets without an additional feature flag.
+
+```rust,ignore
+use lix::plugin::{CreateContext, FileEdit};
+use lix::plugin::testing::{Harness, Snapshot};
+
+let driver = Harness::<MyPlugin>::default();
+let creates = CreateContext::from_namespace_bytes([1; 12]);
+let file = Snapshot {
+    file_id: "test-file".into(),
+    path: "example.md".into(),
+    bytes: b"Hello\n".to_vec(),
+    ..Snapshot::default()
+};
+let parsed = driver.parse(&file, creates)?;
+assert!(!parsed.row_changes.is_empty());
+let file = parsed.into_snapshot(); // Explicitly accept the staged result.
+let edit = FileEdit { offset: 0, delete_len: 5, insert: b"World".to_vec() };
+let changed = driver.parse_changes(
+    &file, &file.path, &[edit], None,
+    CreateContext::from_namespace_bytes([2; 12]),
+)?;
+assert_eq!(changed.snapshot().bytes, b"World\n");
+```
+
+`serialize` accepts complete `TypedRowRecord` values and an optional accepted
+snapshot. `serialize_changes` accepts sparse `TypedRowChange` values. Results
+expose decoded row changes, the row-replacement flag, emitted byte edits, and
+an optional complete file replacement. Inspect the staged successor with
+`snapshot()` and commit it with `into_snapshot()`. An error leaves the input
+snapshot unchanged, including state writes emitted before the error.
+
+For a cold incremental call, clear the snapshot's disposable `state` and pass
+complete accepted rows in `parse_changes`'s `cold_rows` argument. The driver
+intentionally does not maintain a database: tests apply emitted row changes to
+their own fixture rows. A create's `local_ref` resolves to `creates.id(local_ref)`;
+the fixture must supply generated columns and primary keys when turning creates
+into complete durable rows. Use a new deterministic create namespace for each
+transition. See the Markdown plugin's `src/adapter_qa_tests.rs` for a complete
+parse, sparse-edit, row-edit, and cold-reopen lifecycle.
+
+The harness uses a conservative 1 MiB batch limit by default. Set
+`driver.max_batch_bytes = 2 * 1024 * 1024` to match the standard runtime page
+budget when testing large state pages or embedded files. Cold-file admission can
+raise the real host's budget further. The native driver checks per-operation
+limits, while compiled-component tests cover the complete host budget.

--- a/packages/lix/src/plugin/api/edits.rs
+++ b/packages/lix/src/plugin/api/edits.rs
@@ -1,0 +1,262 @@
+use super::{Error, FileEdit, Result, Snapshot};
+
+/// Validated byte edits in the coordinates of one accepted file.
+///
+/// Starts must be strictly increasing and deletion ranges must not overlap.
+/// Adjacent edits are valid; two insertions at the same offset are not.
+/// Validation never sorts or changes the edits. Text encoding and syntax
+/// boundaries remain the plugin's responsibility.
+#[derive(Debug)]
+pub struct EditSet<'a> {
+    edits: &'a [FileEdit],
+    before_len: u64,
+    after_len: u64,
+}
+
+impl<'a> EditSet<'a> {
+    pub fn new(edits: &'a [FileEdit], before_len: u64) -> Result<Self> {
+        let mut previous_start = None;
+        let mut previous_end = 0;
+        let mut deleted = 0_u64;
+        let mut inserted = 0_u64;
+        for edit in edits {
+            let end = edit
+                .offset
+                .checked_add(edit.delete_len)
+                .ok_or_else(|| Error::invalid_input("file edit range overflowed"))?;
+            if previous_start == Some(edit.offset) || edit.offset < previous_end || end > before_len
+            {
+                return Err(Error::invalid_input(
+                    "file edits must have increasing starts, not overlap, and stay within the accepted file",
+                ));
+            }
+            deleted += edit.delete_len;
+            inserted = inserted
+                .checked_add(edit.insert.len() as u64)
+                .ok_or_else(|| Error::limit_exceeded("edited file length overflowed"))?;
+            previous_start = Some(edit.offset);
+            previous_end = end;
+        }
+        let after_len = (before_len - deleted)
+            .checked_add(inserted)
+            .ok_or_else(|| Error::limit_exceeded("edited file length overflowed"))?;
+        Ok(Self {
+            edits,
+            before_len,
+            after_len,
+        })
+    }
+
+    /// Length in bytes of the resulting file.
+    pub fn len(&self) -> u64 {
+        self.after_len
+    }
+
+    /// Whether the resulting file has no bytes.
+    pub fn is_empty(&self) -> bool {
+        self.after_len == 0
+    }
+
+    /// Applies all edits after checking that the base has the validated length.
+    pub fn apply(&self, before: &[u8]) -> Result<Vec<u8>> {
+        self.check_base(before.len() as u64)?;
+        self.read_with(0, self.after_len, |offset, length| {
+            Ok(before[offset as usize..(offset + length) as usize].to_vec())
+        })
+    }
+
+    /// Reads a range in successor coordinates without materializing the file.
+    /// Only unchanged bytes intersecting the requested range are read from the
+    /// snapshot; inserted bytes are read directly from the edit set.
+    pub fn read_range(&self, before: &Snapshot<'_>, offset: u64, length: u64) -> Result<Vec<u8>> {
+        self.check_base(before.len())?;
+        self.read_with(offset, length, |start, len| before.read_range(start, len))
+    }
+
+    fn check_base(&self, length: u64) -> Result<()> {
+        if length != self.before_len {
+            return Err(Error::invalid_input("file edit base length changed"));
+        }
+        Ok(())
+    }
+
+    fn read_with(
+        &self,
+        offset: u64,
+        length: u64,
+        mut read: impl FnMut(u64, u64) -> Result<Vec<u8>>,
+    ) -> Result<Vec<u8>> {
+        let end = offset
+            .checked_add(length)
+            .filter(|end| *end <= self.after_len)
+            .ok_or_else(|| Error::invalid_input("edited file read exceeds the resulting file"))?;
+        let capacity = usize::try_from(length)
+            .map_err(|_| Error::limit_exceeded("edited file read exceeds guest address space"))?;
+        let mut output = Vec::new();
+        output
+            .try_reserve_exact(capacity)
+            .map_err(|_| Error::limit_exceeded("edited file read allocation failed"))?;
+        let mut before_cursor = 0;
+        let mut after_cursor = 0;
+        for edit in self.edits {
+            let unchanged = edit.offset - before_cursor;
+            if let Some((start, len)) = intersection(after_cursor, unchanged, offset, end) {
+                output.extend(read(before_cursor + start, len)?);
+            }
+            after_cursor += unchanged;
+            if let Some((start, len)) =
+                intersection(after_cursor, edit.insert.len() as u64, offset, end)
+            {
+                output.extend_from_slice(&edit.insert[start as usize..(start + len) as usize]);
+            }
+            after_cursor += edit.insert.len() as u64;
+            before_cursor = edit.offset + edit.delete_len;
+            if after_cursor >= end {
+                break;
+            }
+        }
+        if after_cursor < end {
+            if let Some((start, len)) =
+                intersection(after_cursor, self.before_len - before_cursor, offset, end)
+            {
+                output.extend(read(before_cursor + start, len)?);
+            }
+        }
+        if output.len() != capacity {
+            return Err(Error::invalid_input(
+                "edited file source returned a short read",
+            ));
+        }
+        Ok(output)
+    }
+}
+
+// Returns an offset relative to the segment and its intersecting length.
+fn intersection(segment: u64, length: u64, start: u64, end: u64) -> Option<(u64, u64)> {
+    let from = segment.max(start);
+    let to = (segment + length).min(end);
+    (from < to).then(|| (from - segment, to - from))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edit(offset: u64, delete_len: u64, insert: &[u8]) -> FileEdit {
+        FileEdit {
+            offset,
+            delete_len,
+            insert: insert.to_vec(),
+        }
+    }
+
+    #[test]
+    fn invalid_edits_fail_before_reading() {
+        for edits in [
+            vec![edit(2, 0, b"a"), edit(1, 0, b"b")],
+            vec![edit(1, 0, b"a"), edit(1, 0, b"b")],
+            vec![edit(0, 2, b""), edit(1, 1, b"")],
+            vec![edit(4, 0, b"")],
+            vec![edit(u64::MAX, 1, b"")],
+        ] {
+            assert!(EditSet::new(&edits, 3).is_err());
+        }
+        let edits = [edit(3, 0, b"!")];
+        assert_eq!(
+            EditSet::new(&edits, 3).unwrap().apply(b"abc").unwrap(),
+            b"abc!"
+        );
+        assert!(EditSet::new(&edits, 3).unwrap().apply(b"ab").is_err());
+    }
+
+    #[test]
+    fn all_small_edit_pairs_and_ranges_match_splice_oracle() {
+        let before = b"a\r\n\xffb";
+        let n = before.len();
+        for first in 0..=n {
+            for first_end in first..=n {
+                for second in (first + 1).max(first_end)..=n {
+                    for second_end in second..=n {
+                        for insert in [b"".as_slice(), b"x", b"\r\n!"] {
+                            let edits = [
+                                edit(first as u64, (first_end - first) as u64, insert),
+                                edit(second as u64, (second_end - second) as u64, b"z"),
+                            ];
+                            let mut expected = before.to_vec();
+                            for edit in edits.iter().rev() {
+                                expected.splice(
+                                    edit.offset as usize..(edit.offset + edit.delete_len) as usize,
+                                    edit.insert.iter().copied(),
+                                );
+                            }
+                            let set = EditSet::new(&edits, n as u64).unwrap();
+                            assert_eq!(set.apply(before).unwrap(), expected);
+                            for start in 0..=expected.len() {
+                                for end in start..=expected.len() {
+                                    let actual = set
+                                        .read_with(
+                                            start as u64,
+                                            (end - start) as u64,
+                                            |offset, len| {
+                                                Ok(before[offset as usize..(offset + len) as usize]
+                                                    .to_vec())
+                                            },
+                                        )
+                                        .unwrap();
+                                    assert_eq!(actual, expected[start..end]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn range_reads_only_fetch_intersecting_base_bytes() {
+        let edits = [edit(4, 2, b"XYZ")];
+        let set = EditSet::new(&edits, 1_000_000).unwrap();
+        let mut reads = Vec::new();
+        assert_eq!(
+            set.read_with(3, 5, |offset, len| {
+                reads.push((offset, len));
+                Ok(vec![b'.'; len as usize])
+            })
+            .unwrap(),
+            b".XYZ."
+        );
+        assert_eq!(reads, [(3, 1), (6, 1)]);
+        assert_eq!(
+            set.read_with(4, 3, |_, _| panic!("insertion must not read base"))
+                .unwrap(),
+            b"XYZ"
+        );
+        assert!(set.read_with(set.len(), 1, |_, _| unreachable!()).is_err());
+        assert!(set.read_with(u64::MAX, 1, |_, _| unreachable!()).is_err());
+    }
+
+    #[test]
+    fn empty_noop_and_full_deletion() {
+        assert!(EditSet::new(&[], 0).unwrap().apply(b"").unwrap().is_empty());
+        assert_eq!(EditSet::new(&[], 3).unwrap().apply(b"abc").unwrap(), b"abc");
+        let edits = [edit(0, 3, b"")];
+        let set = EditSet::new(&edits, 3).unwrap();
+        assert!(set.is_empty());
+        assert!(set.apply(b"abc").unwrap().is_empty());
+    }
+
+    #[test]
+    fn large_coordinates_and_read_failures_are_checked() {
+        let growing = [edit(u64::MAX, 0, b"!")];
+        assert!(EditSet::new(&growing, u64::MAX).is_err());
+        let deleting = [edit(0, u64::MAX, b"!")];
+        let set = EditSet::new(&deleting, u64::MAX).unwrap();
+        assert_eq!(set.len(), 1);
+        assert_eq!(set.read_with(0, 1, |_, _| unreachable!()).unwrap(), b"!");
+        let set = EditSet::new(&[], 3).unwrap();
+        assert!(set.read_with(0, 3, |_, _| Ok(vec![0])).is_err());
+        let error = Error::internal("source failed");
+        assert_eq!(set.read_with(0, 3, |_, _| Err(error.clone())), Err(error));
+    }
+}

--- a/packages/lix/src/plugin/api/mod.rs
+++ b/packages/lix/src/plugin/api/mod.rs
@@ -6,6 +6,12 @@
     unused_qualifications
 )]
 
+mod edits;
+pub use edits::EditSet;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod testing;
+
 #[doc(hidden)]
 pub mod column_merger_bindings {
     include!(concat!(env!("OUT_DIR"), "/column_merger_bindings.rs"));
@@ -151,6 +157,7 @@ trait TransitionHost {
     fn max_batch_bytes(&self) -> u32;
     fn put_state(&self, key: &[u8], value: &[u8]) -> std::result::Result<(), CommonHostError>;
     fn delete_state(&self, key: &[u8]) -> std::result::Result<(), CommonHostError>;
+    fn delete_state_prefix(&self, prefix: &[u8]) -> std::result::Result<(), CommonHostError>;
     fn emit_rows(
         &self,
         payload: Vec<u8>,
@@ -283,6 +290,12 @@ macro_rules! impl_projection_hosts {
             }
             fn delete_state(&self, key: &[u8]) -> std::result::Result<(), CommonHostError> {
                 self.delete_state(key).map_err(map_host_error)
+            }
+            fn delete_state_prefix(
+                &self,
+                prefix: &[u8],
+            ) -> std::result::Result<(), CommonHostError> {
+                self.delete_state_prefix(prefix).map_err(map_host_error)
             }
             fn emit_rows(
                 &self,
@@ -680,6 +693,13 @@ impl<'a> TransitionOutput<'a> {
             .map_err(|error| host_error("host rejected state deletion", error))
     }
 
+    fn delete_state_prefix(&self, prefix: &[u8]) -> Result<()> {
+        validate_state_prefix(prefix)?;
+        self.inner
+            .delete_state_prefix(prefix)
+            .map_err(|error| host_error("host rejected state prefix deletion", error))
+    }
+
     fn replace_all_rows(&mut self) -> Result<()> {
         self.flush_typed_rows()?;
         self.inner
@@ -884,6 +904,45 @@ impl<'a> TransitionOutput<'a> {
     }
 }
 
+/// Private state writes shared by every projection output.
+///
+/// State changes commit atomically with the file and row changes. To replace a
+/// collection, delete its prefix first, then write its successor entries.
+/// Prefixes are literal bytes: use a trailing separator to delimit a namespace.
+pub trait StateOutput {
+    fn put_state(&mut self, key: &[u8], value: &[u8]) -> Result<()>;
+    fn delete_state(&mut self, key: &[u8]) -> Result<()>;
+    /// Empty prefixes and prefixes overlapping host-reserved state are rejected.
+    fn delete_state_prefix(&mut self, prefix: &[u8]) -> Result<()>;
+}
+
+fn validate_state_prefix(prefix: &[u8]) -> Result<()> {
+    const RESERVED: &[u8] = b"\0lix/";
+    if prefix.is_empty() || prefix.starts_with(RESERVED) || RESERVED.starts_with(prefix) {
+        return Err(Error::invalid_input(
+            "state prefix must be nonempty and outside host-reserved state",
+        ));
+    }
+    Ok(())
+}
+
+macro_rules! impl_state_output {
+    ($($output:ident),+ $(,)?) => {$(
+        impl StateOutput for $output<'_, '_> {
+            fn put_state(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+                self.put_state(key, value)
+            }
+            fn delete_state(&mut self, key: &[u8]) -> Result<()> {
+                self.delete_state(key)
+            }
+            fn delete_state_prefix(&mut self, prefix: &[u8]) -> Result<()> {
+                self.delete_state_prefix(prefix)
+            }
+        }
+    )+};
+}
+impl_state_output!(RowOutput, RowChangeOutput, FileOutput, FileEditOutput);
+
 /// Complete rows produced by [`FileProjection::parse`] or cold reconciliation
 /// in [`FileProjection::parse_changes`].
 #[derive(Debug)]
@@ -958,6 +1017,12 @@ impl RowOutput<'_, '_> {
 
     pub fn delete_state(&mut self, key: &[u8]) -> Result<()> {
         self.inner.delete_state(key)
+    }
+
+    /// Deletes all private state whose key starts with `prefix`, including
+    /// earlier writes in this transition. Later writes recreate those keys.
+    pub fn delete_state_prefix(&mut self, prefix: &[u8]) -> Result<()> {
+        self.inner.delete_state_prefix(prefix)
     }
 }
 
@@ -1036,6 +1101,12 @@ impl<'host> RowChangeOutput<'_, 'host> {
     pub fn delete_state(&mut self, key: &[u8]) -> Result<()> {
         self.inner.delete_state(key)
     }
+
+    /// Deletes all private state whose key starts with `prefix`, including
+    /// earlier writes in this transition. Later writes recreate those keys.
+    pub fn delete_state_prefix(&mut self, prefix: &[u8]) -> Result<()> {
+        self.inner.delete_state_prefix(prefix)
+    }
 }
 
 /// Complete file bytes produced from complete rows.
@@ -1055,6 +1126,12 @@ impl FileOutput<'_, '_> {
 
     pub fn delete_state(&mut self, key: &[u8]) -> Result<()> {
         self.inner.delete_state(key)
+    }
+
+    /// Deletes all private state whose key starts with `prefix`, including
+    /// earlier writes in this transition. Later writes recreate those keys.
+    pub fn delete_state_prefix(&mut self, prefix: &[u8]) -> Result<()> {
+        self.inner.delete_state_prefix(prefix)
     }
 }
 
@@ -1079,6 +1156,12 @@ impl FileEditOutput<'_, '_> {
 
     pub fn delete_state(&mut self, key: &[u8]) -> Result<()> {
         self.inner.delete_state(key)
+    }
+
+    /// Deletes all private state whose key starts with `prefix`, including
+    /// earlier writes in this transition. Later writes recreate those keys.
+    pub fn delete_state_prefix(&mut self, prefix: &[u8]) -> Result<()> {
+        self.inner.delete_state_prefix(prefix)
     }
 }
 
@@ -1458,6 +1541,11 @@ pub struct FileEditReader<'a> {
 }
 
 impl<'a> FileEditReader<'a> {
+    /// Validates predecessor-coordinate edits before applying or mapping them.
+    pub fn validated(&self, before_len: u64) -> Result<EditSet<'a>> {
+        EditSet::new(self.edits, before_len)
+    }
+
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &'a FileEdit> + Clone {
         self.edits.iter()
     }
@@ -1932,6 +2020,9 @@ mod tests {
         fn delete_state(&self, _: &[u8]) -> std::result::Result<(), CommonHostError> {
             Ok(())
         }
+        fn delete_state_prefix(&self, _: &[u8]) -> std::result::Result<(), CommonHostError> {
+            Ok(())
+        }
         fn emit_rows(
             &self,
             payload: Vec<u8>,
@@ -2007,6 +2098,15 @@ mod tests {
             .fold((0, 0), |(records, bytes), page| {
                 (records + page.0, bytes + page.1)
             })
+    }
+
+    #[test]
+    fn state_prefix_rejects_empty_and_host_reserved_overlap() {
+        for prefix in [b"".as_slice(), b"\0", b"\0lix", b"\0lix/", b"\0lix/private"] {
+            assert!(validate_state_prefix(prefix).is_err());
+        }
+        assert!(validate_state_prefix(b"markdown/blocks/").is_ok());
+        assert!(validate_state_prefix(b"\0other/").is_ok());
     }
 
     #[test]

--- a/packages/lix/src/plugin/api/testing.rs
+++ b/packages/lix/src/plugin/api/testing.rs
@@ -407,6 +407,7 @@ impl TransitionHost for RecordingHost {
         delete_len: u64,
         insert: &[u8],
     ) -> std::result::Result<(), CommonHostError> {
+        self.check_state_size(0, insert.len())?;
         let mut record = self.record.borrow_mut();
         if record.replacement.is_some() || record.pending_replacement.is_some() {
             return Err(CommonHostError::Rejected(
@@ -555,6 +556,18 @@ mod tests {
         );
         host.delete_state(b"abcd").unwrap();
         host.delete_state_prefix(b"abcd").unwrap();
+    }
+
+    #[test]
+    fn file_edits_enforce_each_insertion_batch_boundary() {
+        let host = RecordingHost::new(&Snapshot::default(), 4);
+        host.emit_file_edit(0, 0, b"1234").unwrap();
+        assert!(host.emit_file_edit(0, 0, b"12345").is_err());
+        assert_eq!(host.record.borrow().edits.len(), 1);
+        // The boundary is per insertion, not the sum of separate calls.
+        host.emit_file_edit(0, 0, b"5678").unwrap();
+        host.emit_file_edit(0, 0, b"").unwrap();
+        assert_eq!(host.record.borrow().edits.len(), 3);
     }
 
     #[test]

--- a/packages/lix/src/plugin/api/testing.rs
+++ b/packages/lix/src/plugin/api/testing.rs
@@ -1,0 +1,611 @@
+//! Native tests for a plugin's actual [`FileProjection`] implementation.
+//!
+//! Calls use the same typed page codecs and buffered outputs as the Component
+//! adapter. Successful output is staged: commit it by assigning
+//! `file = transition.into_snapshot()`. Errors leave the input snapshot intact.
+//! This host does not resolve generated row identities or validate SQL schemas;
+//! tests supply complete durable rows when exercising cold transitions.
+
+use super::*;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+/// Accepted bytes and plugin-private state for one file.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Snapshot {
+    pub file_id: String,
+    pub path: String,
+    pub bytes: Vec<u8>,
+    pub state: BTreeMap<Vec<u8>, Vec<u8>>,
+}
+
+/// A successful, uncommitted plugin transition.
+#[derive(Debug)]
+pub struct Transition {
+    pub row_changes: Vec<TypedRowChange>,
+    pub replaces_all_rows: bool,
+    pub file_edits: Vec<FileEdit>,
+    pub file_replacement: Option<Vec<u8>>,
+    snapshot: Snapshot,
+}
+
+impl Transition {
+    /// Inspect the successor without committing it.
+    pub fn snapshot(&self) -> &Snapshot {
+        &self.snapshot
+    }
+
+    /// Commit by replacing the caller's accepted snapshot with this value.
+    pub fn into_snapshot(self) -> Snapshot {
+        self.snapshot
+    }
+}
+
+/// In-memory driver for all four file-projection hooks.
+#[derive(Debug)]
+pub struct Harness<F> {
+    pub max_batch_bytes: u32,
+    plugin: PhantomData<F>,
+}
+
+impl<F> Default for Harness<F> {
+    fn default() -> Self {
+        Self {
+            max_batch_bytes: 1024 * 1024,
+            plugin: PhantomData,
+        }
+    }
+}
+
+impl<F: FileProjection> Harness<F> {
+    pub fn parse(&self, file: &Snapshot, creates: CreateContext) -> Result<Transition> {
+        let host = RecordingHost::new(file, self.max_batch_bytes);
+        let mut output = TransitionOutput::new(&host)?;
+        F::parse(
+            ParseInput {
+                file_id: &file.file_id,
+                path: &file.path,
+                file: super::Snapshot { inner: file },
+                creates,
+            },
+            &mut RowOutput { inner: &mut output },
+        )?;
+        output.finish()?;
+        host.finish(file.clone())
+    }
+
+    pub fn parse_changes(
+        &self,
+        before: &Snapshot,
+        after_path: &str,
+        edits: &[FileEdit],
+        cold_rows: Option<&[TypedRowRecord]>,
+        creates: CreateContext,
+    ) -> Result<Transition> {
+        let bytes = EditSet::new(edits, before.bytes.len() as u64)?.apply(&before.bytes)?;
+        let rows = cold_rows
+            .map(|rows| Rows::complete(rows, self.max_batch_bytes))
+            .transpose()?;
+        let host = RecordingHost::new(before, self.max_batch_bytes);
+        let mut output = TransitionOutput::new(&host)?;
+        F::parse_changes(
+            ParseChangesInput {
+                file_id: &before.file_id,
+                before_path: &before.path,
+                after_path,
+                before: super::Snapshot { inner: before },
+                file_edits: FileEditReader { edits },
+                typed_rows: rows
+                    .as_ref()
+                    .map(|rows| TypedRowReader::new(rows, self.max_batch_bytes)),
+                creates,
+            },
+            &mut RowChangeOutput { inner: &mut output },
+        )?;
+        output.finish()?;
+        let mut successor = before.clone();
+        successor.bytes = bytes;
+        successor.path = after_path.to_owned();
+        host.finish(successor)
+    }
+
+    pub fn serialize(
+        &self,
+        file_id: &str,
+        path: &str,
+        rows: &[TypedRowRecord],
+        before: Option<&Snapshot>,
+    ) -> Result<Transition> {
+        let rows = Rows::complete(rows, self.max_batch_bytes)?;
+        let mut successor = before.cloned().unwrap_or_default();
+        successor.file_id = file_id.to_owned();
+        successor.path = path.to_owned();
+        let host = RecordingHost::new(&successor, self.max_batch_bytes);
+        let mut output = TransitionOutput::new(&host)?;
+        F::serialize(
+            SerializeInput {
+                file_id,
+                path,
+                typed_rows: TypedRowReader::new(&rows, self.max_batch_bytes),
+                before: before.map(|file| super::Snapshot { inner: file }),
+            },
+            &mut FileOutput { inner: &mut output },
+        )?;
+        output.finish()?;
+        if before.is_none() && host.record.borrow().replacement.is_none() {
+            return Err(Error::invalid_input(
+                "cold serialize did not emit a file replacement",
+            ));
+        }
+        host.finish(successor)
+    }
+
+    pub fn serialize_changes(
+        &self,
+        before: &Snapshot,
+        changes: &[TypedRowChange],
+    ) -> Result<Transition> {
+        let rows = Rows::changes(changes, self.max_batch_bytes)?;
+        let host = RecordingHost::new(before, self.max_batch_bytes);
+        let mut output = TransitionOutput::new(&host)?;
+        F::serialize_changes(
+            SerializeChangesInput {
+                file_id: &before.file_id,
+                path: &before.path,
+                before: super::Snapshot { inner: before },
+                typed_row_changes: TypedRowChangeReader::new(&rows, self.max_batch_bytes),
+            },
+            &mut FileEditOutput { inner: &mut output },
+        )?;
+        output.finish()?;
+        host.finish(before.clone())
+    }
+}
+
+impl SnapshotHost for Snapshot {
+    fn file_len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    fn read_file(&self, offset: u64, length: u32) -> std::result::Result<Vec<u8>, CommonHostError> {
+        read_slice(&self.bytes, offset, length, false)
+    }
+
+    fn read_state(
+        &self,
+        key: &[u8],
+        offset: u64,
+        max_bytes: u32,
+    ) -> std::result::Result<Option<CommonRecordChunk>, CommonHostError> {
+        self.state
+            .get(key)
+            .map(|bytes| {
+                Ok(CommonRecordChunk {
+                    total_len: bytes.len() as u64,
+                    bytes: read_slice(bytes, offset, max_bytes, true)?,
+                })
+            })
+            .transpose()
+    }
+}
+
+fn read_slice(
+    bytes: &[u8],
+    offset: u64,
+    length: u32,
+    truncate: bool,
+) -> std::result::Result<Vec<u8>, CommonHostError> {
+    let start = usize::try_from(offset).map_err(|_| CommonHostError::InvalidRange)?;
+    let end = start
+        .checked_add(length as usize)
+        .ok_or(CommonHostError::InvalidRange)?;
+    let end = if truncate { end.min(bytes.len()) } else { end };
+    bytes
+        .get(start..end)
+        .map(<[u8]>::to_vec)
+        .ok_or(CommonHostError::InvalidRange)
+}
+
+type Page = (Vec<u8>, Vec<Vec<u8>>);
+
+struct Rows(RefCell<VecDeque<Page>>);
+
+impl Rows {
+    fn complete(rows: &[TypedRowRecord], max_bytes: u32) -> Result<Self> {
+        let host = RecordingHost::new(&Snapshot::default(), max_bytes);
+        let mut output = TransitionOutput::new(&host)?;
+        for row in rows {
+            output.typed_row(
+                &row.schema_key,
+                row.schema_fingerprint,
+                TypedMutation::Upsert {
+                    row_pk: &row.primary_key,
+                    row: &row.row,
+                    effect: TypedChangeEffect::Content,
+                },
+            )?;
+        }
+        output.finish()?;
+        Ok(Self(RefCell::new(host.record.into_inner().pages.into())))
+    }
+
+    fn changes(changes: &[TypedRowChange], max_bytes: u32) -> Result<Self> {
+        let host = RecordingHost::new(&Snapshot::default(), max_bytes);
+        let mut output = TransitionOutput::new(&host)?;
+        for change in changes {
+            let mutation = match (&change.row, change.local_ref) {
+                (Some(row), Some(local_ref)) if change.primary_key.is_empty() => {
+                    TypedMutation::Create { local_ref, row }
+                }
+                (Some(row), None) => TypedMutation::Upsert {
+                    row_pk: &change.primary_key,
+                    row,
+                    effect: match change.effect {
+                        ChangeEffect::Content => TypedChangeEffect::Content,
+                        ChangeEffect::FormatOnly => TypedChangeEffect::FormatOnly,
+                    },
+                },
+                (None, None) => TypedMutation::Delete {
+                    row_pk: &change.primary_key,
+                },
+                _ => {
+                    return Err(Error::invalid_input(
+                        "inconsistent test row change identity",
+                    ));
+                }
+            };
+            output.typed_row(&change.schema_key, change.schema_fingerprint, mutation)?;
+        }
+        output.finish()?;
+        Ok(Self(RefCell::new(host.record.into_inner().pages.into())))
+    }
+}
+
+impl RowSourceHost for Rows {
+    fn next_page(&self, _: u32) -> std::result::Result<Option<Page>, CommonHostError> {
+        Ok(self.0.borrow_mut().pop_front())
+    }
+}
+
+#[derive(Default)]
+struct Record {
+    state: BTreeMap<Vec<u8>, Vec<u8>>,
+    pages: Vec<Page>,
+    replaces_all_rows: bool,
+    edits: Vec<FileEdit>,
+    replacement: Option<Vec<u8>>,
+    pending_replacement: Option<(u64, Vec<u8>)>,
+}
+
+struct RecordingHost {
+    max_bytes: u32,
+    record: RefCell<Record>,
+}
+
+impl RecordingHost {
+    fn new(before: &Snapshot, max_bytes: u32) -> Self {
+        Self {
+            max_bytes,
+            record: RefCell::new(Record {
+                state: before.state.clone(),
+                ..Record::default()
+            }),
+        }
+    }
+
+    fn check_state_size(
+        &self,
+        key_bytes: usize,
+        value_bytes: usize,
+    ) -> std::result::Result<(), CommonHostError> {
+        if key_bytes
+            .checked_add(value_bytes)
+            .is_none_or(|size| size > self.max_bytes as usize)
+        {
+            return Err(CommonHostError::LimitExceeded(
+                "state operation exceeds max-batch-bytes".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn finish(self, mut snapshot: Snapshot) -> Result<Transition> {
+        let record = self.record.into_inner();
+        if record.pending_replacement.is_some() {
+            return Err(Error::invalid_input("unfinished test file replacement"));
+        }
+        snapshot.bytes = match &record.replacement {
+            Some(bytes) => bytes.clone(),
+            None => {
+                EditSet::new(&record.edits, snapshot.bytes.len() as u64)?.apply(&snapshot.bytes)?
+            }
+        };
+        snapshot.state = record.state;
+        let pages = Rows(RefCell::new(record.pages.into()));
+        let mut reader = TypedRowChangeReader::new(&pages, self.max_bytes);
+        let mut row_changes = Vec::new();
+        while let Some(change) = reader.next()? {
+            row_changes.push(change);
+        }
+        Ok(Transition {
+            row_changes,
+            replaces_all_rows: record.replaces_all_rows,
+            file_edits: record.edits,
+            file_replacement: record.replacement,
+            snapshot,
+        })
+    }
+}
+
+impl TransitionHost for RecordingHost {
+    fn max_batch_bytes(&self) -> u32 {
+        self.max_bytes
+    }
+
+    fn put_state(&self, key: &[u8], value: &[u8]) -> std::result::Result<(), CommonHostError> {
+        if key.starts_with(b"\0lix/") {
+            return Err(CommonHostError::Rejected(
+                "host-reserved state key".to_owned(),
+            ));
+        }
+        self.check_state_size(key.len(), value.len())?;
+        self.record
+            .borrow_mut()
+            .state
+            .insert(key.to_vec(), value.to_vec());
+        Ok(())
+    }
+
+    fn delete_state(&self, key: &[u8]) -> std::result::Result<(), CommonHostError> {
+        if key.starts_with(b"\0lix/") {
+            return Err(CommonHostError::Rejected(
+                "host-reserved state key".to_owned(),
+            ));
+        }
+        self.check_state_size(key.len(), 0)?;
+        self.record.borrow_mut().state.remove(key);
+        Ok(())
+    }
+
+    fn delete_state_prefix(&self, prefix: &[u8]) -> std::result::Result<(), CommonHostError> {
+        if prefix.is_empty() || prefix.starts_with(b"\0lix/") || b"\0lix/".starts_with(prefix) {
+            return Err(CommonHostError::Rejected(
+                "reserved or empty state prefix".to_owned(),
+            ));
+        }
+        self.check_state_size(prefix.len(), 0)?;
+        self.record
+            .borrow_mut()
+            .state
+            .retain(|key, _| !key.starts_with(prefix));
+        Ok(())
+    }
+
+    fn emit_rows(
+        &self,
+        payload: Vec<u8>,
+        attachments: Vec<Vec<u8>>,
+    ) -> std::result::Result<(), CommonHostError> {
+        self.record.borrow_mut().pages.push((payload, attachments));
+        Ok(())
+    }
+
+    fn replace_all_rows(&self) -> std::result::Result<(), CommonHostError> {
+        let mut record = self.record.borrow_mut();
+        if record.replaces_all_rows {
+            return Err(CommonHostError::Rejected(
+                "replace-all-rows was already requested".to_owned(),
+            ));
+        }
+        record.replaces_all_rows = true;
+        Ok(())
+    }
+
+    fn emit_file_edit(
+        &self,
+        offset: u64,
+        delete_len: u64,
+        insert: &[u8],
+    ) -> std::result::Result<(), CommonHostError> {
+        let mut record = self.record.borrow_mut();
+        if record.replacement.is_some() || record.pending_replacement.is_some() {
+            return Err(CommonHostError::Rejected(
+                "cannot mix replacement and file edits".to_owned(),
+            ));
+        }
+        record.edits.push(FileEdit {
+            offset,
+            delete_len,
+            insert: insert.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn begin_file_replacement(&self, length: u64) -> std::result::Result<(), CommonHostError> {
+        let mut record = self.record.borrow_mut();
+        if record.replacement.is_some()
+            || record.pending_replacement.is_some()
+            || !record.edits.is_empty()
+        {
+            return Err(CommonHostError::Rejected(
+                "file output already started".to_owned(),
+            ));
+        }
+        record.pending_replacement = Some((length, Vec::new()));
+        Ok(())
+    }
+
+    fn write_file_replacement(&self, chunk: &[u8]) -> std::result::Result<(), CommonHostError> {
+        let mut record = self.record.borrow_mut();
+        let Some((expected, bytes)) = &mut record.pending_replacement else {
+            return Err(CommonHostError::Rejected(
+                "replacement not started".to_owned(),
+            ));
+        };
+        if chunk.len() > self.max_bytes as usize
+            || bytes.len() as u64 + chunk.len() as u64 > *expected
+        {
+            return Err(CommonHostError::InvalidRange);
+        }
+        bytes.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    fn finish_file_replacement(&self) -> std::result::Result<(), CommonHostError> {
+        let mut record = self.record.borrow_mut();
+        let Some((expected, bytes)) = record.pending_replacement.take() else {
+            return Err(CommonHostError::Rejected(
+                "replacement not started".to_owned(),
+            ));
+        };
+        if bytes.len() as u64 != expected {
+            return Err(CommonHostError::InvalidRange);
+        }
+        record.replacement = Some(bytes);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FailingPlugin;
+
+    impl FileProjection for FailingPlugin {
+        fn parse(_: ParseInput<'_>, output: &mut RowOutput<'_, '_>) -> Result<()> {
+            output.put_state(b"test/new", b"staged")?;
+            output.delete_state_prefix(b"test/old/")?;
+            output.create("test", [1; 32], 0, &TypedRow::default())?;
+            output.flush_page()?;
+            Err(Error::invalid_input("intentional failure"))
+        }
+
+        fn parse_changes(
+            _: ParseChangesInput<'_>,
+            output: &mut RowChangeOutput<'_, '_>,
+        ) -> Result<()> {
+            output.put_state(b"test/new", b"staged")?;
+            output.delete_state_prefix(b"test/old/")?;
+            Err(Error::invalid_input("intentional failure"))
+        }
+
+        fn serialize(_: SerializeInput<'_>, output: &mut FileOutput<'_, '_>) -> Result<()> {
+            output.put_state(b"test/new", b"staged")?;
+            output.write(b"replacement")?;
+            Err(Error::invalid_input("intentional failure"))
+        }
+
+        fn serialize_changes(
+            _: SerializeChangesInput<'_>,
+            output: &mut FileEditOutput<'_, '_>,
+        ) -> Result<()> {
+            output.put_state(b"test/new", b"staged")?;
+            output.replace(0, 1, b"replacement")?;
+            Err(Error::invalid_input("intentional failure"))
+        }
+    }
+
+    #[test]
+    fn failed_hooks_discard_staged_rows_bytes_and_state() {
+        let harness = Harness::<FailingPlugin>::default();
+        let before = Snapshot {
+            file_id: "test-file".into(),
+            path: "test.txt".into(),
+            bytes: b"accepted".to_vec(),
+            state: BTreeMap::from([(b"test/old/key".to_vec(), b"accepted state".to_vec())]),
+        };
+        let saved = before.clone();
+        let creates = CreateContext::from_namespace_bytes([1; 12]);
+        assert!(harness.parse(&before, creates).is_err());
+        assert!(
+            harness
+                .parse_changes(
+                    &before,
+                    "changed.txt",
+                    &[FileEdit {
+                        offset: 0,
+                        delete_len: 1,
+                        insert: b"x".to_vec()
+                    }],
+                    None,
+                    creates
+                )
+                .is_err()
+        );
+        assert!(
+            harness
+                .serialize("test-file", "test.txt", &[], Some(&before))
+                .is_err()
+        );
+        assert!(harness.serialize_changes(&before, &[]).is_err());
+        assert_eq!(before, saved);
+    }
+
+    #[test]
+    fn state_operations_enforce_the_host_batch_boundary() {
+        let host = RecordingHost::new(&Snapshot::default(), 4);
+        host.put_state(b"ab", b"12").unwrap();
+        assert!(host.put_state(b"ab", b"123").is_err());
+        assert!(host.delete_state(b"abcde").is_err());
+        assert!(host.delete_state_prefix(b"abcde").is_err());
+        assert_eq!(
+            host.record.borrow().state.get(b"ab".as_slice()).unwrap(),
+            b"12"
+        );
+        host.delete_state(b"abcd").unwrap();
+        host.delete_state_prefix(b"abcd").unwrap();
+    }
+
+    #[test]
+    fn native_host_preserves_emitted_rows_and_rejects_reserved_state() {
+        let before = Snapshot::default();
+        let host = RecordingHost::new(&before, 1024 * 1024);
+        let mut output = TransitionOutput::new(&host).unwrap();
+        output
+            .typed_row(
+                "test",
+                [1; 32],
+                TypedMutation::Create {
+                    local_ref: 0,
+                    row: &TypedRow::default(),
+                },
+            )
+            .unwrap();
+        output.replace_all_rows().unwrap();
+        assert!(output.replace_all_rows().is_err());
+        assert!(output.put_state(b"\0lix/reserved", b"value").is_err());
+        assert!(output.delete_state(b"\0lix/reserved").is_err());
+        output.finish().unwrap();
+        let result = host.finish(before).unwrap();
+        assert!(result.replaces_all_rows);
+        assert_eq!(result.row_changes.len(), 1);
+        assert_eq!(result.row_changes[0].local_ref, Some(0));
+    }
+
+    #[test]
+    fn prefix_deletion_respects_call_order_and_snapshot_is_explicitly_committed() {
+        let before = Snapshot {
+            state: BTreeMap::from([
+                (b"index/old".to_vec(), b"old".to_vec()),
+                (b"index-other/keep".to_vec(), b"keep".to_vec()),
+            ]),
+            ..Snapshot::default()
+        };
+        let host = RecordingHost::new(&before, 1024 * 1024);
+        let output = TransitionOutput::new(&host).unwrap();
+        output.put_state(b"index/staged", b"staged").unwrap();
+        output.delete_state_prefix(b"index/").unwrap();
+        output.put_state(b"index/new", b"new").unwrap();
+        let transition = host.finish(before.clone()).unwrap();
+        assert_eq!(before.state.len(), 2);
+        let committed = transition.into_snapshot();
+        assert_eq!(
+            committed.state,
+            BTreeMap::from([
+                (b"index/new".to_vec(), b"new".to_vec()),
+                (b"index-other/keep".to_vec(), b"keep".to_vec()),
+            ])
+        );
+    }
+}

--- a/packages/lix/src/plugin/runtime/arena.rs
+++ b/packages/lix/src/plugin/runtime/arena.rs
@@ -1072,6 +1072,19 @@ impl Transaction {
         self.state_changes.insert(key, None);
     }
 
+    /// Clears accepted and already staged keys with this literal prefix.
+    /// Subsequent puts recreate entries in the same transaction.
+    pub fn delete_state_prefix(&mut self, prefix: &[u8]) {
+        for key in self.base.state.keys().filter(|key| key.starts_with(prefix)) {
+            self.state_changes.insert(key.to_vec(), None);
+        }
+        for (key, value) in &mut self.state_changes {
+            if key.starts_with(prefix) {
+                *value = None;
+            }
+        }
+    }
+
     pub fn upgrade_to(&mut self, generation: impl Into<Arc<str>>) {
         self.generation = Some(generation.into());
     }
@@ -1168,6 +1181,35 @@ mod tests {
             [(b"index/0".to_vec(), b"row/1".to_vec())],
         );
         (store, root)
+    }
+
+    #[test]
+    fn prefix_deletion_obeys_write_order_and_preserves_the_base() {
+        let (_, root) = fixture();
+        let mut transaction = root.transaction();
+        transaction.put_state(b"index/new".to_vec(), b"pending".to_vec());
+        transaction.put_state(b"index-other/0".to_vec(), b"untouched".to_vec());
+        transaction.delete_state_prefix(b"index/");
+        transaction.put_state(b"index/replacement".to_vec(), b"new".to_vec());
+        let successor = transaction.commit().unwrap();
+        assert!(successor.state.get(b"index/0").unwrap().is_none());
+        assert!(successor.state.get(b"index/new").unwrap().is_none());
+        assert_eq!(
+            successor.state.get(b"index/replacement").unwrap(),
+            Some(b"new".to_vec())
+        );
+        assert_eq!(
+            successor.state.get(b"index-other/0").unwrap(),
+            Some(b"untouched".to_vec())
+        );
+        assert_eq!(root.state.get(b"index/0").unwrap(), Some(b"row/1".to_vec()));
+        let mut discarded = successor.transaction();
+        discarded.delete_state_prefix(b"index/");
+        drop(discarded);
+        assert_eq!(
+            successor.state.get(b"index/replacement").unwrap(),
+            Some(b"new".to_vec())
+        );
     }
 
     #[test]

--- a/packages/lix/src/plugin/runtime/default/component_runtime.rs
+++ b/packages/lix/src/plugin/runtime/default/component_runtime.rs
@@ -1024,6 +1024,31 @@ impl bindings::lix::plugin::host::HostTransition for WasiHostState {
         Ok(())
     }
 
+    fn delete_state_prefix(
+        &mut self,
+        resource: Resource<TransitionResource>,
+        prefix: Vec<u8>,
+    ) -> Result<(), bindings::lix::plugin::host::HostError> {
+        const RESERVED: &[u8] = b"\0lix/";
+        if prefix.is_empty() || prefix.starts_with(RESERVED) || RESERVED.starts_with(&prefix) {
+            return Err(bindings::lix::plugin::host::HostError::Rejected(
+                "state prefix must be nonempty and outside host-reserved state".to_owned(),
+            ));
+        }
+        let resource = self.table.get_mut(&resource).map_err(host_table_error)?;
+        {
+            let mut state = resource
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.charge_page(prefix.len())?;
+            state.counters.component_import_calls =
+                state.counters.component_import_calls.saturating_add(1);
+        }
+        resource.transaction.delete_state_prefix(&prefix);
+        Ok(())
+    }
+
     fn emit_rows(
         &mut self,
         resource: Resource<TransitionResource>,

--- a/packages/lix/wit/lix-plugin.wit
+++ b/packages/lix/wit/lix-plugin.wit
@@ -49,6 +49,9 @@ interface host {
     max-batch-bytes: func() -> u32;
     put-state: func(key: bytes, value: bytes) -> result<_, host-error>;
     delete-state: func(key: bytes) -> result<_, host-error>;
+    /// Delete matching accepted and pending private state. Later writes survive.
+    /// Empty prefixes and prefixes overlapping host-reserved state are rejected.
+    delete-state-prefix: func(prefix: bytes) -> result<_, host-error>;
     emit-rows: func(page: row-page) -> result<_, host-error>;
     replace-all-rows: func() -> result<_, host-error>;
     emit-file-edit: func(edit: file-edit) -> result<_, host-error>;

--- a/plugins/csv/src/lib.rs
+++ b/plugins/csv/src/lib.rs
@@ -3,6 +3,8 @@
 
 mod core;
 
+use lix::plugin::StateOutput;
+
 use core::{
     ArenaRowIndex, ChangeEffect, ColdInitialImport, Dialect, Document, FileEdit, IdNamespace,
     ROW_SCHEMA_KEY, RowChange, RowIdentity, RowRecord, TABLE_SCHEMA_KEY, Terminator,
@@ -83,10 +85,10 @@ fn cold_parse_changes(
     if let Some((namespace, state)) = successor.canonical_arena_state() {
         sink.put_state(ID_NAMESPACE_STATE, &namespace)?;
         store_csv_index(sink, &state)?;
-        delete_identity_checkpoint(&update.before, sink)?;
+        delete_identity_checkpoint(sink)?;
     } else {
-        delete_csv_index(&update.before, sink)?;
-        store_identity_checkpoint(Some(&update.before), sink, &successor)?;
+        delete_csv_index(sink)?;
+        store_identity_checkpoint(sink, &successor)?;
     }
     for change in changes {
         emit_change(change, update.creates, sink)?;
@@ -122,8 +124,8 @@ impl sdk::FileProjection for CsvPlugin {
         for edit in edits {
             sink.replace(edit.offset, edit.delete_len, &edit.insert)?;
         }
-        store_identity_checkpoint(Some(&update.before), sink, &successor)?;
-        delete_csv_index(&update.before, sink)?;
+        store_identity_checkpoint(sink, &successor)?;
+        delete_csv_index(sink)?;
         Ok(())
     }
 
@@ -143,14 +145,14 @@ impl sdk::FileProjection for CsvPlugin {
         if let Some((namespace, state)) = document.canonical_arena_state() {
             sink.put_state(ID_NAMESPACE_STATE, &namespace)?;
             store_csv_index(sink, &state)?;
-            if let Some(before) = input.before.as_ref() {
-                delete_identity_checkpoint(before, sink)?;
+            if input.before.is_some() {
+                delete_identity_checkpoint(sink)?;
             }
         } else {
-            if let Some(before) = input.before.as_ref() {
-                delete_csv_index(before, sink)?;
+            if input.before.is_some() {
+                delete_csv_index(sink)?;
             }
-            store_identity_checkpoint(input.before.as_ref(), sink, &document)?;
+            store_identity_checkpoint(sink, &document)?;
         }
         sink.write(&document.bytes())
     }
@@ -257,19 +259,20 @@ impl sdk::FileProjection for CsvPlugin {
         if delete_end > row_end {
             return fallback_file_changed(update, sink);
         }
-        let mut row = update.before.read_range(row_start, row_end - row_start)?;
-        let local_start = usize::try_from(edit.offset - row_start)
-            .map_err(|_| sdk::Error::invalid_input("CSV edit offset exceeds guest memory"))?;
-        let local_end =
-            local_start
-                .checked_add(usize::try_from(edit.delete_len).map_err(|_| {
-                    sdk::Error::invalid_input("CSV edit deletion exceeds guest memory")
-                })?)
-                .ok_or_else(|| sdk::Error::invalid_input("CSV edit range overflowed"))?;
-        if index.edit_touches_structure(&row[local_start..local_end], insert) {
+        let deleted = update.before.read_range(edit.offset, edit.delete_len)?;
+        if index.edit_touches_structure(&deleted, insert) {
             return fallback_file_changed(update, sink);
         }
-        row.splice(local_start..local_end, insert.iter().copied());
+        let edits = update.file_edits.validated(update.before.len())?;
+        // Equal-length edits can create a BOM, including by changing only
+        // the final byte of another leading UTF-8 character.
+        if edit.offset < 3
+            && edits.len() >= 3
+            && edits.read_range(&update.before, 0, 3)? == b"\xef\xbb\xbf"
+        {
+            return fallback_file_changed(update, sink);
+        }
+        let row = edits.read_range(&update.before, row_start, row_end - row_start)?;
         let change = index
             .row_change(ordinal, row)
             .map_err(sdk::Error::invalid_input)?;
@@ -367,6 +370,7 @@ fn merge_typed_csv_cells(
 
 fn store_csv_index(successor: &mut impl StateOutput, state: &[u8]) -> sdk::Result<()> {
     let (header, pages) = split_csv_index(state)?;
+    successor.delete_state_prefix(b"csv/index-page/")?;
     successor.put_state(CSV_INDEX_KEY, header)?;
     for (ordinal, page) in pages.into_iter().enumerate() {
         successor.put_state(&csv_index_page_key(ordinal as u32), page)?;
@@ -396,34 +400,9 @@ fn decode_csv_index_header(header: &[u8]) -> sdk::Result<ArenaRowIndex> {
     ArenaRowIndex::decode_header(header, logical_state_len).map_err(sdk::Error::invalid_input)
 }
 
-fn csv_index_page_count(root: &sdk::Snapshot<'_>) -> sdk::Result<u32> {
-    let Some(header) = root.read_state_range(CSV_INDEX_KEY, 0, CSV_INDEX_HEADER_BYTES)? else {
-        return Ok(0);
-    };
-    if header.len() != CSV_INDEX_HEADER_BYTES as usize {
-        return Err(sdk::Error::invalid_input(
-            "CSV row index header is truncated",
-        ));
-    }
-    let row_count = u32::from_le_bytes(header[32..36].try_into().expect("CSV row count"));
-    let offsets_bytes = usize::try_from(row_count)
-        .expect("u32 fits usize")
-        .checked_mul(4)
-        .ok_or_else(|| sdk::Error::invalid_input("CSV row index size overflowed"))?;
-    Ok(u32::try_from(offsets_bytes.div_ceil(CSV_INDEX_PAGE_BYTES))
-        .map_err(|_| sdk::Error::limit_exceeded("too many CSV row index pages"))?)
-}
-
-fn delete_csv_index(
-    before: &sdk::Snapshot<'_>,
-    successor: &mut impl StateOutput,
-) -> sdk::Result<()> {
-    let page_count = csv_index_page_count(before)?;
+fn delete_csv_index(successor: &mut impl StateOutput) -> sdk::Result<()> {
     successor.delete_state(CSV_INDEX_KEY)?;
-    for ordinal in 0..page_count {
-        successor.delete_state(&csv_index_page_key(ordinal))?;
-    }
-    Ok(())
+    successor.delete_state_prefix(b"csv/index-page/")
 }
 
 fn csv_index_page_key(ordinal: u32) -> Vec<u8> {
@@ -438,31 +417,13 @@ fn identity_page_key(ordinal: u32) -> Vec<u8> {
     key
 }
 
-fn identity_page_count(before: &sdk::Snapshot<'_>) -> sdk::Result<u32> {
-    let Some(manifest) = before.get_state(CSV_IDENTITIES_KEY)? else {
-        return Ok(0);
-    };
-    decode_identity_manifest(&manifest).map(|(_, page_count, _)| page_count)
-}
-
-fn delete_identity_checkpoint(
-    before: &sdk::Snapshot<'_>,
-    sink: &mut impl StateOutput,
-) -> sdk::Result<()> {
-    let page_count = identity_page_count(before)?;
+fn delete_identity_checkpoint(sink: &mut impl StateOutput) -> sdk::Result<()> {
     sink.delete_state(CSV_IDENTITIES_KEY)?;
-    for ordinal in 0..page_count {
-        sink.delete_state(&identity_page_key(ordinal))?;
-    }
-    Ok(())
+    sink.delete_state_prefix(b"csv/identity-page/")
 }
 
-fn store_identity_checkpoint(
-    before: Option<&sdk::Snapshot<'_>>,
-    sink: &mut impl StateOutput,
-    document: &Document,
-) -> sdk::Result<()> {
-    let old_page_count = before.map(identity_page_count).transpose()?.unwrap_or(0);
+fn store_identity_checkpoint(sink: &mut impl StateOutput, document: &Document) -> sdk::Result<()> {
+    sink.delete_state_prefix(b"csv/identity-page/")?;
     let (dialect, identities) = document.identity_checkpoint();
     let mut payload = Vec::new();
     for identity in &identities {
@@ -500,9 +461,6 @@ fn store_identity_checkpoint(
     sink.put_state(CSV_IDENTITIES_KEY, &manifest)?;
     for (ordinal, page) in pages.iter().enumerate() {
         sink.put_state(&identity_page_key(ordinal as u32), page)?;
-    }
-    for ordinal in pages.len() as u32..old_page_count {
-        sink.delete_state(&identity_page_key(ordinal))?;
     }
     Ok(())
 }
@@ -643,10 +601,10 @@ fn fallback_file_changed(
     if let Some((namespace, state)) = successor.canonical_arena_state() {
         sink.put_state(ID_NAMESPACE_STATE, &namespace)?;
         store_csv_index(sink, &state)?;
-        delete_identity_checkpoint(&update.before, sink)?;
+        delete_identity_checkpoint(sink)?;
     } else {
-        delete_csv_index(&update.before, sink)?;
-        store_identity_checkpoint(Some(&update.before), sink, &successor)?;
+        delete_csv_index(sink)?;
+        store_identity_checkpoint(sink, &successor)?;
     }
     for change in changes {
         emit_change(change, update.creates, sink)?;
@@ -688,24 +646,6 @@ fn namespace_from_changes(changes: &[RowChange]) -> Option<IdNamespace> {
         })
 }
 
-fn apply_edits(mut bytes: Vec<u8>, edits: &[core::ByteEdit]) -> sdk::Result<Vec<u8>> {
-    for edit in edits.iter().rev() {
-        let start = usize::try_from(edit.offset)
-            .map_err(|_| sdk::Error::invalid_input("CSV edit offset exceeds guest memory"))?;
-        let end =
-            start
-                .checked_add(usize::try_from(edit.delete_len).map_err(|_| {
-                    sdk::Error::invalid_input("CSV edit deletion exceeds guest memory")
-                })?)
-                .ok_or_else(|| sdk::Error::invalid_input("CSV edit range overflowed"))?;
-        if end > bytes.len() {
-            return Err(sdk::Error::invalid_input("CSV edit exceeds accepted bytes"));
-        }
-        bytes.splice(start..end, edit.insert.iter().copied());
-    }
-    Ok(bytes)
-}
-
 fn emit_change(
     change: RowChange,
     creates: sdk::CreateContext,
@@ -743,27 +683,6 @@ fn emit_change(
     }
     Ok(())
 }
-
-trait StateOutput {
-    fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()>;
-    fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()>;
-}
-macro_rules! impl_state_output {
-    ($type:ty) => {
-        impl StateOutput for $type {
-            fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()> {
-                <$type>::put_state(self, key, value)
-            }
-            fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()> {
-                <$type>::delete_state(self, key)
-            }
-        }
-    };
-}
-impl_state_output!(sdk::RowOutput<'_, '_>);
-impl_state_output!(sdk::RowChangeOutput<'_, '_>);
-impl_state_output!(sdk::FileOutput<'_, '_>);
-impl_state_output!(sdk::FileEditOutput<'_, '_>);
 
 trait MutationOutput {
     fn create(&mut self, schema_key: &str, local_ref: u32, row: &sdk::TypedRow) -> sdk::Result<()>;
@@ -945,6 +864,98 @@ mod tests {
 mod adapter_qa_tests {
     use super::*;
 
+    #[test]
+    fn equal_length_prefix_edits_detect_new_bom_in_native_adapter() {
+        let harness = sdk::testing::Harness::<CsvPlugin>::default();
+        let creates = sdk::CreateContext::from_namespace_bytes([0x51; 12]);
+        for (bytes, edit) in [
+            (
+                b"abc,x\n".as_slice(),
+                sdk::FileEdit {
+                    offset: 0,
+                    delete_len: 3,
+                    insert: b"\xef\xbb\xbf".to_vec(),
+                },
+            ),
+            (
+                "\u{fefe},x\n".as_bytes(),
+                sdk::FileEdit {
+                    offset: 2,
+                    delete_len: 1,
+                    insert: vec![0xbf],
+                },
+            ),
+        ] {
+            let file = sdk::testing::Snapshot {
+                file_id: "bom-prefix".to_owned(),
+                path: "data.csv".to_owned(),
+                bytes: bytes.to_vec(),
+                ..sdk::testing::Snapshot::default()
+            };
+            let file = harness.parse(&file, creates).unwrap().into_snapshot();
+            let namespace = IdNamespace::from_namespace_bytes(creates.namespace_bytes());
+            let before = Document::open_file(bytes.to_vec(), None, namespace)
+                .unwrap()
+                .0;
+            let next_creates = sdk::CreateContext::from_namespace_bytes([0x52; 12]);
+            let changed = harness
+                .parse_changes(&file, &file.path, &[edit], None, next_creates)
+                .unwrap();
+            assert_eq!(changed.snapshot().bytes, b"\xef\xbb\xbf,x\n");
+            let changes = changed
+                .row_changes
+                .iter()
+                .map(|change| {
+                    let mut row = change.row.clone();
+                    let row_pk = change.local_ref.map_or_else(
+                        || change.primary_key.clone(),
+                        |local| {
+                            let id = sdk::TypedValue::Uuid(next_creates.id(local));
+                            row.as_mut().unwrap().insert("id", id.clone());
+                            vec![id]
+                        },
+                    );
+                    RowChange {
+                        schema_key: change.schema_key.clone(),
+                        row_pk,
+                        row,
+                        effect: ChangeEffect::Content,
+                    }
+                })
+                .collect::<Vec<_>>();
+            let mut records = before.row_records().unwrap();
+            for change in changes {
+                records.retain(|record| {
+                    record.schema_key != change.schema_key || record.row_pk != change.row_pk
+                });
+                if let Some(row) = change.row {
+                    records.push(RowRecord {
+                        schema_key: change.schema_key,
+                        row_pk: change.row_pk,
+                        row,
+                    });
+                }
+            }
+            let actual = Document::open_rows(records).unwrap().0;
+            let expected = Document::open_file(changed.snapshot().bytes.clone(), None, namespace)
+                .unwrap()
+                .0;
+            assert_eq!(actual.dialect(), expected.dialect());
+            assert_eq!(actual.bytes(), expected.bytes());
+            let cells = |document: &Document| {
+                document
+                    .row_records()
+                    .unwrap()
+                    .into_iter()
+                    .skip(1)
+                    .map(|record| core::parse_csv_row(&record.row).unwrap().cells)
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(cells(&actual), cells(&expected));
+            assert_eq!(cells(&actual), vec![vec![String::new(), "x".to_owned()]]);
+        }
+    }
+
     #[derive(Default)]
     struct MemoryState(std::collections::BTreeMap<Vec<u8>, Vec<u8>>);
     impl StateOutput for MemoryState {
@@ -954,6 +965,10 @@ mod adapter_qa_tests {
         }
         fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()> {
             self.0.remove(key);
+            Ok(())
+        }
+        fn delete_state_prefix(&mut self, prefix: &[u8]) -> sdk::Result<()> {
+            self.0.retain(|key, _| !key.starts_with(prefix));
             Ok(())
         }
     }
@@ -1247,7 +1262,7 @@ mod adapter_qa_tests {
         let row_count = CSV_IDENTITY_PAGE_BYTES / 36 + 3;
         let (document, _) = Document::open_file(b"x\n".repeat(row_count), None, namespace).unwrap();
         let mut stored = MemoryState::default();
-        store_identity_checkpoint(None, &mut stored, &document).unwrap();
+        store_identity_checkpoint(&mut stored, &document).unwrap();
         let (stored_count, page_count, dialect) =
             decode_identity_manifest(stored.0.get(CSV_IDENTITIES_KEY).unwrap()).unwrap();
         assert_eq!(stored_count as usize, row_count);
@@ -1283,7 +1298,7 @@ mod adapter_qa_tests {
             let (document, _) = Document::open_file(bytes.clone(), None, namespace).unwrap();
             assert!(document.dialect().bom);
             let mut stored = MemoryState::default();
-            store_identity_checkpoint(None, &mut stored, &document).unwrap();
+            store_identity_checkpoint(&mut stored, &document).unwrap();
             let (_, _, dialect) =
                 decode_identity_manifest(stored.0.get(CSV_IDENTITIES_KEY).unwrap()).unwrap();
             assert!(dialect.bom);

--- a/plugins/markdown/src/adapter_qa_tests.rs
+++ b/plugins/markdown/src/adapter_qa_tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+use sdk::testing::{Harness, Snapshot};
+
+fn accept_rows(
+    rows: &mut Vec<sdk::TypedRowRecord>,
+    changes: &[sdk::TypedRowChange],
+    creates: sdk::CreateContext,
+) {
+    for change in changes {
+        let primary_key = change.local_ref.map_or_else(
+            || change.primary_key.clone(),
+            |local| vec![sdk::TypedValue::Uuid(creates.id(local))],
+        );
+        rows.retain(|row| row.schema_key != change.schema_key || row.primary_key != primary_key);
+        if let Some(mut row) = change.row.clone() {
+            if change.local_ref.is_some() {
+                row.insert("id".to_owned(), primary_key[0].clone());
+            }
+            rows.push(sdk::TypedRowRecord {
+                schema_key: change.schema_key.clone(),
+                schema_fingerprint: change.schema_fingerprint,
+                primary_key,
+                row,
+            });
+        }
+    }
+}
+
+#[test]
+fn native_adapter_exercises_all_hooks_and_cold_reopen_without_stale_overlays() {
+    let harness = Harness::<MarkdownPlugin>::default();
+    let creates = sdk::CreateContext::from_namespace_bytes([9; 12]);
+    let mut file = Snapshot {
+        file_id: "native-markdown".to_owned(),
+        path: "doc.md".to_owned(),
+        bytes: b"Alpha\n\nBravo\n".to_vec(),
+        ..Snapshot::default()
+    };
+    let parsed = harness.parse(&file, creates).unwrap();
+    let mut rows = Vec::new();
+    accept_rows(&mut rows, &parsed.row_changes, creates);
+    file = parsed.into_snapshot();
+    let rendered = harness
+        .serialize(&file.file_id, &file.path, &rows, None)
+        .unwrap();
+    assert_eq!(rendered.snapshot().bytes, file.bytes);
+    file = rendered.into_snapshot();
+
+    let creates = sdk::CreateContext::from_namespace_bytes([10; 12]);
+    let changed = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 0,
+                delete_len: 5,
+                insert: b"Omega".to_vec(),
+            }],
+            None,
+            creates,
+        )
+        .unwrap();
+    accept_rows(&mut rows, &changed.row_changes, creates);
+    file = changed.into_snapshot();
+    assert_eq!(file.bytes, b"Omega\n\nBravo\n");
+    assert!(
+        file.state.contains_key(&block_overlay_key(0)),
+        "fixture must use sparse adapter path"
+    );
+    let orphan_overlay = b"markdown/block-overlay/orphan".to_vec();
+    file.state
+        .insert(orphan_overlay.clone(), b"obsolete".to_vec());
+
+    let target = rows.iter().find(|row| {
+        row.row.get("payload_json").is_some_and(|value| {
+            matches!(value, sdk::TypedValue::Jsonb(payload) if serde_json::to_string(payload).unwrap().contains("Omega"))
+        })
+    }).unwrap();
+    let mut row = target.row.clone();
+    let Some(sdk::TypedValue::Jsonb(payload)) = row.get("payload_json") else {
+        unreachable!()
+    };
+    let payload: Value = serde_json::from_str(
+        &serde_json::to_string(payload)
+            .unwrap()
+            .replace("Omega", "Delta"),
+    )
+    .unwrap();
+    row.insert(
+        "payload_json".to_owned(),
+        sdk::TypedValue::Jsonb(payload.into()),
+    );
+    let row_edit = sdk::TypedRowChange {
+        schema_key: target.schema_key.clone(),
+        schema_fingerprint: target.schema_fingerprint,
+        primary_key: target.primary_key.clone(),
+        row: Some(row),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    };
+    let changed = harness
+        .serialize_changes(&file, std::slice::from_ref(&row_edit))
+        .unwrap();
+    assert_eq!(changed.snapshot().bytes, b"Delta\n\nBravo\n");
+    assert!(!changed.snapshot().state.contains_key(&orphan_overlay));
+    accept_rows(&mut rows, &[row_edit], creates);
+    file = changed.into_snapshot();
+
+    let unchanged = harness.serialize_changes(&file, &[]).unwrap();
+    assert_eq!(unchanged.snapshot().bytes, b"Delta\n\nBravo\n");
+    file = unchanged.into_snapshot();
+    file.state.clear();
+    let creates = sdk::CreateContext::from_namespace_bytes([11; 12]);
+    let identities_before = rows
+        .iter()
+        .map(|row| {
+            let [sdk::TypedValue::Uuid(id)] = row.primary_key.as_slice() else {
+                unreachable!()
+            };
+            *id
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    let reopened = harness
+        .parse_changes(
+            &file,
+            "renamed.md",
+            &[sdk::FileEdit {
+                offset: 7,
+                delete_len: 5,
+                insert: b"Charlie".to_vec(),
+            }],
+            Some(&rows),
+            creates,
+        )
+        .unwrap();
+    assert_eq!(reopened.snapshot().bytes, b"Delta\n\nCharlie\n");
+    assert_eq!(reopened.snapshot().path, "renamed.md");
+    assert!(!reopened.snapshot().state.is_empty());
+    accept_rows(&mut rows, &reopened.row_changes, creates);
+    let identities_after = rows
+        .iter()
+        .map(|row| {
+            let [sdk::TypedValue::Uuid(id)] = row.primary_key.as_slice() else {
+                unreachable!()
+            };
+            *id
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(identities_before, identities_after);
+    file = reopened.into_snapshot();
+    let roundtrip = harness
+        .serialize(&file.file_id, &file.path, &rows, Some(&file))
+        .unwrap();
+    assert_eq!(roundtrip.snapshot().bytes, file.bytes);
+}

--- a/plugins/markdown/src/lib.rs
+++ b/plugins/markdown/src/lib.rs
@@ -1,6 +1,8 @@
 //! Markdown support for the row-first Component API v2.
 #![allow(dead_code)]
 
+use lix::plugin::StateOutput;
+
 extern crate alloc;
 
 mod core;
@@ -111,7 +113,7 @@ impl sdk::FileProjection for MarkdownPlugin {
         for edit in edits {
             sink.replace(edit.offset, edit.delete_len, &edit.insert)?;
         }
-        store_rendered_markdown_state(&update.before, sink, &successor)?;
+        store_markdown_state(sink, &successor)?;
         Ok(())
     }
 
@@ -189,29 +191,7 @@ impl sdk::FileProjection for MarkdownPlugin {
             .file_changed(&splices, namespace)
             .map_err(core_error)?;
         strip_duplicated_lexical_fallback(&mut changes)?;
-        let (root, blocks) = document.arena_state().map_err(core_error)?;
-        sink.put_state(ROOT_STATE, &root)?;
-        let (old_index_pages, old_block_pages) = block_page_counts(&update.before)?;
-        let encoded = encode_blocks(&blocks)?;
-        sink.put_state(BLOCKS_STATE, &encoded.manifest)?;
-        for (ordinal, page) in encoded.index_pages.iter().enumerate() {
-            sink.put_state(&block_index_page_key(ordinal as u32), page)?;
-        }
-        for ordinal in encoded.index_pages.len() as u32..old_index_pages {
-            sink.delete_state(&block_index_page_key(ordinal))?;
-        }
-        for (ordinal, page) in encoded.block_pages.iter().enumerate() {
-            sink.put_state(&block_page_key(ordinal as u32), page)?;
-        }
-        for ordinal in encoded.block_pages.len() as u32..old_block_pages {
-            sink.delete_state(&block_page_key(ordinal))?;
-        }
-        if let Some(shifts) = update.before.get_state(BLOCK_SHIFTS_STATE)? {
-            for (ordinal, _) in decode_block_shifts(&shifts)? {
-                sink.delete_state(&block_overlay_key(ordinal))?;
-            }
-        }
-        sink.delete_state(BLOCK_SHIFTS_STATE)?;
+        store_markdown_state(sink, &document)?;
         emit_changes(changes, update.creates, Some(0), sink)?;
         Ok(())
     }
@@ -247,67 +227,21 @@ impl sdk::ColumnMerger for MarkdownPlugin {
     }
 }
 
-fn store_rendered_markdown_state(
-    before: &sdk::Snapshot<'_>,
-    sink: &mut impl StateOutput,
-    document: &Document,
-) -> sdk::Result<()> {
+fn store_markdown_state(sink: &mut impl StateOutput, document: &Document) -> sdk::Result<()> {
     let (root, blocks) = document.arena_state().map_err(core_error)?;
     sink.put_state(ROOT_STATE, &root)?;
-    let (old_index_pages, old_block_pages) = block_page_counts(before)?;
+    sink.delete_state_prefix(b"markdown/block-index-page/")?;
+    sink.delete_state_prefix(b"markdown/block-page/")?;
     let encoded = encode_blocks(&blocks)?;
     sink.put_state(BLOCKS_STATE, &encoded.manifest)?;
     for (ordinal, page) in encoded.index_pages.iter().enumerate() {
         sink.put_state(&block_index_page_key(ordinal as u32), page)?;
     }
-    for ordinal in encoded.index_pages.len() as u32..old_index_pages {
-        sink.delete_state(&block_index_page_key(ordinal))?;
-    }
     for (ordinal, page) in encoded.block_pages.iter().enumerate() {
         sink.put_state(&block_page_key(ordinal as u32), page)?;
     }
-    for ordinal in encoded.block_pages.len() as u32..old_block_pages {
-        sink.delete_state(&block_page_key(ordinal))?;
-    }
-    if let Some(shifts) = before.get_state(BLOCK_SHIFTS_STATE)? {
-        for (ordinal, _) in decode_block_shifts(&shifts)? {
-            sink.delete_state(&block_overlay_key(ordinal))?;
-        }
-    }
+    sink.delete_state_prefix(b"markdown/block-overlay/")?;
     sink.delete_state(BLOCK_SHIFTS_STATE)?;
-    Ok(())
-}
-
-fn apply_edits(mut bytes: Vec<u8>, edits: &[core::ByteEdit]) -> sdk::Result<Vec<u8>> {
-    for edit in edits.iter().rev() {
-        let start = usize::try_from(edit.offset)
-            .map_err(|_| sdk::Error::invalid_input("Markdown edit offset exceeds guest memory"))?;
-        let end = start
-            .checked_add(usize::try_from(edit.delete_len).map_err(|_| {
-                sdk::Error::invalid_input("Markdown edit deletion exceeds guest memory")
-            })?)
-            .ok_or_else(|| sdk::Error::invalid_input("Markdown edit range overflowed"))?;
-        if end > bytes.len() {
-            return Err(sdk::Error::invalid_input(
-                "Markdown edit exceeds accepted bytes",
-            ));
-        }
-        bytes.splice(start..end, edit.insert.iter().copied());
-    }
-    Ok(bytes)
-}
-
-fn store_markdown_state(successor: &mut impl StateOutput, document: &Document) -> sdk::Result<()> {
-    let (root, blocks) = document.arena_state().map_err(core_error)?;
-    successor.put_state(ROOT_STATE, &root)?;
-    let encoded = encode_blocks(&blocks)?;
-    successor.put_state(BLOCKS_STATE, &encoded.manifest)?;
-    for (ordinal, page) in encoded.index_pages.iter().enumerate() {
-        successor.put_state(&block_index_page_key(ordinal as u32), page)?;
-    }
-    for (ordinal, page) in encoded.block_pages.iter().enumerate() {
-        successor.put_state(&block_page_key(ordinal as u32), page)?;
-    }
     Ok(())
 }
 
@@ -621,21 +555,6 @@ fn block_index_page_key(ordinal: u32) -> Vec<u8> {
     key
 }
 
-fn block_page_counts(root: &sdk::Snapshot<'_>) -> sdk::Result<(u32, u32)> {
-    let Some(header) = root.read_state_range(BLOCKS_STATE, 0, BLOCK_INDEX_HEADER_BYTES)? else {
-        return Ok((0, 0));
-    };
-    if header.get(..4) != Some(BLOCK_INDEX_MAGIC) {
-        return Err(sdk::Error::invalid_input(
-            "unsupported Markdown block index",
-        ));
-    }
-    Ok((
-        u32::from_le_bytes(header[12..16].try_into().expect("fixed Markdown header")),
-        u32::from_le_bytes(header[8..12].try_into().expect("fixed Markdown header")),
-    ))
-}
-
 fn effective_block_position(base: u64, ordinal: u32, shifts: &[(u32, i64)]) -> sdk::Result<u64> {
     let delta = shifts
         .iter()
@@ -783,27 +702,6 @@ fn emit_changes(
     }
     Ok(())
 }
-
-trait StateOutput {
-    fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()>;
-    fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()>;
-}
-macro_rules! impl_state_output {
-    ($type:ty) => {
-        impl StateOutput for $type {
-            fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()> {
-                <$type>::put_state(self, key, value)
-            }
-            fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()> {
-                <$type>::delete_state(self, key)
-            }
-        }
-    };
-}
-impl_state_output!(sdk::RowOutput<'_, '_>);
-impl_state_output!(sdk::RowChangeOutput<'_, '_>);
-impl_state_output!(sdk::FileOutput<'_, '_>);
-impl_state_output!(sdk::FileEditOutput<'_, '_>);
 
 trait MutationOutput {
     fn create(&mut self, schema_key: &str, local_ref: u32, row: &sdk::TypedRow) -> sdk::Result<()>;
@@ -1070,3 +968,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod adapter_qa_tests;

--- a/rfcs/universal-plugin-api.md
+++ b/rfcs/universal-plugin-api.md
@@ -30,6 +30,11 @@ pub trait ColumnMerger: 'static {
 Files are only a projection of rows. A file format additionally implements all
 four directions so incremental behavior is explicit at compile time:
 
+The SDK also provides a native projection test harness, validated `EditSet`
+range reads, and a shared `StateOutput` with transactional prefix deletion.
+See [Testing and maintaining file plugins](../docs/plugin-testing.md) for their
+contracts and lossless-editing checks.
+
 ```rust
 pub trait FileProjection: 'static {
     fn parse(input: ParseInput<'_>, output: &mut RowOutput<'_, '_>) -> Result<()>;


### PR DESCRIPTION
Plugin authors currently duplicate file-edit validation and private-state cleanup, and lifecycle tests require compiling components. This adds `EditSet`, shared `StateOutput` operations, and a native `Harness<F>` covering all four projection hooks with atomic staged transitions.

Markdown and CSV adopt the helpers. CSV also preserves cells when an edit introduces a BOM. Documentation shows sparse edits, generated identities, cold hydration, and rollback testing.

The WIT host contract gains `delete-state-prefix`; plugin components must be rebuilt against the updated SDK/runtime.

Validation:
- 3,527 engine tests passed with `cargo nextest run -p lix --features all-simulations` (76 skipped).
- 10 SDK doctests passed with `cargo test -p lix --doc`.
- 221 Markdown and CSV tests passed, including native lifecycle regressions (1 ignored).

The dependent JSON/Excalidraw PR exercises the harness beyond Markdown and CSV.

