### PR TITLE
Support structural JSON edits and preserve JSON/Excalidraw source

### DIFF
--- a/.changenotes/json-excalidraw-roundtrip-preservation.md
+++ b/.changenotes/json-excalidraw-roundtrip-preservation.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Improved JSON and Excalidraw data and formatting preservation when alternating file and row edits.
+
+JSON retains number spelling and string escapes when rebuilding files from rows, and inserted array items remain writable after later insertions. Excalidraw preserves unchanged element and embedded-file formatting, including unknown fields. Rebuilt plugin indexes discard stale offsets so subsequent edits address the correct bytes.

--- a/.changenotes/json-structural-row-edits.md
+++ b/.changenotes/json-structural-row-edits.md
@@ -1,0 +1,9 @@
+---
+type: minor
+---
+
+Support structural JSON row edits, including insertion, deletion, reordering, moves, and scalar/container conversion. Structural batches validate and rebuild the final tree, preserve row identities and unchanged scalar spelling, and stream the replacement file. Existing scalar updates retain their byte-splice fast path.
+
+Container deletion requires removing or moving descendants in the same plugin row batch; invalid trees reject atomically. SQL projects each statement separately. Structural upserts follow normal row last-write-wins behavior, including recreating a previously deleted key.
+
+Repeated row updates honor the final update even when it restores the original value. Renames adapt existing key-formatting hints, and scalar conversions ignore obsolete empty-container whitespace. File-derived row deltas use deterministic key order so stale edits across multiple parents can compose reliably.

--- a/docs/plugin-testing.md
+++ b/docs/plugin-testing.md
@@ -110,6 +110,24 @@ into complete durable rows. Use a new deterministic create namespace for each
 transition. See the Markdown plugin's `src/adapter_qa_tests.rs` for a complete
 parse, sparse-edit, row-edit, and cold-reopen lifecycle.
 
+Additional examples live in `plugins/json/src/adapter_qa_tests.rs` and
+`plugins/excalidraw/src/qa_tests.rs`. They exercise composite and native primary
+keys, repeated edits, exact scalar/object spelling, and embedded files. JSON's
+row-edit contract supports scalar updates, insertion, deletion, reordering, moves,
+and scalar/container conversion. Scalar updates use small byte splices; structural
+batches rebuild the tree and stream a complete replacement, preserving unchanged
+scalar spelling and row identities. Invalid final trees reject the entire plugin
+call. Deleting a container requires deleting or moving its descendants in the same
+row batch; there is no implicit cascade.
+
+SQL projects each statement separately, including within `execute_batch`. Delete
+a subtree in one `DELETE` statement, and remove children before changing their
+parent's kind. Object keys are primary keys: rename them with a delete and insert.
+Valid existing key-layout hints adapt to the new key while preserving whitespace;
+empty-container whitespace hints are ignored after conversion to a scalar. Structural writes use normal
+row upsert semantics, so a later stale writer can recreate a deleted key. The
+plugin does not provide a separate deletion-wins concurrency policy.
+
 The harness uses a conservative 1 MiB batch limit by default. Set
 `driver.max_batch_bytes = 2 * 1024 * 1024` to match the standard runtime page
 budget when testing large state pages or embedded files. Cold-file admission can

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -8485,3 +8485,47 @@ async fn json_structural_qa_multi_parent_file_updates_are_deterministic() {
     }
     lix.close().await.unwrap();
 }
+#[tokio::test]
+async fn json_decimal_spelling_survives_structural_rebuild_and_reopen() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/decimal-spelling.json";
+    let original = br#"{"one":1.0,"hundred":100.0,"array":[1.0,-0.0],"remove":0}"#;
+    write_file(&lix, path, original.to_vec()).await.unwrap();
+    lix.close().await.unwrap();
+    let reopened = open_rocksdb_lix(root.path()).await;
+    reopened
+        .execute("DELETE FROM json_object_member WHERE key = 'remove'", &[])
+        .await
+        .unwrap();
+    let expected = br#"{"one":1.0,"hundred":100.0,"array":[1.0,-0.0]}"#;
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(expected.to_vec())
+    );
+    reopened.close().await.unwrap();
+    let reopened = open_rocksdb_lix(root.path()).await;
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(expected.to_vec())
+    );
+    reopened
+        .execute(
+            "UPDATE json_object_member SET scalar_json = $1 WHERE key = 'hundred'",
+            &[Value::Jsonb(serde_json::json!(7).into())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(br#"{"one":1.0,"hundred":7,"array":[1.0,-0.0]}"#.to_vec())
+    );
+    reopened.close().await.unwrap();
+}

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -3208,6 +3208,241 @@ async fn v2_csv_rename_and_same_row_edit_fail_without_a_cross_row_conflict_api()
 }
 
 #[tokio::test]
+async fn json_structural_sql_edits_and_root_conversion_survive_reopen() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/structural.json";
+    write_file(&lix, path, br#"{"keep":1.2300e+04,"remove":2}"#.to_vec())
+        .await
+        .unwrap();
+    let file_id = file_id_at_path(&lix, path).await;
+    lix.execute("INSERT INTO json_object_member (parent_id, key, order_key, kind, scalar_json, lixcol_file_id) VALUES ('root', 'new', 'ff', 'number', $1, $2)", &[Value::Jsonb(serde_json::json!(9).into()), Value::Text(file_id.clone())]).await.unwrap();
+    lix.execute(
+        "DELETE FROM json_object_member WHERE key = 'remove' AND lixcol_file_id = $1",
+        &[Value::Text(file_id.clone())],
+    )
+    .await
+    .unwrap();
+    lix.execute_batch(&[
+        ExecuteBatchStatement { label: None, sql: "DELETE FROM json_object_member WHERE key = 'new' AND lixcol_file_id = $1".into(), params: vec![Value::Text(file_id.clone())] },
+        ExecuteBatchStatement { label: None, sql: "INSERT INTO json_object_member (parent_id, key, order_key, kind, scalar_json, lixcol_file_id) VALUES ('root', 'renamed', 'ff', 'number', $1, $2)".into(), params: vec![Value::Jsonb(serde_json::json!(9).into()), Value::Text(file_id.clone())] },
+    ]).await.unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(br#"{"keep":1.2300e+04,"renamed":9}"#.to_vec())
+    );
+    lix.execute_batch(&[
+        ExecuteBatchStatement {
+            label: None,
+            sql: "DELETE FROM json_object_member WHERE lixcol_file_id = $1".into(),
+            params: vec![Value::Text(file_id.clone())],
+        },
+        ExecuteBatchStatement {
+            label: None,
+            sql: "UPDATE json_root SET kind = 'array' WHERE lixcol_file_id = $1".into(),
+            params: vec![Value::Text(file_id.clone())],
+        },
+    ])
+    .await
+    .expect("SQL projects each statement, so remove children before converting the root");
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(b"[]".to_vec()));
+    let inserted = lix.execute("INSERT INTO json_array_item (parent_id, order_key, kind, scalar_json, lixcol_file_id) VALUES ('root', '80', 'number', $1, $2) RETURNING id", &[Value::Jsonb(serde_json::json!(1).into()), Value::Text(file_id.clone())]).await.unwrap();
+    let inserted_id = inserted.rows()[0].get::<Value>("id").unwrap();
+    lix.execute("INSERT INTO json_array_item (parent_id, order_key, kind, scalar_json, lixcol_file_id) VALUES ('root', '40', 'number', $1, $2)", &[Value::Jsonb(serde_json::json!(2).into()), Value::Text(file_id.clone())]).await.unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"[2,1]".to_vec())
+    );
+    lix.execute(
+        "UPDATE json_array_item SET order_key = '20' WHERE id = $1 AND lixcol_file_id = $2",
+        &[inserted_id.clone(), Value::Text(file_id.clone())],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"[1,2]".to_vec())
+    );
+    lix.close().await.unwrap();
+    let reopened = open_rocksdb_lix(root.path()).await;
+    reopened
+        .execute(
+            "UPDATE json_array_item SET scalar_json = $1 WHERE id = $2 AND lixcol_file_id = $3",
+            &[
+                Value::Jsonb(serde_json::json!(100).into()),
+                inserted_id,
+                Value::Text(file_id.clone()),
+            ],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(b"[100,2]".to_vec())
+    );
+    let before = read_file(&reopened, path).await.unwrap();
+    assert!(
+        reopened
+            .execute(
+                "DELETE FROM json_root WHERE lixcol_file_id = $1",
+                &[Value::Text(file_id.clone())]
+            )
+            .await
+            .is_err()
+    );
+    assert_eq!(read_file(&reopened, path).await.unwrap(), before);
+    reopened.execute_batch(&[
+        ExecuteBatchStatement { label: None, sql: "DELETE FROM json_array_item WHERE lixcol_file_id = $1".into(), params: vec![Value::Text(file_id.clone())] },
+        ExecuteBatchStatement { label: None, sql: "UPDATE json_root SET kind = 'boolean', scalar_json = $1 WHERE lixcol_file_id = $2".into(), params: vec![Value::Jsonb(serde_json::json!(true).into()), Value::Text(file_id)] },
+    ]).await.unwrap();
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(b"true".to_vec())
+    );
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn json_structural_sql_rejects_orphans_and_accepts_subtree_deletion() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/subtree.json";
+    let original = br#"{"box":{"x":1},"keep":2}"#;
+    write_file(&lix, path, original.to_vec()).await.unwrap();
+    assert!(
+        lix.execute("DELETE FROM json_object_member WHERE key = 'box'", &[])
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(original.to_vec())
+    );
+    assert_eq!(
+        lix.execute("SELECT key FROM json_object_member", &[])
+            .await
+            .unwrap()
+            .len(),
+        3
+    );
+    lix.execute(
+        "DELETE FROM json_object_member WHERE key IN ('box', 'x')",
+        &[],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(br#"{"keep":2}"#.to_vec())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn json_scalar_spelling_survives_row_edits_and_cold_reopen() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/scalar-spelling.json";
+    let original =
+        " { \"number\" : 1.2300e+04, \"escaped\" : \"\\u0041\", \"edit\" : \"old\" } \r\n";
+    write_file(&lix, path, original.as_bytes().to_vec())
+        .await
+        .unwrap();
+    lix.close().await.unwrap();
+
+    let reopened = open_rocksdb_lix(root.path()).await;
+    reopened
+        .execute(
+            "UPDATE json_object_member SET scalar_json = $1 WHERE key = 'edit'",
+            &[Value::Jsonb(serde_json::json!("longer").into())],
+        )
+        .await
+        .unwrap();
+    let edited = original.replace("old", "longer");
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(edited.as_bytes().to_vec())
+    );
+
+    let file_edited = edited.replace("longer", "new");
+    write_file(&reopened, path, file_edited.as_bytes().to_vec())
+        .await
+        .unwrap();
+    reopened
+        .execute(
+            "UPDATE json_object_member SET scalar_json = $1 WHERE key = 'number'",
+            &[Value::Jsonb(serde_json::json!(7).into())],
+        )
+        .await
+        .unwrap();
+    let expected = file_edited.replace("1.2300e+04", "7");
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(expected.as_bytes().to_vec())
+    );
+    reopened.close().await.unwrap();
+
+    let reopened = open_rocksdb_lix(root.path()).await;
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(expected.into_bytes())
+    );
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn json_repeated_array_insertions_keep_inserted_rows_writable() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/inserted-identities.json";
+    write_file(&lix, path, b"[1,2]".to_vec()).await.unwrap();
+    write_file(&lix, path, b"[0,1,2]".to_vec()).await.unwrap();
+    let rows = lix
+        .execute("SELECT id FROM json_array_item ORDER BY order_key", &[])
+        .await
+        .unwrap();
+    let inserted_id = rows.rows()[0].get::<Value>("id").unwrap();
+    write_file(&lix, path, b"[0,1,2,3]".to_vec()).await.unwrap();
+    lix.execute(
+        "UPDATE json_array_item SET scalar_json = $1 WHERE id = $2",
+        &[Value::Jsonb(serde_json::json!(100).into()), inserted_id],
+    )
+    .await
+    .expect("an inserted row must remain writable after another insertion");
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(b"[100,1,2,3]".to_vec())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
 async fn json_first_structural_fallback_preserves_accepted_array_identities() {
     let lix = open_lix().await.unwrap();
     install_reference_plugin_in_blank_registry(
@@ -3415,7 +3650,7 @@ async fn v2_json_roundtrips_recursive_state_and_keeps_leaf_edits_sparse() {
 }
 
 #[tokio::test]
-async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_nodes() {
+async fn v2_json_scalar_lww_and_structural_upserts_compose() {
     let archive = build_json_plugin_archive();
     let lix = open_lix().await.unwrap();
     install_reference_plugin_in_blank_registry(
@@ -3497,38 +3732,31 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
     let lww = b"{\"left\":\"LWW-B\",\"right\":\"TWO-B\",\"gone\":\"three\"}".to_vec();
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(lww.clone()));
 
-    // Structure is not a direct semantic SQL operation. Its rejection must
-    // roll back the staged row and leave the actor usable for a later scalar.
-    let direct_structure_error = lix
-        .execute(
-            "DELETE FROM json_object_member \
-             WHERE parent_id = 'root' AND key = 'gone' AND lixcol_file_id = $1",
-            &[Value::Text(file_id.clone())],
-        )
-        .await
-        .expect_err("direct JSON semantic deletion must use an authoritative byte write");
-    assert_eq!(direct_structure_error.code, LixError::CODE_INVALID_PLUGIN);
-    assert!(
-        direct_structure_error
-            .message
-            .contains("existing scalar values only")
+    // Structural deletion updates both the file and durable rows.
+    lix.execute(
+        "DELETE FROM json_object_member WHERE parent_id = 'root' AND key = 'gone' AND lixcol_file_id = $1",
+        &[Value::Text(file_id.clone())],
+    ).await.unwrap();
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(br#"{"left":"LWW-B","right":"TWO-B"}"#.to_vec())
     );
-    assert_eq!(read_file(&lix, path).await.unwrap(), Some(lww));
+    write_file(&lix, path, lww).await.unwrap();
     lix.execute(
         "UPDATE json_object_member SET scalar_json = $1 \
          WHERE parent_id = 'root' AND key = 'right' AND lixcol_file_id = $2",
         &[
-            Value::Jsonb(serde_json::json!("AFTER-DIRECT-REJECT").into()),
+            Value::Jsonb(serde_json::json!("AFTER-DELETE").into()),
             Value::Text(file_id.clone()),
         ],
     )
     .await
     .unwrap();
-    let scalar_after_direct_reject =
-        b"{\"left\":\"LWW-B\",\"right\":\"AFTER-DIRECT-REJECT\",\"gone\":\"three\"}".to_vec();
+    let scalar_after_delete =
+        b"{\"left\":\"LWW-B\",\"right\":\"AFTER-DELETE\",\"gone\":\"three\"}".to_vec();
     assert_eq!(
         read_file(&lix, path).await.unwrap(),
-        Some(scalar_after_direct_reject.clone())
+        Some(scalar_after_delete.clone())
     );
     lix.execute(
         "UPDATE json_object_member SET scalar_json = $1 \
@@ -3544,39 +3772,35 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
         read_file(&lix, path).await.unwrap(),
         Some(b"{\"left\":\"BULK\",\"right\":\"BULK\",\"gone\":\"BULK\"}".to_vec())
     );
-    write_file(&lix, path, scalar_after_direct_reject.clone())
+    write_file(&lix, path, scalar_after_delete.clone())
         .await
         .unwrap();
 
-    // Structure is byte-owned. A stale scalar delta is not allowed to
-    // recreate a row after another writer removes its containing slot.
+    // A later upsert can recreate a deleted key under normal row LWW semantics.
+    // The rendered file and durable rows must agree after that replay.
     let stale_writer = lix.open_another_session().await.unwrap();
     let structure_writer = lix.open_another_session().await.unwrap();
     assert_eq!(
         read_file(&stale_writer, path).await.unwrap(),
-        Some(scalar_after_direct_reject.clone())
+        Some(scalar_after_delete.clone())
     );
     assert_eq!(
         read_file(&structure_writer, path).await.unwrap(),
-        Some(scalar_after_direct_reject)
+        Some(scalar_after_delete)
     );
-    let without_gone = b"{\"left\":\"LWW-B\",\"right\":\"AFTER-DIRECT-REJECT\"}".to_vec();
+    let without_gone = b"{\"left\":\"LWW-B\",\"right\":\"AFTER-DELETE\"}".to_vec();
     write_file(&structure_writer, path, without_gone.clone())
         .await
         .unwrap();
-    let error = write_file(
+    let restored = br#"{"left":"LWW-B","right":"AFTER-DELETE","gone":"STALE"}"#.to_vec();
+    write_file(
         &stale_writer,
         path,
-        b"{\"left\":\"LWW-B\",\"right\":\"AFTER-DIRECT-REJECT\",\"gone\":\"STALE\"}".to_vec(),
+        b"{\"left\":\"LWW-B\",\"right\":\"AFTER-DELETE\",\"gone\":\"STALE\"}".to_vec(),
     )
     .await
-    .expect_err("a stale scalar must not resurrect a byte-deleted JSON node");
-    assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN);
-    assert!(error.message.contains("existing scalar values only"));
-    assert_eq!(
-        read_file(&lix, path).await.unwrap(),
-        Some(without_gone.clone())
-    );
+    .expect("a later row upsert can recreate a deleted key");
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(restored));
     let gone = lix
         .execute(
             "SELECT key FROM json_object_member \
@@ -3585,10 +3809,13 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
         )
         .await
         .unwrap();
-    assert!(gone.is_empty(), "the deleted node must not be resurrected");
+    assert_eq!(
+        gone.len(),
+        1,
+        "the recreated node must exist in durable rows"
+    );
 
-    // A clean semantic scalar write still works after the rejected replay;
-    // returned invalid-input errors discard only the prospective transition.
+    // The rebuilt indexes support the next scalar edit.
     lix.execute(
         "UPDATE json_object_member SET scalar_json = $1 \
          WHERE parent_id = 'root' AND key = 'left' AND lixcol_file_id = $2",
@@ -3601,7 +3828,7 @@ async fn v2_json_scalar_lww_composes_and_stale_structure_does_not_resurrect_node
     .unwrap();
     assert_eq!(
         read_file(&lix, path).await.unwrap(),
-        Some(b"{\"left\":\"AFTER-FENCE\",\"right\":\"AFTER-DIRECT-REJECT\"}".to_vec())
+        Some(b"{\"left\":\"AFTER-FENCE\",\"right\":\"AFTER-DELETE\",\"gone\":\"STALE\"}".to_vec())
     );
 
     for session in [
@@ -5068,6 +5295,98 @@ async fn v2_json_rejects_mixed_byte_and_row_transitions_in_one_transaction() {
     transaction.commit().await.unwrap();
     assert_eq!(read_file(&lix, path).await.unwrap(), Some(bytes_only));
     lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn excalidraw_row_edits_preserve_unrelated_source_and_embedded_files() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_excalidraw",
+        &build_excalidraw_plugin_archive(),
+        &["excalidraw_scene", "excalidraw_element", "excalidraw_file"],
+    )
+    .await;
+    let path = "/source-preservation.excalidraw";
+    let untouched =
+        r#"{ "id" : "a", "type" : "rectangle", "x" : 1.2300e+04, "custom" : "\u0041" }"#;
+    let file = r#"{ "id" : "img", "dataURL" : "data:image/png;base64,AA==", "extra" : 1.20e2 }"#;
+    let app_state = r#""appState" : { "future" : [null,true,{"name":"\u0041"}] }"#;
+    let source = format!(
+        "{{\n\"type\":\"excalidraw\",\"version\":2,\"elements\":[{untouched},{{\"id\":\"b\",\"type\":\"ellipse\",\"x\":2}}],{app_state},\"files\":{{\"img\":{file}}}\n}}\n"
+    );
+    write_file(&lix, path, source.into_bytes()).await.unwrap();
+    let result = lix
+        .execute(
+            "SELECT element_json FROM excalidraw_element WHERE id = 'b'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let mut element = result.rows()[0]
+        .get::<serde_json::Value>("element_json")
+        .unwrap();
+    element["x"] = serde_json::json!(1234);
+    lix.execute(
+        "UPDATE excalidraw_element SET element_json = $1 WHERE id = 'b'",
+        &[Value::Jsonb(element.into())],
+    )
+    .await
+    .unwrap();
+    let rendered = String::from_utf8(read_file(&lix, path).await.unwrap().unwrap()).unwrap();
+    assert!(
+        rendered.contains(untouched),
+        "untouched element spelling must survive"
+    );
+    assert!(
+        rendered.contains(file),
+        "untouched embedded file spelling must survive"
+    );
+    assert!(
+        rendered.contains(app_state),
+        "unknown scene data must survive"
+    );
+    let edited = rendered.replace("1234", "12345");
+    write_file(&lix, path, edited.as_bytes().to_vec())
+        .await
+        .unwrap();
+    lix.close().await.unwrap();
+
+    let reopened = open_rocksdb_lix(root.path()).await;
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(edited.into_bytes())
+    );
+    let result = reopened
+        .execute(
+            "SELECT file_json FROM excalidraw_file WHERE id = 'img'",
+            &[],
+        )
+        .await
+        .unwrap();
+    let mut file_json = result.rows()[0]
+        .get::<serde_json::Value>("file_json")
+        .unwrap();
+    file_json["future"] = serde_json::json!({"preserved": true});
+    reopened
+        .execute(
+            "UPDATE excalidraw_file SET file_json = $1 WHERE id = 'img'",
+            &[Value::Jsonb(file_json.into())],
+        )
+        .await
+        .unwrap();
+    let rendered = String::from_utf8(read_file(&reopened, path).await.unwrap().unwrap()).unwrap();
+    assert!(rendered.contains(untouched));
+    assert!(rendered.contains(app_state));
+    let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+    assert_eq!(parsed["elements"][1]["x"], serde_json::json!(12345));
+    assert_eq!(
+        parsed["files"]["img"]["dataURL"],
+        "data:image/png;base64,AA=="
+    );
+    assert_eq!(parsed["files"]["img"]["future"]["preserved"], true);
+    reopened.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -7952,4 +8271,217 @@ fn build_csv_plugin_archive_variant(
         writer.write_all(marker).unwrap();
     }
     writer.finish().unwrap().into_inner()
+}
+#[tokio::test]
+async fn json_structural_qa_stale_subtree_upsert_rejects_atomically_and_reopens() {
+    let root = tempfile::tempdir().unwrap();
+    let lix = open_rocksdb_lix(root.path()).await;
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/stale-subtree.json";
+    let initial = br#"{"box":{"nested":{"leaf":1}},"keep":2}"#.to_vec();
+    write_file(&lix, path, initial.clone()).await.unwrap();
+    let stale = lix.open_another_session().await.unwrap();
+    assert_eq!(read_file(&stale, path).await.unwrap(), Some(initial));
+    lix.execute(
+        "DELETE FROM json_object_member WHERE key IN ('box', 'nested', 'leaf')",
+        &[],
+    )
+    .await
+    .unwrap();
+    let accepted = br#"{"keep":2}"#.to_vec();
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(accepted.clone()));
+    // Only the leaf and keep differ from the stale observation. The leaf cannot
+    // be reinstated without its deleted ancestors, and keep must roll back too.
+    let error = write_file(
+        &stale,
+        path,
+        br#"{"box":{"nested":{"leaf":9}},"keep":8}"#.to_vec(),
+    )
+    .await
+    .expect_err("a stale child upsert must not create an orphan");
+    assert_eq!(error.code, LixError::CODE_INVALID_PLUGIN, "{error:?}");
+    assert_eq!(read_file(&lix, path).await.unwrap(), Some(accepted.clone()));
+    let rows = lix
+        .execute("SELECT key, scalar_json FROM json_object_member", &[])
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows.rows()[0].get::<String>("key").unwrap(), "keep");
+    assert_eq!(
+        rows.rows()[0].get::<Value>("scalar_json").unwrap(),
+        Value::Jsonb(serde_json::json!(2).into())
+    );
+    stale.close().await.unwrap();
+    lix.close().await.unwrap();
+    let reopened = open_rocksdb_lix(root.path()).await;
+    assert_eq!(read_file(&reopened, path).await.unwrap(), Some(accepted));
+    assert_eq!(
+        reopened
+            .execute("SELECT key FROM json_object_member", &[])
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    reopened
+        .execute(
+            "UPDATE json_object_member SET scalar_json = $1 WHERE key = 'keep'",
+            &[Value::Jsonb(serde_json::json!(3).into())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        read_file(&reopened, path).await.unwrap(),
+        Some(br#"{"keep":3}"#.to_vec())
+    );
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn json_structural_qa_stale_disjoint_insertions_and_deletions_compose() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/stale-disjoint.json";
+    let initial = br#"{"keep":1.2300e+04,"gone":2}"#.to_vec();
+    write_file(&lix, path, initial.clone()).await.unwrap();
+    let first = lix.open_another_session().await.unwrap();
+    let second = lix.open_another_session().await.unwrap();
+    assert_eq!(
+        read_file(&first, path).await.unwrap(),
+        Some(initial.clone())
+    );
+    assert_eq!(read_file(&second, path).await.unwrap(), Some(initial));
+    lix.execute("DELETE FROM json_object_member WHERE key = 'gone'", &[])
+        .await
+        .unwrap();
+    write_file(
+        &first,
+        path,
+        br#"{"keep":1.2300e+04,"gone":2,"alpha":3}"#.to_vec(),
+    )
+    .await
+    .unwrap();
+    let before_stale = read_file(&lix, path).await.unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(before_stale.as_ref().unwrap()).unwrap(),
+        serde_json::json!({"keep":12300.0,"alpha":3})
+    );
+    let error = write_file(
+        &second,
+        path,
+        br#"{"keep":1.2300e+04,"gone":2,"beta":4}"#.to_vec(),
+    )
+    .await
+    .expect_err("full replacement invalidates the older observation history");
+    assert_eq!(error.code, LixError::CODE_PLUGIN_OBSERVATION_STALE);
+    assert_eq!(read_file(&lix, path).await.unwrap(), before_stale);
+    // Explicitly re-observe before retrying, retaining the accepted sibling.
+    let current = read_file(&second, path).await.unwrap().unwrap();
+    let mut retry = String::from_utf8(current).unwrap();
+    retry.pop();
+    retry.push_str(",\"beta\":4}");
+    write_file(&second, path, retry.into_bytes()).await.unwrap();
+    let rendered = read_file(&lix, path).await.unwrap().unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&rendered).unwrap(),
+        serde_json::json!({"keep":12300.0,"alpha":3,"beta":4})
+    );
+    assert!(String::from_utf8(rendered).unwrap().contains("1.2300e+04"));
+    let rows = lix
+        .execute("SELECT key FROM json_object_member ORDER BY key", &[])
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+    assert_eq!(
+        rows.rows()
+            .iter()
+            .map(|row| row.get::<String>("key").unwrap())
+            .collect::<Vec<_>>(),
+        vec!["alpha", "beta", "keep"]
+    );
+    // Both inserted keys remain directly writable after the merged rebuilds.
+    lix.execute(
+        "UPDATE json_object_member SET scalar_json = $1 WHERE key IN ('alpha', 'beta')",
+        &[Value::Jsonb(serde_json::json!(5).into())],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&read_file(&lix, path).await.unwrap().unwrap())
+            .unwrap(),
+        serde_json::json!({"keep":12300.0,"alpha":5,"beta":5})
+    );
+    first.close().await.unwrap();
+    second.close().await.unwrap();
+    lix.close().await.unwrap();
+}
+#[tokio::test]
+async fn json_structural_qa_multi_parent_file_updates_are_deterministic() {
+    let lix = open_lix().await.unwrap();
+    install_reference_plugin_in_blank_registry(
+        &lix,
+        "plugin_json",
+        &build_json_plugin_archive(),
+        &["json_root", "json_object_member", "json_array_item"],
+    )
+    .await;
+    let path = "/multi-parent.json";
+    write_file(
+        &lix,
+        path,
+        br#"{"box":{"leaf":1},"keep":2,"gone":0}"#.to_vec(),
+    )
+    .await
+    .unwrap();
+    let stale = lix.open_another_session().await.unwrap();
+    read_file(&stale, path).await.unwrap();
+    lix.execute("DELETE FROM json_object_member WHERE key = 'gone'", &[])
+        .await
+        .unwrap();
+    write_file(
+        &stale,
+        path,
+        br#"{"box":{"leaf":2},"keep":3,"gone":0}"#.to_vec(),
+    )
+    .await
+    .expect("valid stale multi-parent changes must compose with independent deletion");
+    assert_eq!(
+        read_file(&lix, path).await.unwrap(),
+        Some(br#"{"box":{"leaf":2},"keep":3}"#.to_vec())
+    );
+    stale.close().await.unwrap();
+    for value in 3..15 {
+        let source = format!("{{\"box\":{{\"leaf\":{value}}},\"keep\":{value}}}").into_bytes();
+        write_file(&lix, path, source.clone())
+            .await
+            .expect("valid changes under different parents must be accepted");
+        assert_eq!(read_file(&lix, path).await.unwrap(), Some(source));
+        let rows = lix
+            .execute(
+                "SELECT scalar_json FROM json_object_member WHERE key IN ('leaf', 'keep')",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        for row in rows.rows() {
+            assert_eq!(
+                row.get::<Value>("scalar_json").unwrap(),
+                Value::Jsonb(serde_json::json!(value).into())
+            );
+        }
+    }
+    lix.close().await.unwrap();
 }

--- a/packages/lix-schema/fixtures/current/excalidraw_element.json
+++ b/packages/lix-schema/fixtures/current/excalidraw_element.json
@@ -38,6 +38,12 @@
       "type": "text",
       "nullable": false,
       "description": "A stable fractional key representing array order independently from identity."
+    },
+    {
+      "name": "source_json",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact original JSON spelling. A formatting hint only; edited JSONB values remain authoritative."
     }
   ],
   "primary_key": [

--- a/packages/lix-schema/fixtures/current/excalidraw_file.json
+++ b/packages/lix-schema/fixtures/current/excalidraw_file.json
@@ -26,6 +26,12 @@
       "type": "text",
       "nullable": false,
       "description": "Exact whitespace, encoded map key, and colon immediately preceding file_json; commas are supplied by the renderer."
+    },
+    {
+      "name": "source_json",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact original JSON spelling. A formatting hint only; edited JSONB values remain authoritative."
     }
   ],
   "primary_key": [

--- a/packages/lix-schema/fixtures/current/json_array_item.json
+++ b/packages/lix-schema/fixtures/current/json_array_item.json
@@ -47,6 +47,12 @@
       "description": "The JSON scalar value. Omitted when kind is object or array."
     },
     {
+      "name": "scalar_text",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact noncanonical scalar spelling, used only while it agrees with scalar_json."
+    },
+    {
       "name": "suffix_json",
       "type": "text",
       "nullable": true,

--- a/packages/lix-schema/fixtures/current/json_object_member.json
+++ b/packages/lix-schema/fixtures/current/json_object_member.json
@@ -52,6 +52,12 @@
       "description": "The JSON scalar value. Omitted when kind is object or array."
     },
     {
+      "name": "scalar_text",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact noncanonical scalar spelling, used only while it agrees with scalar_json."
+    },
+    {
       "name": "suffix_json",
       "type": "text",
       "nullable": true,

--- a/packages/lix-schema/fixtures/current/json_root.json
+++ b/packages/lix-schema/fixtures/current/json_root.json
@@ -34,6 +34,12 @@
       "description": "The JSON scalar value. Omitted for object and array roots."
     },
     {
+      "name": "scalar_text",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact noncanonical scalar spelling, used only while it agrees with scalar_json."
+    },
+    {
       "name": "suffix_json",
       "type": "text",
       "nullable": true,

--- a/packages/lix-schema/tests/schema_v1.rs
+++ b/packages/lix-schema/tests/schema_v1.rs
@@ -233,17 +233,17 @@ fn bundled_native_jsonb_schemas_match_canonical_fixtures_and_fingerprints() {
         (
             "json",
             "json_root",
-            "041872f6589bbdf8187bccc3894451407073ba21a2a3d396503ac071f8402704",
+            "f9983019fd1050c5234ae1957ecf300757d0a43eb89a24e91ed184c85599f3ad",
         ),
         (
             "json",
             "json_object_member",
-            "be012f960e381e167cc6da518891a6a68b47233eb67153bbba96bb4ba02f5734",
+            "83dd43c644fd996fdec5b907ab08396270adfbe7fdc2f4792e00827f51304bb3",
         ),
         (
             "json",
             "json_array_item",
-            "a980f74baf5f9156853cd73cb3222f79ec5dbfaffa5da4d9d7f705c35357d662",
+            "e5eba027bc7ceb323bfa045dfcf39134565bfc23f84844be628283db1bc62422",
         ),
         (
             "excalidraw",
@@ -253,12 +253,12 @@ fn bundled_native_jsonb_schemas_match_canonical_fixtures_and_fingerprints() {
         (
             "excalidraw",
             "excalidraw_element",
-            "9d4e6f076618c02e1b15e86c0d77bb36545b78330f967f9049985ac79968fd0f",
+            "6f2a49b904fe1f46d484e1488f43c7454e4f0c07c27c299a0bf740ce7e36843b",
         ),
         (
             "excalidraw",
             "excalidraw_file",
-            "f0cc6e729ea8d42f69558972e783e66087addfe13ed34435f10da51fa3694847",
+            "20b7f07a50252241780f2f772f9bcd537d3b42a82d44876f7de6fad2bb241bbd",
         ),
     ];
 

--- a/plugins/excalidraw/schema/excalidraw_element.json
+++ b/plugins/excalidraw/schema/excalidraw_element.json
@@ -38,6 +38,12 @@
       "type": "text",
       "nullable": false,
       "description": "A stable fractional key representing array order independently from identity."
+    },
+    {
+      "name": "source_json",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact original JSON spelling. A formatting hint only; edited JSONB values remain authoritative."
     }
   ],
   "primary_key": [

--- a/plugins/excalidraw/schema/excalidraw_file.json
+++ b/plugins/excalidraw/schema/excalidraw_file.json
@@ -26,6 +26,12 @@
       "type": "text",
       "nullable": false,
       "description": "Exact whitespace, encoded map key, and colon immediately preceding file_json; commas are supplied by the renderer."
+    },
+    {
+      "name": "source_json",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact original JSON spelling. A formatting hint only; edited JSONB values remain authoritative."
     }
   ],
   "primary_key": [

--- a/plugins/excalidraw/src/core.rs
+++ b/plugins/excalidraw/src/core.rs
@@ -312,6 +312,10 @@ impl ElementRow {
             TypedValue::Boolean(self.is_deleted),
         );
         row.insert("element_json".to_owned(), TypedValue::Jsonb(element_json));
+        row.insert(
+            "source_json".to_owned(),
+            source_hint(&row, "element_json", &self.element_json),
+        );
         Ok(RowRecord {
             schema_key: ELEMENT_SCHEMA_KEY.into(),
             row_pk: vec![TypedValue::Text(self.id.clone())],
@@ -338,8 +342,7 @@ impl ElementRow {
         }
         let declared_type = required_text(&record.row, "element_type")?;
         let declared_deleted = required_typed_bool(&record.row, "is_deleted")?;
-        let element_json = serde_json::to_string(required_jsonb(&record.row, "element_json")?)
-            .map_err(|error| format!("serialize Excalidraw element JSONB: {error}"))?;
+        let element_json = render_payload(&record.row, "element_json")?;
         let row = Self::from_source(
             required_text(&record.row, "order_key")?.to_owned(),
             required_text(&record.row, "leading_json")?.to_owned(),
@@ -400,6 +403,10 @@ impl FileRow {
             TypedValue::Text(self.prefix_json.clone()),
         );
         row.insert("file_json".to_owned(), TypedValue::Jsonb(file_json));
+        row.insert(
+            "source_json".to_owned(),
+            source_hint(&row, "file_json", &self.file_json),
+        );
         Ok(RowRecord {
             schema_key: FILE_SCHEMA_KEY.into(),
             row_pk: vec![TypedValue::Text(self.id.clone())],
@@ -417,8 +424,7 @@ impl FileRow {
         if required_text(&record.row, "id")? != id {
             return Err("excalidraw_file row id does not match its key".to_owned());
         }
-        let file_json = serde_json::to_string(required_jsonb(&record.row, "file_json")?)
-            .map_err(|error| format!("serialize Excalidraw file JSONB: {error}"))?;
+        let file_json = render_payload(&record.row, "file_json")?;
         Self::from_source(
             id.to_owned(),
             required_text(&record.row, "order_key")?.to_owned(),
@@ -1032,6 +1038,13 @@ fn scan_array_collection(bytes: &[u8], start: usize, end: usize) -> Result<RawCo
         scanner.skip_whitespace();
         match scanner.peek() {
             Some(b',') => {
+                // Whitespace before a separator belongs to the preceding raw
+                // value; otherwise rebuilding the collection drops it.
+                let entry = entries.last_mut().expect("just scanned a collection entry");
+                entry
+                    .raw
+                    .push_str(&bytes_to_string(&bytes[value_end..scanner.cursor])?);
+                entry.span = span(value_start, scanner.cursor)?;
                 scanner.cursor += 1;
                 segment_start = scanner.cursor;
             }
@@ -1096,6 +1109,13 @@ fn scan_object_collection(bytes: &[u8], start: usize, end: usize) -> Result<RawC
         scanner.skip_whitespace();
         match scanner.peek() {
             Some(b',') => {
+                // Whitespace before a separator belongs to the preceding raw
+                // value; otherwise rebuilding the collection drops it.
+                let entry = entries.last_mut().expect("just scanned a collection entry");
+                entry
+                    .raw
+                    .push_str(&bytes_to_string(&bytes[value_end..scanner.cursor])?);
+                entry.span = span(value_start, scanner.cursor)?;
                 scanner.cursor += 1;
                 segment_start = scanner.cursor;
             }
@@ -1663,7 +1683,18 @@ fn diff_records(before: Vec<RowRecord>, after: Vec<RowRecord>) -> Result<Vec<Row
     }
     for (key, record) in after {
         if before.get(&key) != Some(&record.row) {
-            changes.push(RowChange::upsert(record));
+            let format_only = before.get(&key).is_some_and(|before| {
+                let mut before = before.clone();
+                let mut after = record.row.clone();
+                before.remove("source_json");
+                after.remove("source_json");
+                before == after
+            });
+            let mut change = RowChange::upsert(record);
+            if format_only {
+                change.effect = ChangeEffect::FormatOnly;
+            }
+            changes.push(change);
         }
     }
     changes.sort_unstable_by(|left, right| {
@@ -1744,13 +1775,81 @@ fn require_fields(row: &TypedRow, required: &[&str]) -> Result<(), String> {
         }
     }
     for field in row.keys() {
-        if !expected.contains(field) {
+        if !expected.contains(field)
+            && !(field == "source_json"
+                && (expected.contains("element_json") || expected.contains("file_json")))
+        {
             return Err(format!(
                 "Excalidraw row contains unsupported field {field:?}"
             ));
         }
     }
     Ok(())
+}
+
+fn source_hint(row: &TypedRow, field: &str, source: &str) -> TypedValue {
+    let Some(TypedValue::Jsonb(value)) = row.get(field) else {
+        unreachable!()
+    };
+    if value
+        .to_json_string()
+        .is_ok_and(|canonical| canonical == source)
+    {
+        TypedValue::Null
+    } else {
+        // Transport validation reports unsupported JSONB values as errors;
+        // inability to compute this optional hint must not panic during parse.
+        TypedValue::Text(source.to_owned())
+    }
+}
+
+/// Retain exact object spelling while keeping the JSONB payload authoritative.
+fn render_payload(row: &TypedRow, field: &str) -> Result<String, String> {
+    let value = required_jsonb(row, field)?;
+    let canonical = || serde_json::to_string(value).map_err(|error| error.to_string());
+    let source = match row.get("source_json") {
+        None | Some(TypedValue::Null) => return canonical(),
+        Some(TypedValue::Text(source)) => source,
+        _ => return Err("source_json must be typed text or null".to_owned()),
+    };
+    let Ok(original) = serde_json::from_str::<Value>(source) else {
+        return canonical();
+    };
+    let Some(TypedValue::Jsonb(current)) = row.get(field) else {
+        unreachable!()
+    };
+    if current == &original {
+        return Ok(source.clone());
+    }
+    // A common geometry/text edit changes existing object fields. Reuse the
+    // existing scanner to replace only those values, preserving all other
+    // property spelling, escapes, and unknown nested fields.
+    let (Some(old), Some(new)) = (original.as_object(), value.as_object()) else {
+        return canonical();
+    };
+    if old.len() != new.len() || old.keys().any(|key| !new.contains_key(key)) {
+        return canonical();
+    }
+    let Ok(fields) = scan_root_fields(source.as_bytes()) else {
+        return canonical();
+    };
+    let mut edits = Vec::new();
+    for field in fields {
+        let before = TypedValue::Jsonb(old[&field.key].clone().into());
+        let after = TypedValue::Jsonb(new[&field.key].clone().into());
+        if before != after {
+            edits.push((
+                field.value_start,
+                field.value_end,
+                serde_json::to_string(&new[&field.key]).map_err(|error| error.to_string())?,
+            ));
+        }
+    }
+    let mut output = source.clone();
+    for (start, end, insert) in edits.into_iter().rev() {
+        output.replace_range(start..end, &insert);
+    }
+    Ok(output)
 }
 
 fn text_primary_key(record: &RowRecord) -> Result<&str, String> {

--- a/plugins/excalidraw/src/lib.rs
+++ b/plugins/excalidraw/src/lib.rs
@@ -9,6 +9,7 @@ use core::{
     RowRecord,
 };
 use lix::plugin as sdk;
+use sdk::StateOutput;
 use std::sync::OnceLock;
 
 struct ExcalidrawPlugin;
@@ -221,8 +222,7 @@ impl sdk::FileProjection for ExcalidrawPlugin {
         let (document, changes) = document
             .file_changed(&splices, create_namespace)
             .map_err(sdk::Error::invalid_input)?;
-        replace_element_index(
-            &update.before,
+        store_element_index(
             sink,
             &encode_element_index(&document.arena_element_spans())?,
         )?;
@@ -385,6 +385,7 @@ fn sparse_element_change(
     let leading_json = state_text(&metadata[order_key_end..leading_json_end])?;
 
     let mut element = update.before.read_range(span_offset, span_length)?;
+    let previous = element.clone();
     let local_start = usize::try_from(edit.offset - span_offset)
         .map_err(|_| sdk::Error::invalid_input("Excalidraw edit offset exceeds guest memory"))?;
     let local_end = local_start
@@ -395,12 +396,24 @@ fn sparse_element_change(
     element.splice(local_start..local_end, insert.iter().copied());
     let element_json = String::from_utf8(element)
         .map_err(|error| sdk::Error::invalid_input(format!("invalid Excalidraw UTF-8: {error}")))?;
-    let Some(change) =
+    if element_json.as_bytes() == previous {
+        return Ok(None);
+    }
+    let Some(mut change) =
         Document::element_change_from_source(&id, order_key, leading_json, element_json)
             .map_err(sdk::Error::invalid_input)?
     else {
         return Ok(None);
     };
+
+    if let (Ok(before), Some(row)) = (
+        serde_json::from_slice::<serde_json::Value>(&previous),
+        &change.row,
+    ) && let Some(sdk::TypedValue::Jsonb(after)) = row.get("element_json")
+        && after == &before
+    {
+        change.effect = ChangeEffect::FormatOnly;
+    }
 
     let insert_len = u64::try_from(insert.len())
         .map_err(|_| sdk::Error::limit_exceeded("Excalidraw insert exceeds u64"))?;
@@ -466,6 +479,8 @@ fn store_element_index(
     successor: &mut impl StateOutput,
     encoded: &EncodedElementIndex,
 ) -> sdk::Result<()> {
+    successor.delete_state(ELEMENT_SHIFTS_KEY)?;
+    successor.delete_state_prefix(b"excalidraw/element-index-page/")?;
     let page_count = u32::try_from(encoded.payload.len().div_ceil(ELEMENT_INDEX_PAGE_BYTES))
         .map_err(|_| sdk::Error::limit_exceeded("too many Excalidraw index pages"))?;
     let mut manifest = Vec::with_capacity(ELEMENT_INDEX_HEADER_BYTES as usize);
@@ -482,38 +497,6 @@ fn store_element_index(
         successor.put_state(&element_index_page_key(ordinal as u32), page)?;
     }
     Ok(())
-}
-
-fn replace_element_index(
-    before: &sdk::Snapshot<'_>,
-    successor: &mut impl StateOutput,
-    encoded: &EncodedElementIndex,
-) -> sdk::Result<()> {
-    let old_page_count = element_index_page_count(before)?;
-    store_element_index(successor, encoded)?;
-    let new_page_count = u32::try_from(encoded.payload.len().div_ceil(ELEMENT_INDEX_PAGE_BYTES))
-        .map_err(|_| sdk::Error::limit_exceeded("too many Excalidraw index pages"))?;
-    for ordinal in new_page_count..old_page_count {
-        successor.delete_state(&element_index_page_key(ordinal))?;
-    }
-    Ok(())
-}
-
-fn element_index_page_count(root: &sdk::Snapshot<'_>) -> sdk::Result<u32> {
-    let Some(header) = root.read_state_range(ELEMENT_INDEX_KEY, 0, ELEMENT_INDEX_HEADER_BYTES)?
-    else {
-        return Ok(0);
-    };
-    if header.get(..4) != Some(ELEMENT_INDEX_MAGIC) {
-        return Err(sdk::Error::invalid_input(
-            "unsupported Excalidraw element index",
-        ));
-    }
-    Ok(u32::from_le_bytes(
-        header[12..16]
-            .try_into()
-            .expect("fixed Excalidraw manifest"),
-    ))
 }
 
 fn element_index_page_key(ordinal: u32) -> Vec<u8> {
@@ -690,27 +673,6 @@ where
     }
     Ok(())
 }
-
-trait StateOutput {
-    fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()>;
-    fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()>;
-}
-macro_rules! impl_state_output {
-    ($type:ty) => {
-        impl StateOutput for $type {
-            fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()> {
-                <$type>::put_state(self, key, value)
-            }
-            fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()> {
-                <$type>::delete_state(self, key)
-            }
-        }
-    };
-}
-impl_state_output!(sdk::RowOutput<'_, '_>);
-impl_state_output!(sdk::RowChangeOutput<'_, '_>);
-impl_state_output!(sdk::FileOutput<'_, '_>);
-impl_state_output!(sdk::FileEditOutput<'_, '_>);
 
 trait MutationOutput {
     fn upsert(
@@ -901,3 +863,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod qa_tests;

--- a/plugins/excalidraw/src/qa_tests.rs
+++ b/plugins/excalidraw/src/qa_tests.rs
@@ -1,0 +1,526 @@
+use super::*;
+use sdk::testing::{Harness, Snapshot};
+use serde_json::{Value, json};
+
+const SOURCE: &str = "{\r\n  \"type\": \"excalidraw\", \"version\":2,\r\n  \"future\": {\"keep\":[null,{\"text\":\"λ😀\"}]},\r\n  \"elements\": [\r\n    { \"id\": \"a\", \"type\": \"rectangle\", \"x\": 1, \"custom\": {\"n\":4e0,\"unicode\":\"\\u03bb\"} },\r\n    { \"id\": \"b\", \"type\": \"text\", \"text\": \"untouched\", \"isDeleted\": false }\r\n  ],\r\n  \"appState\": {\"theme\":\"dark\"},\r\n  \"files\": { \"image\" : { \"mimeType\":\"image/png\", \"dataURL\":\"data:image/png;base64,AAAA\", \"extra\": [1,{\"a\":true}] } }\r\n}\r\n";
+
+fn ctx(n: u8) -> sdk::CreateContext {
+    sdk::CreateContext::from_namespace_bytes([n; 12])
+}
+fn initial() -> (
+    Harness<ExcalidrawPlugin>,
+    Snapshot,
+    Vec<sdk::TypedRowRecord>,
+) {
+    let harness = Harness::<ExcalidrawPlugin>::default();
+    let file = Snapshot {
+        file_id: "qa".into(),
+        path: "scene.excalidraw".into(),
+        bytes: SOURCE.as_bytes().to_vec(),
+        ..Snapshot::default()
+    };
+    let parsed = harness.parse(&file, ctx(1)).unwrap();
+    let mut rows = Vec::new();
+    accept(&mut rows, &parsed.row_changes);
+    (harness, parsed.into_snapshot(), rows)
+}
+fn accept(rows: &mut Vec<sdk::TypedRowRecord>, changes: &[sdk::TypedRowChange]) {
+    for c in changes {
+        assert!(c.local_ref.is_none());
+        rows.retain(|r| r.schema_key != c.schema_key || r.primary_key != c.primary_key);
+        if let Some(row) = &c.row {
+            rows.push(sdk::TypedRowRecord {
+                schema_key: c.schema_key.clone(),
+                schema_fingerprint: c.schema_fingerprint,
+                primary_key: c.primary_key.clone(),
+                row: row.clone(),
+            });
+        }
+    }
+}
+fn change(r: &sdk::TypedRowRecord) -> sdk::TypedRowChange {
+    sdk::TypedRowChange {
+        schema_key: r.schema_key.clone(),
+        schema_fingerprint: r.schema_fingerprint,
+        primary_key: r.primary_key.clone(),
+        row: Some(r.row.clone()),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    }
+}
+fn element(rows: &[sdk::TypedRowRecord], id: &str) -> sdk::TypedRowRecord {
+    rows.iter()
+        .find(|r| {
+            r.schema_key.as_ref() == core::ELEMENT_SCHEMA_KEY
+                && r.primary_key == [sdk::TypedValue::Text(id.into())]
+        })
+        .unwrap()
+        .clone()
+}
+fn payload(row: &sdk::TypedRowRecord, field: &str) -> Value {
+    let sdk::TypedValue::Jsonb(value) = row.row.get(field).unwrap() else {
+        panic!("expected JSONB")
+    };
+    serde_json::to_value(value).unwrap()
+}
+fn set_payload(row: &mut sdk::TypedRowRecord, field: &str, value: Value) {
+    row.row.insert(field, sdk::TypedValue::Jsonb(value.into()));
+}
+fn json(bytes: &[u8]) -> Value {
+    serde_json::from_slice(bytes).unwrap()
+}
+fn replace(file: &Snapshot, needle: &str, insert: &str) -> sdk::FileEdit {
+    let text = std::str::from_utf8(&file.bytes).unwrap();
+    sdk::FileEdit {
+        offset: text.find(needle).unwrap() as u64,
+        delete_len: needle.len() as u64,
+        insert: insert.as_bytes().to_vec(),
+    }
+}
+fn canonical_rows(rows: &[sdk::TypedRowRecord]) -> Vec<(String, String, sdk::TypedRow)> {
+    let mut out = rows
+        .iter()
+        .map(|r| {
+            (
+                r.schema_key.to_string(),
+                format!("{:?}", r.primary_key),
+                r.row.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    out.sort_by(|a, b| (&a.0, &a.1).cmp(&(&b.0, &b.1)));
+    out
+}
+
+#[test]
+fn qa_noop_rows_and_full_serialize_preserve_exact_source() {
+    let (h, file, rows) = initial();
+    assert_eq!(
+        h.serialize(&file.file_id, &file.path, &rows, Some(&file))
+            .unwrap()
+            .snapshot()
+            .bytes,
+        file.bytes
+    );
+    assert_eq!(
+        h.serialize(&file.file_id, &file.path, &rows, None)
+            .unwrap()
+            .snapshot()
+            .bytes,
+        file.bytes,
+        "cold render needs exact payload spelling"
+    );
+    for changes in [
+        vec![],
+        vec![change(&element(&rows, "a"))],
+        rows.iter().map(change).collect(),
+    ] {
+        let out = h.serialize_changes(&file, &changes).unwrap();
+        assert_eq!(
+            out.snapshot().bytes,
+            file.bytes,
+            "unchanged rows must not normalize source"
+        );
+        assert!(out.file_edits.is_empty());
+    }
+}
+
+#[test]
+fn qa_element_edit_preserves_unrelated_raw_objects_and_nested_data() {
+    let (h, file, rows) = initial();
+    let mut a = element(&rows, "a");
+    let mut p = payload(&a, "element_json");
+    p["x"] = json!(42);
+    set_payload(&mut a, "element_json", p);
+    let out = h.serialize_changes(&file, &[change(&a)]).unwrap();
+    let mut expected = json(&file.bytes);
+    expected["elements"][0]["x"] = json!(42);
+    assert_eq!(json(&out.snapshot().bytes), expected);
+    let untouched =
+        "{ \"id\": \"b\", \"type\": \"text\", \"text\": \"untouched\", \"isDeleted\": false }";
+    assert!(
+        std::str::from_utf8(&out.snapshot().bytes)
+            .unwrap()
+            .contains(untouched)
+    );
+    assert!(std::str::from_utf8(&out.snapshot().bytes).unwrap().contains("\"image\" : { \"mimeType\":\"image/png\", \"dataURL\":\"data:image/png;base64,AAAA\", \"extra\": [1,{\"a\":true}] }"));
+}
+
+#[test]
+fn qa_sparse_edits_full_serialize_reopen_and_cold_edits_agree() {
+    let (h, mut file, mut rows) = initial();
+    let edit = replace(&file, "\"x\": 1", "\"x\": 123456");
+    let out = h
+        .parse_changes(&file, &file.path, &[edit], None, ctx(2))
+        .unwrap();
+    assert!(
+        out.snapshot().state.contains_key(ELEMENT_SHIFTS_KEY),
+        "fixture takes sparse path"
+    );
+    accept(&mut rows, &out.row_changes);
+    file = out.into_snapshot();
+    file = h
+        .serialize(&file.file_id, &file.path, &rows, Some(&file))
+        .unwrap()
+        .into_snapshot();
+    let edit = replace(&file, "untouched", "edited");
+    let warm = h
+        .parse_changes(&file, &file.path, std::slice::from_ref(&edit), None, ctx(3))
+        .unwrap();
+    let mut cold = file.clone();
+    cold.state.clear();
+    let cold = h
+        .parse_changes(&cold, &cold.path, &[edit], Some(&rows), ctx(3))
+        .unwrap();
+    let mut warm_rows = rows.clone();
+    let mut cold_rows = rows.clone();
+    accept(&mut warm_rows, &warm.row_changes);
+    accept(&mut cold_rows, &cold.row_changes);
+    assert_eq!(warm.snapshot().bytes, cold.snapshot().bytes);
+    assert_eq!(canonical_rows(&warm_rows), canonical_rows(&cold_rows));
+    let fresh = h.parse(warm.snapshot(), ctx(4)).unwrap();
+    let mut fresh_rows = Vec::new();
+    accept(&mut fresh_rows, &fresh.row_changes);
+    assert_eq!(canonical_rows(&warm_rows), canonical_rows(&fresh_rows));
+}
+
+#[test]
+fn qa_reorder_delete_create_preserves_native_ids_and_unknown_content() {
+    let (h, file, mut rows) = initial();
+    let mut expected = json(&file.bytes);
+    expected["elements"].as_array_mut().unwrap().swap(0, 1);
+    let text = serde_json::to_vec(&expected).unwrap();
+    let out = h
+        .parse_changes(
+            &file,
+            "renamed.excalidraw",
+            &[sdk::FileEdit {
+                offset: 0,
+                delete_len: file.bytes.len() as u64,
+                insert: text,
+            }],
+            None,
+            ctx(2),
+        )
+        .unwrap();
+    accept(&mut rows, &out.row_changes);
+    let mut file = out.into_snapshot();
+    let mut a = element(&rows, "a");
+    let mut p = payload(&a, "element_json");
+    p["id"] = json!("c");
+    p["custom"]["new"] = json!([true,null,{"deep":"preserved"}]);
+    a.primary_key = vec![sdk::TypedValue::Text("c".into())];
+    a.row.insert("id", sdk::TypedValue::Text("c".into()));
+    set_payload(&mut a, "element_json", p.clone());
+    let mut delete = change(&element(&rows, "a"));
+    delete.row = None;
+    let changes = vec![delete, change(&a)];
+    let out = h.serialize_changes(&file, &changes).unwrap();
+    accept(&mut rows, &changes);
+    file = out.into_snapshot();
+    expected["elements"][1] = p;
+    assert_eq!(json(&file.bytes), expected);
+    let fresh = h.parse(&file, ctx(3)).unwrap();
+    let mut fresh_rows = Vec::new();
+    accept(&mut fresh_rows, &fresh.row_changes);
+    let rendered = h.serialize(&file.file_id, &file.path, &rows, None).unwrap();
+    assert_eq!(json(&rendered.snapshot().bytes), json(&file.bytes));
+    assert_eq!(
+        element(&fresh_rows, "c").primary_key,
+        [sdk::TypedValue::Text("c".into())]
+    );
+}
+
+#[test]
+fn qa_invalid_json_and_row_changes_roll_back() {
+    let (h, file, rows) = initial();
+    let before = file.clone();
+    for insert in [
+        b"{".to_vec(),
+        b"{\"elements\":[{\"id\":\"x\",\"type\":\"rectangle\"},{\"id\":\"x\",\"type\":\"text\"}]}"
+            .to_vec(),
+    ] {
+        assert!(
+            h.parse_changes(
+                &file,
+                &file.path,
+                &[sdk::FileEdit {
+                    offset: 0,
+                    delete_len: file.bytes.len() as u64,
+                    insert
+                }],
+                None,
+                ctx(2)
+            )
+            .is_err()
+        );
+        assert_eq!(file, before);
+    }
+    let mut a = element(&rows, "a");
+    let mut p = payload(&a, "element_json");
+    p["id"] = json!("wrong");
+    set_payload(&mut a, "element_json", p);
+    assert!(h.serialize_changes(&file, &[change(&a)]).is_err());
+    assert_eq!(file, before);
+}
+
+#[test]
+fn qa_repeated_edits_are_deterministic_and_preserve_data() {
+    let (h, file, rows) = initial();
+    let run = || {
+        let (mut file, mut rows) = (file.clone(), rows.clone());
+        for n in 0..24 {
+            let value = json!({"id":"a","type":"rectangle","x":n,"custom":{"nested":[null,{"text":"λ😀"}],"n":4.0}});
+            let mut a = element(&rows, "a");
+            set_payload(&mut a, "element_json", value);
+            let changes = [change(&a)];
+            let out = h.serialize_changes(&file, &changes).unwrap();
+            accept(&mut rows, &changes);
+            file = out.into_snapshot();
+            if n % 4 == 0 {
+                file.state.clear();
+                let noop = h
+                    .parse_changes(&file, &file.path, &[], Some(&rows), ctx(n as u8 + 2))
+                    .unwrap();
+                accept(&mut rows, &noop.row_changes);
+                file = noop.into_snapshot();
+            }
+            assert_eq!(json(&file.bytes)["elements"][0]["x"], json!(n));
+        }
+        (file, canonical_rows(&rows))
+    };
+    assert_eq!(run(), run());
+}
+
+#[test]
+fn qa_full_render_discards_sparse_length_shifts() {
+    let h = Harness::<ExcalidrawPlugin>::default();
+    let file = Snapshot {
+        file_id: "small".into(),
+        path: "a.excalidraw".into(),
+        bytes: br#"{"elements":[{"id":"a","type":"text","text":"x"}]}"#.to_vec(),
+        ..Snapshot::default()
+    };
+    let parsed = h.parse(&file, ctx(1)).unwrap();
+    let mut rows = Vec::new();
+    accept(&mut rows, &parsed.row_changes);
+    let file = parsed.into_snapshot();
+    let out = h
+        .parse_changes(
+            &file,
+            &file.path,
+            &[replace(&file, "\"x\"", "\"abcdefghijklmnopqrstuvwxyz\"")],
+            None,
+            ctx(2),
+        )
+        .unwrap();
+    accept(&mut rows, &out.row_changes);
+    let file = out.into_snapshot();
+    let file = h
+        .serialize(&file.file_id, &file.path, &rows, Some(&file))
+        .unwrap()
+        .into_snapshot();
+    let out = h
+        .parse_changes(
+            &file,
+            &file.path,
+            &[replace(&file, "abcdef", "ABCDEF")],
+            None,
+            ctx(3),
+        )
+        .unwrap();
+    assert_eq!(
+        json(&out.snapshot().bytes)["elements"][0]["text"],
+        json!("ABCDEFghijklmnopqrstuvwxyz")
+    );
+}
+
+#[test]
+fn qa_whitespace_before_collection_commas_survives_cold_render_and_edits() {
+    let h = Harness::<ExcalidrawPlugin>::default();
+    let file=Snapshot{file_id:"spacing".into(),path:"s.excalidraw".into(),bytes:br#"{"elements":[{"id":"a","type":"text","text":"x"}  , {"id":"b","type":"rectangle"} ],"files":{"f":{"dataURL":"A"}   , "g":{"dataURL":"B"}}}"#.to_vec(),..Snapshot::default()};
+    let parsed = h.parse(&file, ctx(1)).unwrap();
+    let mut rows = Vec::new();
+    accept(&mut rows, &parsed.row_changes);
+    let file = parsed.into_snapshot();
+    assert_eq!(
+        h.serialize(&file.file_id, &file.path, &rows, None)
+            .unwrap()
+            .snapshot()
+            .bytes,
+        file.bytes
+    );
+    let mut a = element(&rows, "a");
+    let mut p = payload(&a, "element_json");
+    p["text"] = json!("changed");
+    set_payload(&mut a, "element_json", p);
+    let out = h.serialize_changes(&file, &[change(&a)]).unwrap();
+    assert_eq!(
+        std::str::from_utf8(&out.snapshot().bytes).unwrap(),
+        std::str::from_utf8(&file.bytes)
+            .unwrap()
+            .replace("\"x\"", "\"changed\"")
+    );
+}
+
+#[test]
+fn qa_row_reorder_and_embedded_file_edit_keep_every_other_value() {
+    let (h, file, mut rows) = initial();
+    let (mut a, mut b) = (element(&rows, "a"), element(&rows, "b"));
+    let ak = a.row.get("order_key").unwrap().clone();
+    let bk = b.row.get("order_key").unwrap().clone();
+    a.row.insert("order_key", bk);
+    b.row.insert("order_key", ak);
+    let updates = [change(&a), change(&b)];
+    let out = h.serialize_changes(&file, &updates).unwrap();
+    accept(&mut rows, &updates);
+    let file = out.into_snapshot();
+    let mut expected = json(SOURCE.as_bytes());
+    expected["elements"].as_array_mut().unwrap().swap(0, 1);
+    assert_eq!(json(&file.bytes), expected);
+    let mut image = rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == core::FILE_SCHEMA_KEY)
+        .unwrap()
+        .clone();
+    let mut p = payload(&image, "file_json");
+    p["dataURL"] = json!("data:image/png;base64,BBBB");
+    set_payload(&mut image, "file_json", p);
+    let out = h.serialize_changes(&file, &[change(&image)]).unwrap();
+    assert_eq!(
+        std::str::from_utf8(&out.snapshot().bytes).unwrap(),
+        std::str::from_utf8(&file.bytes)
+            .unwrap()
+            .replace("base64,AAAA", "base64,BBBB")
+    );
+}
+
+#[test]
+fn qa_stale_or_absent_spelling_hints_never_override_payload_edits() {
+    let (h, file, rows) = initial();
+    for hint in [
+        sdk::TypedValue::Null,
+        sdk::TypedValue::Text("not json".into()),
+        sdk::TypedValue::Text(r#"{"id":"wrong","type":"text","x":9000}"#.into()),
+    ] {
+        let mut a = element(&rows, "a");
+        a.row.insert("source_json", hint);
+        let mut p = payload(&a, "element_json");
+        p["x"] = json!(777);
+        set_payload(&mut a, "element_json", p);
+        let out = h.serialize_changes(&file, &[change(&a)]).unwrap();
+        assert_eq!(json(&out.snapshot().bytes)["elements"][0]["x"], json!(777));
+        assert_eq!(json(&out.snapshot().bytes)["elements"][0]["id"], json!("a"));
+        assert_eq!(
+            json(&out.snapshot().bytes)["elements"][0]["custom"]["unicode"],
+            json!("λ")
+        );
+    }
+}
+
+#[test]
+fn qa_spelling_only_and_identical_file_edits_have_correct_effects() {
+    let (h, file, _) = initial();
+    for path in [&file.path, "renamed.excalidraw"] {
+        let out = h
+            .parse_changes(
+                &file,
+                path,
+                &[replace(&file, "\"x\": 1", "\"x\": 1.0")],
+                None,
+                ctx(2),
+            )
+            .unwrap();
+        assert_eq!(out.row_changes.len(), 1);
+        assert_eq!(out.row_changes[0].effect, sdk::ChangeEffect::FormatOnly);
+    }
+    let out = h
+        .parse_changes(
+            &file,
+            &file.path,
+            &[replace(&file, "untouched", "untouched")],
+            None,
+            ctx(2),
+        )
+        .unwrap();
+    assert!(out.row_changes.is_empty());
+    assert_eq!(out.snapshot().bytes, file.bytes);
+}
+
+#[test]
+fn qa_large_embedded_file_avoids_redundant_canonical_hint_and_roundtrips() {
+    let value = json!({"elements":[],"files":{"image":{"dataURL":format!("data:image/png;base64,{}","A".repeat(600*1024)),"mimeType":"image/png"}}});
+    for pretty in [false, true] {
+        let mut h = Harness::<ExcalidrawPlugin>::default();
+        if pretty {
+            h.max_batch_bytes = 2 * 1024 * 1024;
+        }
+        let bytes = if pretty {
+            serde_json::to_vec_pretty(&value).unwrap()
+        } else {
+            serde_json::to_vec(&value).unwrap()
+        };
+        let file = Snapshot {
+            file_id: "large".into(),
+            path: "large.excalidraw".into(),
+            bytes,
+            ..Snapshot::default()
+        };
+        let parsed = h.parse(&file, ctx(1)).unwrap();
+        let mut rows = Vec::new();
+        accept(&mut rows, &parsed.row_changes);
+        let image = rows
+            .iter()
+            .find(|r| r.schema_key.as_ref() == core::FILE_SCHEMA_KEY)
+            .unwrap();
+        assert_eq!(
+            matches!(image.row.get("source_json"), Some(sdk::TypedValue::Null)),
+            !pretty
+        );
+        let rendered = h.serialize(&file.file_id, &file.path, &rows, None).unwrap();
+        assert_eq!(rendered.snapshot().bytes, file.bytes);
+    }
+}
+
+#[test]
+fn qa_soft_delete_then_remove_all_children_retains_scene_metadata() {
+    let (h, file, mut rows) = initial();
+    let mut b = element(&rows, "b");
+    let mut p = payload(&b, "element_json");
+    p["isDeleted"] = json!(true);
+    set_payload(&mut b, "element_json", p);
+    b.row.insert("is_deleted", sdk::TypedValue::Boolean(true));
+    let changes = [change(&b)];
+    let out = h.serialize_changes(&file, &changes).unwrap();
+    accept(&mut rows, &changes);
+    let file = out.into_snapshot();
+    assert_eq!(json(&file.bytes)["elements"][1]["isDeleted"], json!(true));
+    let deletes = rows
+        .iter()
+        .filter(|r| r.schema_key.as_ref() != core::SCENE_SCHEMA_KEY)
+        .map(|r| {
+            let mut c = change(r);
+            c.row = None;
+            c
+        })
+        .collect::<Vec<_>>();
+    let out = h.serialize_changes(&file, &deletes).unwrap();
+    let mut expected = json(&file.bytes);
+    expected["elements"] = json!([]);
+    expected["files"] = json!({});
+    assert_eq!(json(&out.snapshot().bytes), expected);
+}
+
+#[test]
+fn qa_unrepresentable_jsonb_is_rejected_without_panicking_or_mutation() {
+    let h = Harness::<ExcalidrawPlugin>::default();
+    let file = Snapshot {
+        file_id: "invalid-jsonb".into(),
+        path: "invalid.excalidraw".into(),
+        bytes: br#"{"elements":[{"id":"a","type":"text","text":"\u0000"}]}"#.to_vec(),
+        ..Snapshot::default()
+    };
+    let before = file.clone();
+    assert!(h.parse(&file, ctx(1)).is_err());
+    assert_eq!(file, before);
+}

--- a/plugins/json/schema/json_array_item.json
+++ b/plugins/json/schema/json_array_item.json
@@ -47,6 +47,12 @@
       "description": "The JSON scalar value. Omitted when kind is object or array."
     },
     {
+      "name": "scalar_text",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact noncanonical scalar spelling, used only while it agrees with scalar_json."
+    },
+    {
       "name": "suffix_json",
       "type": "text",
       "nullable": true,

--- a/plugins/json/schema/json_object_member.json
+++ b/plugins/json/schema/json_object_member.json
@@ -52,6 +52,12 @@
       "description": "The JSON scalar value. Omitted when kind is object or array."
     },
     {
+      "name": "scalar_text",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact noncanonical scalar spelling, used only while it agrees with scalar_json."
+    },
+    {
       "name": "suffix_json",
       "type": "text",
       "nullable": true,

--- a/plugins/json/schema/json_root.json
+++ b/plugins/json/schema/json_root.json
@@ -34,6 +34,12 @@
       "description": "The JSON scalar value. Omitted for object and array roots."
     },
     {
+      "name": "scalar_text",
+      "type": "text",
+      "nullable": true,
+      "description": "Exact noncanonical scalar spelling, used only while it agrees with scalar_json."
+    },
+    {
       "name": "suffix_json",
       "type": "text",
       "nullable": true,

--- a/plugins/json/src/adapter_qa_tests.rs
+++ b/plugins/json/src/adapter_qa_tests.rs
@@ -1,0 +1,820 @@
+use super::*;
+use sdk::testing::{Harness, Snapshot};
+
+fn accept(
+    rows: &mut Vec<sdk::TypedRowRecord>,
+    transition: &sdk::testing::Transition,
+    creates: sdk::CreateContext,
+) {
+    if transition.replaces_all_rows {
+        rows.clear();
+    }
+    for change in &transition.row_changes {
+        let primary_key = change.local_ref.map_or_else(
+            || change.primary_key.clone(),
+            |local| vec![sdk::TypedValue::Uuid(creates.id(local))],
+        );
+        rows.retain(|r| r.schema_key != change.schema_key || r.primary_key != primary_key);
+        if let Some(mut row) = change.row.clone() {
+            if change.local_ref.is_some() {
+                row.insert("id", primary_key[0].clone());
+            }
+            rows.push(sdk::TypedRowRecord {
+                schema_key: change.schema_key.clone(),
+                schema_fingerprint: change.schema_fingerprint,
+                primary_key,
+                row,
+            });
+        }
+    }
+}
+
+fn parse(bytes: &[u8]) -> (Snapshot, Vec<sdk::TypedRowRecord>) {
+    let file = Snapshot {
+        file_id: "json-native".into(),
+        path: "data.json".into(),
+        bytes: bytes.to_vec(),
+        ..Snapshot::default()
+    };
+    let creates = sdk::CreateContext::from_namespace_bytes([0x61; 12]);
+    let parsed = Harness::<JsonPlugin>::default()
+        .parse(&file, creates)
+        .unwrap();
+    let mut rows = Vec::new();
+    accept(&mut rows, &parsed, creates);
+    (parsed.into_snapshot(), rows)
+}
+
+fn render(file: &Snapshot, rows: &[sdk::TypedRowRecord], warm: bool) -> sdk::testing::Transition {
+    Harness::<JsonPlugin>::default()
+        .serialize(&file.file_id, &file.path, rows, warm.then_some(file))
+        .unwrap()
+}
+
+#[test]
+fn native_exact_roundtrip_json_corpus() {
+    for bytes in [
+        b"null".as_slice(),
+        b" 1.2300e+04 \r\n",
+        b"-0",
+        b"{\r\n  \"a\" : 1.00 , \"b\": [ true, null, \"\\u0061\" ] \r\n}\n",
+        b"{\"empty\": { \n }, \"array\": [ \t ]}",
+        "{\"雪\":\"😀\",\"escaped\":\"\\uD83D\\uDE00\"}".as_bytes(),
+        b"[1,2,3]",
+        b"{\"a\":1,\"b\":2}",
+    ] {
+        let (file, rows) = parse(bytes);
+        for warm in [false, true] {
+            assert_eq!(
+                render(&file, &rows, warm).snapshot().bytes,
+                bytes,
+                "warm={warm} source={bytes:?}"
+            );
+        }
+        let no_op = Harness::<JsonPlugin>::default()
+            .serialize_changes(&file, &[])
+            .unwrap();
+        assert_eq!(no_op.snapshot().bytes, bytes);
+    }
+}
+
+#[test]
+fn native_repeated_file_changes_match_cold_rows_and_keep_array_ids() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) = parse(b"{\"items\":[{\"value\":1},{\"value\":2}],\"name\":\"old\"}");
+    for revision in 0..16 {
+        let value = if revision % 2 == 0 { "1000" } else { "2" };
+        let after =
+            format!("{{\"items\":[{{\"value\":1}},{{\"value\":{value}}}],\"name\":\"old\"}}")
+                .into_bytes();
+        let creates = sdk::CreateContext::from_namespace_bytes([0x70 + revision; 12]);
+        let prior_ids = rows
+            .iter()
+            .filter(|r| r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY)
+            .map(|r| r.primary_key.clone())
+            .collect::<Vec<_>>();
+        let start = file
+            .bytes
+            .windows(b"\"value\":".len())
+            .enumerate()
+            .rfind(|(_, w)| *w == b"\"value\":")
+            .unwrap()
+            .0
+            + b"\"value\":".len();
+        let end = start + file.bytes[start..].iter().position(|b| *b == b'}').unwrap();
+        let edit = sdk::FileEdit {
+            offset: start as u64,
+            delete_len: (end - start) as u64,
+            insert: value.as_bytes().to_vec(),
+        };
+        let changed = harness
+            .parse_changes(
+                &file,
+                &file.path,
+                std::slice::from_ref(&edit),
+                None,
+                creates,
+            )
+            .unwrap();
+        let mut cold = file.clone();
+        cold.state.clear();
+        let changed_cold = harness
+            .parse_changes(&cold, &cold.path, &[edit], Some(&rows), creates)
+            .unwrap();
+        let mut cold_rows = rows.clone();
+        accept(&mut cold_rows, &changed_cold, creates);
+        accept(&mut rows, &changed, creates);
+        file = changed.into_snapshot();
+        assert_eq!(file.bytes, after);
+        assert_eq!(render(&file, &rows, false).snapshot().bytes, after);
+        assert_eq!(render(&file, &cold_rows, false).snapshot().bytes, after);
+        let new_ids = rows
+            .iter()
+            .filter(|r| r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY)
+            .map(|r| r.primary_key.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(prior_ids, new_ids);
+    }
+}
+
+#[test]
+fn native_invalid_json_rolls_back() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, _) = parse(b"{\"value\":1}");
+    for bytes in [
+        b"".as_slice(),
+        b"{",
+        b"{\"value\":01}",
+        b"{\"value\":NaN}",
+        b"{\"value\":\"\\uD800\"}",
+        b"{\"value\":1} junk",
+    ] {
+        let saved = file.clone();
+        let result = harness.parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 0,
+                delete_len: file.bytes.len() as u64,
+                insert: bytes.to_vec(),
+            }],
+            None,
+            sdk::CreateContext::from_namespace_bytes([0x62; 12]),
+        );
+        assert!(result.is_err(), "accepted invalid JSON {bytes:?}");
+        assert_eq!(file, saved);
+    }
+}
+
+#[test]
+fn native_scalar_row_edits_preserve_spelling_and_refresh_offsets() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) =
+        parse(b"{ \"number\": 1.2300e+04, \"string\": \"\\u0041\", \"edit\": 1 }");
+    for replacement in [100000, 2, 300] {
+        let record = rows
+            .iter()
+            .find(|r| r.row.get("key") == Some(&sdk::TypedValue::Text("edit".into())))
+            .unwrap()
+            .clone();
+        let mut row = record.row.clone();
+        row.insert(
+            "scalar_json",
+            sdk::TypedValue::Jsonb(serde_json::json!(replacement).into()),
+        );
+        let change = sdk::TypedRowChange {
+            schema_key: record.schema_key,
+            schema_fingerprint: record.schema_fingerprint,
+            primary_key: record.primary_key,
+            row: Some(row),
+            local_ref: None,
+            effect: sdk::ChangeEffect::Content,
+        };
+        let transition = harness
+            .serialize_changes(&file, std::slice::from_ref(&change))
+            .unwrap();
+        let fake = &change;
+        rows.iter_mut()
+            .find(|r| r.schema_key == fake.schema_key && r.primary_key == fake.primary_key)
+            .unwrap()
+            .row = fake.row.clone().unwrap();
+        file = transition.into_snapshot();
+        assert!(String::from_utf8_lossy(&file.bytes).contains("1.2300e+04"));
+        assert!(String::from_utf8_lossy(&file.bytes).contains("\\u0041"));
+        assert_eq!(render(&file, &rows, false).snapshot().bytes, file.bytes);
+    }
+    let index = rows
+        .iter()
+        .position(|r| r.row.get("key") == Some(&sdk::TypedValue::Text("number".into())))
+        .unwrap();
+    let mut row = rows[index].row.clone();
+    row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(7).into()),
+    );
+    let change = sdk::TypedRowChange {
+        schema_key: rows[index].schema_key.clone(),
+        schema_fingerprint: rows[index].schema_fingerprint,
+        primary_key: rows[index].primary_key.clone(),
+        row: Some(row.clone()),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    };
+    let transition = harness.serialize_changes(&file, &[change]).unwrap();
+    rows[index].row = row;
+    file = transition.into_snapshot();
+    assert!(String::from_utf8_lossy(&file.bytes).contains("\"number\": 7,"));
+    assert_eq!(render(&file, &rows, false).snapshot().bytes, file.bytes);
+}
+
+#[test]
+fn native_object_insert_delete_and_rename_are_supported() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(b"{\"a\":1}");
+    let record = rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == OBJECT_MEMBER_SCHEMA_KEY)
+        .unwrap();
+    let mut insertion = record.row.clone();
+    insertion.insert("key", sdk::TypedValue::Text("new".into()));
+    let changes = [
+        sdk::TypedRowChange {
+            schema_key: record.schema_key.clone(),
+            schema_fingerprint: record.schema_fingerprint,
+            primary_key: record.primary_key.clone(),
+            row: None,
+            local_ref: None,
+            effect: sdk::ChangeEffect::Content,
+        },
+        sdk::TypedRowChange {
+            schema_key: record.schema_key.clone(),
+            schema_fingerprint: record.schema_fingerprint,
+            primary_key: vec![
+                sdk::TypedValue::Text("root".into()),
+                sdk::TypedValue::Text("new".into()),
+            ],
+            row: Some(insertion),
+            local_ref: None,
+            effect: sdk::ChangeEffect::Content,
+        },
+    ];
+    let deleted = harness.serialize_changes(&file, &changes[..1]).unwrap();
+    assert_eq!(deleted.snapshot().bytes, b"{}");
+    let inserted = harness.serialize_changes(&file, &changes[1..]).unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&inserted.snapshot().bytes).unwrap(),
+        serde_json::json!({"a":1,"new":1})
+    );
+    let renamed = harness.serialize_changes(&file, &changes).unwrap();
+    assert_eq!(renamed.snapshot().bytes, br#"{"new":1}"#);
+}
+
+#[test]
+fn native_array_insert_then_structural_reparse_preserves_durable_rows() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) = parse(b"[1,2]");
+    for (revision, next) in [b"[0,1,2]".as_slice(), b"[0,1,2,3]", b"[0,1,2,3,4]"]
+        .into_iter()
+        .enumerate()
+    {
+        let creates = sdk::CreateContext::from_namespace_bytes([0x80 + revision as u8; 12]);
+        let changed = harness
+            .parse_changes(
+                &file,
+                &file.path,
+                &[sdk::FileEdit {
+                    offset: 0,
+                    delete_len: file.bytes.len() as u64,
+                    insert: next.to_vec(),
+                }],
+                None,
+                creates,
+            )
+            .unwrap();
+        accept(&mut rows, &changed, creates);
+        file = changed.into_snapshot();
+        assert_eq!(render(&file, &rows, false).snapshot().bytes, next);
+    }
+}
+
+#[test]
+fn native_numeric_and_string_limits_return_errors_without_panicking() {
+    for source in [b"1e9999".as_slice(), b"\"\\u0000\"", b"{\"\\u0000\":1}"] {
+        let file = Snapshot {
+            file_id: "limits".into(),
+            path: "limits.json".into(),
+            bytes: source.to_vec(),
+            ..Snapshot::default()
+        };
+        let result = std::panic::catch_unwind(|| {
+            Harness::<JsonPlugin>::default()
+                .parse(&file, sdk::CreateContext::from_namespace_bytes([0x90; 12]))
+        });
+        assert!(result.is_ok(), "panicked on {source:?}");
+    }
+}
+
+#[test]
+fn native_array_insertion_identity_survives_later_scalar_and_reopen() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) = parse(b"[1,2]");
+    let creates = sdk::CreateContext::from_namespace_bytes([0xa1; 12]);
+    let first = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 1,
+                delete_len: 0,
+                insert: b"0,".to_vec(),
+            }],
+            None,
+            creates,
+        )
+        .unwrap();
+    accept(&mut rows, &first, creates);
+    file = first.into_snapshot();
+    let index = rows
+        .iter()
+        .position(|r| {
+            r.row.get("scalar_json") == Some(&sdk::TypedValue::Jsonb(serde_json::json!(0).into()))
+        })
+        .unwrap();
+    let inserted_id = rows[index].primary_key.clone();
+    let creates = sdk::CreateContext::from_namespace_bytes([0xa2; 12]);
+    let second = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 6,
+                delete_len: 0,
+                insert: b",3".to_vec(),
+            }],
+            None,
+            creates,
+        )
+        .unwrap();
+    assert!(!second.replaces_all_rows);
+    accept(&mut rows, &second, creates);
+    file = second.into_snapshot();
+    let index = rows
+        .iter()
+        .position(|r| {
+            r.row.get("scalar_json") == Some(&sdk::TypedValue::Jsonb(serde_json::json!(0).into()))
+        })
+        .unwrap();
+    assert_eq!(rows[index].primary_key, inserted_id);
+    assert_eq!(render(&file, &rows, false).snapshot().bytes, b"[0,1,2,3]");
+    let record = rows[index].clone();
+    let mut row = record.row;
+    row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(100).into()),
+    );
+    let write = harness
+        .serialize_changes(
+            &file,
+            &[sdk::TypedRowChange {
+                schema_key: record.schema_key,
+                schema_fingerprint: record.schema_fingerprint,
+                primary_key: record.primary_key,
+                row: Some(row),
+                local_ref: None,
+                effect: sdk::ChangeEffect::Content,
+            }],
+        )
+        .unwrap();
+    assert_eq!(write.snapshot().bytes, b"[100,1,2,3]");
+}
+
+#[test]
+fn native_scalar_spelling_change_is_format_only() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, _) = parse(b"{\"n\":1.00}");
+    let changed = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 5,
+                delete_len: 4,
+                insert: b"1e0".to_vec(),
+            }],
+            None,
+            sdk::CreateContext::from_namespace_bytes([0xb0; 12]),
+        )
+        .unwrap();
+    assert_eq!(changed.row_changes.len(), 1);
+    assert_eq!(changed.row_changes[0].effect, sdk::ChangeEffect::FormatOnly);
+}
+
+#[test]
+fn native_full_serialize_clears_prior_scalar_shift_state() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) = parse(b"{\"a\":1,\"b\":2}");
+    let creates = sdk::CreateContext::from_namespace_bytes([0xc1; 12]);
+    let changed = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 5,
+                delete_len: 1,
+                insert: b"10000".to_vec(),
+            }],
+            None,
+            creates,
+        )
+        .unwrap();
+    accept(&mut rows, &changed, creates);
+    file = changed.into_snapshot();
+    assert!(file.state.contains_key(SCALAR_SHIFTS_STATE));
+    file = render(&file, &rows, true).into_snapshot();
+    let record = rows
+        .iter()
+        .find(|r| r.row.get("key") == Some(&sdk::TypedValue::Text("b".into())))
+        .unwrap();
+    let mut row = record.row.clone();
+    row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(4).into()),
+    );
+    let changed = harness
+        .serialize_changes(
+            &file,
+            &[sdk::TypedRowChange {
+                schema_key: record.schema_key.clone(),
+                schema_fingerprint: record.schema_fingerprint,
+                primary_key: record.primary_key.clone(),
+                row: Some(row),
+                local_ref: None,
+                effect: sdk::ChangeEffect::Content,
+            }],
+        )
+        .unwrap();
+    assert_eq!(changed.snapshot().bytes, b"{\"a\":10000,\"b\":4}");
+}
+
+#[test]
+fn native_nested_array_identities_survive_structural_edits_and_cold_restore() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) = parse(b"{\"items\":[{\"inner\":[1,2]}]}");
+    for (revision, next) in [
+        b"{\"items\":[{\"inner\":[0,1,2]}]}".as_slice(),
+        b"{\"items\":[{\"inner\":[0,1,2]},{\"inner\":[3]}]}",
+        b"{\"items\":[{\"inner\":[3]},{\"inner\":[0,1,2]}]}",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let creates = sdk::CreateContext::from_namespace_bytes([0xd0 + revision as u8; 12]);
+        let changed = harness
+            .parse_changes(
+                &file,
+                &file.path,
+                &[sdk::FileEdit {
+                    offset: 0,
+                    delete_len: file.bytes.len() as u64,
+                    insert: next.to_vec(),
+                }],
+                None,
+                creates,
+            )
+            .unwrap();
+        accept(&mut rows, &changed, creates);
+        file = changed.into_snapshot();
+        assert_eq!(render(&file, &rows, false).snapshot().bytes, next);
+        file = render(&file, &rows, false).into_snapshot();
+        let record = rows
+            .iter()
+            .find(|r| {
+                r.row.get("scalar_json")
+                    == Some(&sdk::TypedValue::Jsonb(serde_json::json!(0).into()))
+            })
+            .unwrap()
+            .clone();
+        let mut row = record.row;
+        row.insert(
+            "scalar_json",
+            sdk::TypedValue::Jsonb(serde_json::json!(0).into()),
+        );
+        let changed = harness
+            .serialize_changes(
+                &file,
+                &[sdk::TypedRowChange {
+                    schema_key: record.schema_key,
+                    schema_fingerprint: record.schema_fingerprint,
+                    primary_key: record.primary_key,
+                    row: Some(row),
+                    local_ref: None,
+                    effect: sdk::ChangeEffect::Content,
+                }],
+            )
+            .unwrap();
+        assert_eq!(changed.snapshot().bytes, next);
+    }
+}
+
+#[test]
+fn native_corrupt_cache_rejects_without_panicking_or_mutation() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, rows) = parse(b"{\"a\":1}");
+    file.state
+        .insert(SCALAR_INDEX_STATE.to_vec(), SCALAR_INDEX_MAGIC.to_vec());
+    let record = rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == OBJECT_MEMBER_SCHEMA_KEY)
+        .unwrap();
+    let change = sdk::TypedRowChange {
+        schema_key: record.schema_key.clone(),
+        schema_fingerprint: record.schema_fingerprint,
+        primary_key: record.primary_key.clone(),
+        row: Some(record.row.clone()),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    };
+    let result = std::panic::catch_unwind(|| harness.serialize_changes(&file, &[change]));
+    assert!(result.is_ok(), "invalid state panicked");
+    assert!(result.unwrap().is_err());
+}
+
+#[test]
+fn native_paged_identities_restore_and_shrink_without_stale_pages() {
+    let mut harness = Harness::<JsonPlugin>::default();
+    harness.max_batch_bytes = 2 * 1024 * 1024;
+    let bytes = format!("[{}]", vec!["0"; 20_000].join(",")).into_bytes();
+    let file = Snapshot {
+        file_id: "large".into(),
+        path: "large.json".into(),
+        bytes,
+        ..Snapshot::default()
+    };
+    let creates = sdk::CreateContext::from_namespace_bytes([0xe0; 12]);
+    let file = harness.parse(&file, creates).unwrap().into_snapshot();
+    assert!(file.state.contains_key(&identity_page_key(1)));
+    let changed = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: (file.bytes.len() - 1) as u64,
+                delete_len: 0,
+                insert: b",1".to_vec(),
+            }],
+            None,
+            sdk::CreateContext::from_namespace_bytes([0xe1; 12]),
+        )
+        .unwrap();
+    assert!(changed.snapshot().bytes.ends_with(b",0,1]"));
+    let file = changed.into_snapshot();
+    let changed = harness
+        .parse_changes(
+            &file,
+            &file.path,
+            &[sdk::FileEdit {
+                offset: 0,
+                delete_len: file.bytes.len() as u64,
+                insert: b"[]".to_vec(),
+            }],
+            None,
+            sdk::CreateContext::from_namespace_bytes([0xe2; 12]),
+        )
+        .unwrap();
+    assert_eq!(changed.snapshot().bytes, b"[]");
+    assert!(!changed.snapshot().state.contains_key(&identity_page_key(1)));
+}
+
+#[test]
+fn native_duplicate_member_keys_fail_before_rows_are_accepted() {
+    for source in [
+        br#"{"a":1,"a":2}"#.as_slice(),
+        br#"{"a":1,"\u0061":2}"#,
+        br#"[{"a":1,"a":2}]"#,
+    ] {
+        let file = Snapshot {
+            file_id: "duplicates".into(),
+            path: "data.json".into(),
+            bytes: source.to_vec(),
+            ..Snapshot::default()
+        };
+        assert!(
+            Harness::<JsonPlugin>::default()
+                .parse(&file, sdk::CreateContext::from_namespace_bytes([0xf0; 12]))
+                .is_err(),
+            "accepted duplicate fields {source:?}"
+        );
+    }
+}
+
+fn upsert_record(record: &sdk::TypedRowRecord) -> sdk::TypedRowChange {
+    sdk::TypedRowChange {
+        schema_key: record.schema_key.clone(),
+        schema_fingerprint: record.schema_fingerprint,
+        primary_key: record.primary_key.clone(),
+        row: Some(record.row.clone()),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    }
+}
+
+fn delete_record(record: &sdk::TypedRowRecord) -> sdk::TypedRowChange {
+    let mut change = upsert_record(record);
+    change.row = None;
+    change
+}
+
+#[test]
+fn native_structural_batches_validate_the_final_tree_and_roll_back() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(br#"{"box":{"x":1},"keep":2}"#);
+    let member = |key: &str| {
+        rows.iter()
+            .find(|r| r.row.get("key") == Some(&sdk::TypedValue::Text(key.into())))
+            .unwrap()
+    };
+    let root = rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == ROOT_SCHEMA_KEY)
+        .unwrap();
+    let saved = file.clone();
+    let mut updated = upsert_record(member("keep"));
+    updated.row.as_mut().unwrap().insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(9).into()),
+    );
+    for batch in [
+        vec![delete_record(root)],
+        vec![updated, delete_record(member("box"))],
+    ] {
+        assert!(harness.serialize_changes(&file, &batch).is_err());
+        assert_eq!(file, saved);
+    }
+    // Parent-first deletion is valid when the same batch removes descendants.
+    let deleted = harness
+        .serialize_changes(
+            &file,
+            &[delete_record(member("box")), delete_record(member("x"))],
+        )
+        .unwrap();
+    assert_eq!(deleted.snapshot().bytes, br#"{"keep":2}"#);
+    // Or move the child to a surviving container in the same batch.
+    let mut moved = member("x").clone();
+    moved.primary_key[0] = sdk::TypedValue::Text("root".into());
+    moved.row.insert("parent_id", moved.primary_key[0].clone());
+    let moved = harness
+        .serialize_changes(
+            &file,
+            &[
+                delete_record(member("box")),
+                delete_record(member("x")),
+                upsert_record(&moved),
+            ],
+        )
+        .unwrap();
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&moved.snapshot().bytes).unwrap(),
+        serde_json::json!({"x":1,"keep":2})
+    );
+}
+
+#[test]
+fn native_array_reorder_move_and_cycles_preserve_identity_or_reject() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(br#"[[1],[2]]"#);
+    let arrays: Vec<_> = rows
+        .iter()
+        .filter(|r| {
+            r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY
+                && r.row.get("kind") == Some(&sdk::TypedValue::Text("array".into()))
+        })
+        .collect();
+    let mut a = arrays[0].clone();
+    let mut b = arrays[1].clone();
+    let order = a.row.get("order_key").unwrap().clone();
+    a.row
+        .insert("order_key", b.row.get("order_key").unwrap().clone());
+    b.row.insert("order_key", order);
+    let reordered = harness
+        .serialize_changes(&file, &[upsert_record(&a), upsert_record(&b)])
+        .unwrap();
+    assert_eq!(reordered.snapshot().bytes, b"[[2],[1]]");
+    let mut changed_rows = rows.clone();
+    for row in &mut changed_rows {
+        if row.primary_key == a.primary_key {
+            *row = a.clone();
+        }
+        if row.primary_key == b.primary_key {
+            *row = b.clone();
+        }
+    }
+    let file = reordered.into_snapshot();
+    assert_eq!(
+        render(&file, &changed_rows, false).snapshot().bytes,
+        file.bytes
+    );
+    let id_text = |r: &sdk::TypedRowRecord| match &r.primary_key[0] {
+        sdk::TypedValue::Uuid(id) => sdk::TypedValue::Text(id.to_string()),
+        _ => panic!("uuid"),
+    };
+    a.row.insert("parent_id", id_text(&b));
+    b.row.insert("parent_id", id_text(&a));
+    assert!(
+        harness
+            .serialize_changes(&file, &[upsert_record(&a), upsert_record(&b)])
+            .is_err()
+    );
+    a.row
+        .insert("parent_id", sdk::TypedValue::Text("missing".into()));
+    assert!(
+        harness
+            .serialize_changes(&file, &[upsert_record(&a)])
+            .is_err()
+    );
+}
+
+#[test]
+fn native_scalar_container_conversion_and_empty_container_insertion() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, _) = parse(b" 0\n");
+    let (_, target_rows) = parse(br#"{"child":1}"#);
+    let changes: Vec<_> = target_rows.iter().map(upsert_record).collect();
+    let converted = harness.serialize_changes(&file, &changes).unwrap();
+    assert_eq!(converted.snapshot().bytes, br#"{"child":1}"#);
+    let (_, scalar_rows) = parse(b"true");
+    let mut back: Vec<_> = target_rows
+        .iter()
+        .filter(|r| r.schema_key.as_ref() != ROOT_SCHEMA_KEY)
+        .map(delete_record)
+        .collect();
+    back.push(upsert_record(&scalar_rows[0]));
+    let converted = harness
+        .serialize_changes(converted.snapshot(), &back)
+        .unwrap();
+    assert_eq!(converted.snapshot().bytes, b"true");
+    let (empty, _) = parse(b"{  }");
+    let member = target_rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == OBJECT_MEMBER_SCHEMA_KEY)
+        .unwrap();
+    let inserted = harness
+        .serialize_changes(&empty, &[upsert_record(member)])
+        .unwrap();
+    assert_eq!(inserted.snapshot().bytes, br#"{"child":1}"#);
+    let mut edited = member.clone();
+    edited.row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(7).into()),
+    );
+    let scalar = harness
+        .serialize_changes(inserted.snapshot(), &[upsert_record(&edited)])
+        .unwrap();
+    assert!(
+        scalar.file_replacement.is_none(),
+        "scalar fast path must survive a structural rebuild"
+    );
+    assert_eq!(scalar.snapshot().bytes, br#"{"child":7}"#);
+}
+
+#[test]
+fn native_structural_edit_preserves_unmodified_spelling_and_streams_large_files() {
+    let mut harness = Harness::<JsonPlugin>::default();
+    harness.max_batch_bytes = 2 * 1024 * 1024;
+    let source = format!(
+        r#"{{"keep":1.2300e+04,"escaped":"\u0041","large":"{}","remove":0}}"#,
+        "x".repeat(3 * 1024 * 1024)
+    );
+    // Cold admission permits oversized values; serialize_changes itself emits
+    // a streamed replacement using the ordinary page budget.
+    harness.max_batch_bytes = 8 * 1024 * 1024;
+    let raw = Snapshot {
+        file_id: "large".into(),
+        path: "large.json".into(),
+        bytes: source.into_bytes(),
+        ..Snapshot::default()
+    };
+    let creates = sdk::CreateContext::from_namespace_bytes([5; 12]);
+    let parsed = harness.parse(&raw, creates).unwrap();
+    let mut rows = Vec::new();
+    accept(&mut rows, &parsed, creates);
+    let file = parsed.into_snapshot();
+    let removed = rows
+        .iter()
+        .find(|r| r.row.get("key") == Some(&sdk::TypedValue::Text("remove".into())))
+        .unwrap();
+    harness.max_batch_bytes = 2 * 1024 * 1024;
+    let transition = harness
+        .serialize_changes(&file, &[delete_record(removed)])
+        .unwrap();
+    let output = std::str::from_utf8(&transition.snapshot().bytes).unwrap();
+    assert!(output.contains("1.2300e+04"));
+    assert!(output.contains(r#""escaped":"\u0041""#));
+    assert!(transition.file_replacement.is_some());
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(output).unwrap()["large"]
+            .as_str()
+            .unwrap()
+            .len(),
+        3 * 1024 * 1024
+    );
+}

--- a/plugins/json/src/adapter_qa_tests.rs
+++ b/plugins/json/src/adapter_qa_tests.rs
@@ -55,6 +55,9 @@ fn render(file: &Snapshot, rows: &[sdk::TypedRowRecord], warm: bool) -> sdk::tes
 fn native_exact_roundtrip_json_corpus() {
     for bytes in [
         b"null".as_slice(),
+        b"1.0",
+        b"100.0",
+        b"[1.0,100.0,-0.0]",
         b" 1.2300e+04 \r\n",
         b"-0",
         b"{\r\n  \"a\" : 1.00 , \"b\": [ true, null, \"\\u0061\" ] \r\n}\n",

--- a/plugins/json/src/core.rs
+++ b/plugins/json/src/core.rs
@@ -13,7 +13,7 @@ pub const ARRAY_ITEM_SCHEMA_KEY: &str = "json_array_item";
 const ROOT_ID: &str = "root";
 const OBJECT_CONTAINER_DOMAIN: &[u8] = b"lix-json-object-container\0";
 const NODES_PER_SPAN_CHUNK: usize = 512;
-const SCALAR_ONLY_SEMANTIC_WRITE: &str = "JSON semantic writes support existing scalar values only; use a file byte write for additions, deletions, containers, moves, ordering, or layout changes";
+const REQUIRES_TREE_REBUILD: &str = "JSON row change requires a full tree rebuild";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IdNamespace(pub [u8; 16]);
@@ -583,7 +583,7 @@ impl Node {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum RowIdentity {
     Snapshot,
     Object { parent_id: Arc<str>, key: Arc<str> },
@@ -1141,6 +1141,54 @@ struct DocumentInner {
 }
 
 impl Document {
+    pub fn identity_checkpoint(&self) -> Vec<(Option<String>, String)> {
+        self.0
+            .nodes
+            .iter()
+            .map(|node| {
+                let id = match &node.relation {
+                    NodeRelation::Array { id, .. } => Some(id.to_string()),
+                    _ => None,
+                };
+                (id, relation_order(&node.relation).to_owned())
+            })
+            .collect()
+    }
+
+    pub fn open_file_with_checkpoint(
+        bytes: Vec<u8>,
+        namespace: IdNamespace,
+        checkpoint: &[(Option<String>, String)],
+    ) -> Result<Self, String> {
+        let mut nodes = JsonParser::parse(&bytes, namespace)?;
+        if nodes.len() != checkpoint.len() {
+            return Err("JSON identity checkpoint does not match accepted nodes".to_owned());
+        }
+        for (ordinal, (id, order)) in checkpoint.iter().enumerate() {
+            match (&mut nodes[ordinal].relation, id) {
+                (NodeRelation::Array { id: current, .. }, Some(id)) => {
+                    parse_uuid(id, "checkpoint id")?;
+                    *current = Arc::from(id.as_str());
+                }
+                (NodeRelation::Snapshot | NodeRelation::Object { .. }, None) => {}
+                _ => return Err("JSON identity checkpoint relation mismatch".to_owned()),
+            }
+            if nodes[ordinal].parent.is_some() {
+                parse_order_key(order)?;
+                set_relation_order(&mut nodes[ordinal].relation, order);
+            } else if !order.is_empty() {
+                return Err("JSON root checkpoint cannot have an order key".to_owned());
+            }
+            if let Some(parent) = nodes[ordinal].parent {
+                let parent_id = nodes[parent as usize]
+                    .container_id()
+                    .ok_or_else(|| "JSON checkpoint parent is not a container".to_owned())?;
+                refresh_parent(&mut nodes, ordinal as u32, parent_id);
+            }
+        }
+        Self::from_parts(PersistentBlob::from_shared(Arc::new(bytes))?, nodes, 0)
+    }
+
     pub fn open_file(
         bytes: Vec<u8>,
         _path: Option<&str>,
@@ -1430,6 +1478,7 @@ impl Document {
         if let Some(value) = empty_json {
             row.insert("empty_json".to_owned(), sdk::TypedValue::Text(value));
         }
+        set_scalar_text(&mut row, scalar.as_bytes())?;
         complete_nullable_fields(&mut row, schema_key);
         Ok(Some(RowChange {
             schema_key: schema_key.into(),
@@ -1445,16 +1494,16 @@ impl Document {
         change: &RowChange,
     ) -> Result<Option<ByteEdit>, String> {
         let current = Self::scalar_change_from_arena(metadata.clone(), current_scalar)?
-            .ok_or_else(|| SCALAR_ONLY_SEMANTIC_WRITE.to_owned())?;
+            .ok_or_else(|| REQUIRES_TREE_REBUILD.to_owned())?;
         if current.schema_key != change.schema_key || current.row_pk != change.row_pk {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         }
         let Some(changed_row) = &change.row else {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         };
         let current_row = current
             .row
-            .ok_or_else(|| SCALAR_ONLY_SEMANTIC_WRITE.to_owned())?;
+            .ok_or_else(|| REQUIRES_TREE_REBUILD.to_owned())?;
         let mut strings = HashSet::new();
         let changed = SemanticRow::parse(
             RowRecord {
@@ -1481,12 +1530,7 @@ impl Document {
         if !changed.same_location(&current) {
             return Err("indexed semantic row location changed".to_owned());
         }
-        let scalar = serde_json::to_vec(
-            changed
-                .scalar_json()
-                .ok_or_else(|| "scalar JSON row is missing scalar_json".to_owned())?,
-        )
-        .map_err(|error| format!("failed to serialize scalar_json: {error}"))?;
+        let scalar = changed.scalar_bytes()?;
         if parse_complete_scalar(&scalar)? != changed.kind() {
             return Err("scalar_json does not match the row kind".to_owned());
         }
@@ -1609,7 +1653,12 @@ impl Document {
         let changes = if before_row == after_row {
             Vec::new()
         } else {
-            vec![RowChange::upsert(&identity, after_row)]
+            let effect = if rows_equal_without_layout(&before_row, &after_row) {
+                ChangeEffect::FormatOnly
+            } else {
+                ChangeEffect::Content
+            };
+            vec![RowChange::upsert_with_effect(&identity, after_row, effect)]
         };
         Ok(Some((after, changes)))
     }
@@ -1642,6 +1691,15 @@ impl Document {
                 changes.push(RowChange::upsert(&identity, row));
             }
         }
+        // Historical file observations can replay this delta as renderer input.
+        // The host requires schema/key order; HashMap iteration is not stable.
+        changes.sort_by_cached_key(|change| {
+            (
+                change.schema_key.clone(),
+                RowIdentity::from_parts(&change.schema_key, &change.row_pk)
+                    .expect("document diff contains valid JSON identities"),
+            )
+        });
         Ok((after, changes))
     }
 
@@ -1684,9 +1742,17 @@ impl Document {
             return Ok((self.clone(), Vec::new()));
         }
         let mut edits = Vec::with_capacity(changes.len());
+        let mut seen = HashSet::with_capacity(changes.len());
         for change in changes {
-            if let Some(edit) = self.scalar_row_edit(change)? {
-                edits.push(edit);
+            if !seen.insert(RowIdentity::from_parts(&change.schema_key, &change.row_pk)?) {
+                return self.rebuild_rows(changes);
+            }
+            match self.scalar_row_edit(change) {
+                Ok(Some(edit)) => edits.push(edit),
+                Ok(None) => {}
+                // The full-tree path validates the entire batch, including
+                // malformed rows; a rejected scalar shortcut is not acceptance.
+                Err(_) => return self.rebuild_rows(changes),
             }
         }
         edits.sort_unstable_by_key(|edit| edit.offset);
@@ -1696,7 +1762,7 @@ impl Document {
                 .checked_add(pair[0].delete_len)
                 .is_none_or(|end| end > pair[1].offset)
         }) {
-            return Err("JSON semantic write batch contains overlapping scalar edits".to_owned());
+            return self.rebuild_rows(changes);
         }
         if edits.is_empty() {
             return Ok((self.clone(), edits));
@@ -1713,10 +1779,39 @@ impl Document {
         Ok((after, edits))
     }
 
+    fn rebuild_rows(&self, changes: &[RowChange]) -> Result<(Self, Vec<ByteEdit>), String> {
+        let mut rows = self.rows_by_identity()?;
+        for change in changes {
+            let identity = RowIdentity::from_parts(&change.schema_key, &change.row_pk)?;
+            match &change.row {
+                Some(row) => {
+                    rows.insert(identity, row.clone());
+                }
+                None => {
+                    rows.remove(&identity);
+                }
+            }
+        }
+        let mut builder = RowImportBuilder::new();
+        for (identity, row) in rows {
+            builder.push(RowRecord {
+                schema_key: identity.schema_key().into(),
+                row_pk: identity.row_pk(),
+                row,
+            })?;
+        }
+        let (successor, mut edit) = builder.finish()?;
+        if self.bytes_equal(&edit.insert) {
+            return Ok((successor, Vec::new()));
+        }
+        edit.delete_len = self.byte_len() as u64;
+        Ok((successor, vec![edit]))
+    }
+
     fn scalar_row_edit(&self, change: &RowChange) -> Result<Option<ByteEdit>, String> {
         let identity = RowIdentity::from_parts(&change.schema_key, &change.row_pk)?;
         let Some(&node_index) = self.0.lookup.get(&identity_fingerprint(&identity)) else {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         };
         let node_index = usize::try_from(node_index).expect("u32 fits usize");
         let node = &self.0.nodes[node_index];
@@ -1724,10 +1819,10 @@ impl Document {
             return Err("JSON row identity fingerprint collision".to_owned());
         }
         if node.kind.is_container() {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         }
         let Some(changed_row) = &change.row else {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         };
         let mut strings = HashSet::new();
         let row = SemanticRow::parse(
@@ -1739,7 +1834,7 @@ impl Document {
             &mut strings,
         )?;
         if row.identity() != identity || row.kind().is_container() {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         }
         let current = SemanticRow::parse(
             RowRecord {
@@ -1750,13 +1845,9 @@ impl Document {
             &mut strings,
         )?;
         if !row.same_location(&current) {
-            return Err(SCALAR_ONLY_SEMANTIC_WRITE.to_owned());
+            return Err(REQUIRES_TREE_REBUILD.to_owned());
         }
-        let scalar = serde_json::to_vec(
-            row.scalar_json()
-                .ok_or_else(|| "scalar JSON row is missing scalar_json".to_owned())?,
-        )
-        .map_err(|error| format!("failed to serialize scalar_json: {error}"))?;
+        let scalar = row.scalar_bytes()?;
         let scalar_kind = parse_complete_scalar(&scalar)?;
         if scalar_kind != row.kind() {
             return Err("scalar_json does not match the row kind".to_owned());
@@ -1885,6 +1976,7 @@ enum SemanticRow {
     Snapshot {
         kind: NodeKind,
         scalar_json: Option<Value>,
+        scalar_text: Option<String>,
         layout: Option<Arc<NodeLayout>>,
     },
     Object {
@@ -1893,6 +1985,7 @@ enum SemanticRow {
         order_key: Arc<str>,
         kind: NodeKind,
         scalar_json: Option<Value>,
+        scalar_text: Option<String>,
         container_id: Option<Arc<str>>,
         layout: Option<Arc<NodeLayout>>,
     },
@@ -1902,6 +1995,7 @@ enum SemanticRow {
         order_key: Arc<str>,
         kind: NodeKind,
         scalar_json: Option<Value>,
+        scalar_text: Option<String>,
         layout: Option<Arc<NodeLayout>>,
     },
 }
@@ -1915,6 +2009,10 @@ impl SemanticRow {
         let row = &record.row;
         let kind = required_text(row, "kind").and_then(NodeKind::parse)?;
         let scalar_json = optional_jsonb(row, "scalar_json")?;
+        let scalar_text = optional_text(row, "scalar_text")?;
+        if let Some(text) = &scalar_text {
+            parse_complete_scalar(text.as_bytes())?;
+        }
         validate_scalar_fields(kind, scalar_json.as_ref())?;
         let layout = parse_row_layout(row, &identity, kind, strings)?;
         match identity {
@@ -1922,7 +2020,13 @@ impl SemanticRow {
                 require_fields(
                     row,
                     &["id", "kind"],
-                    &["scalar_json", "prefix_json", "suffix_json", "empty_json"],
+                    &[
+                        "scalar_json",
+                        "scalar_text",
+                        "prefix_json",
+                        "suffix_json",
+                        "empty_json",
+                    ],
                 )?;
                 if required_text(row, "id")? != ROOT_ID {
                     return Err("json_root row id must be \"root\"".to_owned());
@@ -1930,6 +2034,7 @@ impl SemanticRow {
                 Ok(Self::Snapshot {
                     kind,
                     scalar_json,
+                    scalar_text,
                     layout,
                 })
             }
@@ -1939,6 +2044,7 @@ impl SemanticRow {
                     &["parent_id", "key", "order_key", "kind"],
                     &[
                         "scalar_json",
+                        "scalar_text",
                         "container_id",
                         "prefix_json",
                         "suffix_json",
@@ -1969,6 +2075,7 @@ impl SemanticRow {
                     order_key: intern_string(strings, &order_key),
                     kind,
                     scalar_json,
+                    scalar_text,
                     container_id: container_id
                         .as_deref()
                         .map(|value| intern_string(strings, value)),
@@ -1979,7 +2086,13 @@ impl SemanticRow {
                 require_fields(
                     row,
                     &["id", "parent_id", "order_key", "kind"],
-                    &["scalar_json", "prefix_json", "suffix_json", "empty_json"],
+                    &[
+                        "scalar_json",
+                        "scalar_text",
+                        "prefix_json",
+                        "suffix_json",
+                        "empty_json",
+                    ],
                 )?;
                 if required_uuid(row, "id")?.to_string() != id.as_ref() {
                     return Err("json_array_item row ID does not match its key".to_owned());
@@ -1992,6 +2105,7 @@ impl SemanticRow {
                     order_key: intern_string(strings, &order_key),
                     kind,
                     scalar_json,
+                    scalar_text,
                     layout,
                 })
             }
@@ -2046,10 +2160,10 @@ impl SemanticRow {
         else {
             return Ok(());
         };
-        if has_children {
-            return Err("JSON non-empty container cannot carry empty_json".to_owned());
+        // Inserting the first child invalidates this empty-container hint.
+        if !has_children {
+            output.extend_from_slice(empty.as_bytes());
         }
-        output.extend_from_slice(empty.as_bytes());
         Ok(())
     }
 
@@ -2060,6 +2174,28 @@ impl SemanticRow {
         {
             output.extend_from_slice(suffix.as_bytes());
         }
+    }
+
+    fn scalar_bytes(&self) -> Result<Vec<u8>, String> {
+        let value = self
+            .scalar_json()
+            .ok_or_else(|| "JSON scalar has no scalar_json".to_owned())?;
+        let text = match self {
+            Self::Snapshot { scalar_text, .. }
+            | Self::Object { scalar_text, .. }
+            | Self::Array { scalar_text, .. } => scalar_text.as_deref(),
+        };
+        if let Some(text) = text {
+            let lexical: Value = serde_json::from_str(text)
+                .map_err(|error| format!("invalid scalar_text: {error}"))?;
+            if sdk::TypedValue::Jsonb(lexical.into())
+                == sdk::TypedValue::Jsonb(value.clone().into())
+            {
+                return Ok(text.as_bytes().to_vec());
+            }
+        }
+        serde_json::to_vec(value)
+            .map_err(|error| format!("failed to serialize scalar_json: {error}"))
     }
 
     fn scalar_json(&self) -> Option<&Value> {
@@ -2321,12 +2457,7 @@ impl SemanticModel {
                 }
                 output.push(b']');
             }
-            _ => serde_json::to_writer(
-                &mut *output,
-                row.scalar_json()
-                    .ok_or_else(|| "JSON scalar has no scalar_json".to_owned())?,
-            )
-            .map_err(|error| format!("failed to serialize scalar_json: {error}"))?,
+            _ => output.extend_from_slice(&row.scalar_bytes()?),
         }
         if let Some(first) = rendered_children.first().copied() {
             nodes[usize::try_from(node_index).expect("u32 fits usize")].first_child = Some(first);
@@ -2373,7 +2504,14 @@ fn typed_node_row(
             )
         }
     };
-    typed_row_for_node(node, scalar)
+    let mut row = typed_row_for_node(node, scalar)?;
+    if !node.kind.is_container() {
+        let raw = blob.range(value_start, value_start + value_len)?;
+        set_scalar_text(&mut row, &raw)?;
+    } else {
+        row.insert("scalar_text", sdk::TypedValue::Null);
+    }
+    Ok(row)
 }
 fn typed_row_for_node(node: &Node, scalar: Option<Value>) -> Result<sdk::TypedRow, String> {
     static ROOT_COLUMNS: OnceLock<Vec<Arc<str>>> = OnceLock::new();
@@ -2519,8 +2657,32 @@ fn typed_row_for_node(node: &Node, scalar: Option<Value>) -> Result<sdk::TypedRo
     sdk::TypedRow::from_sorted_entries(entries).map_err(str::to_owned)
 }
 
+fn set_scalar_text(row: &mut sdk::TypedRow, raw: &[u8]) -> Result<(), String> {
+    let Some(sdk::TypedValue::Jsonb(value)) = row.get("scalar_json") else {
+        return Err("missing scalar_json".to_owned());
+    };
+    let canonical = serde_json::to_vec(value).map_err(|error| error.to_string())?;
+    let spelling = if canonical == raw {
+        sdk::TypedValue::Null
+    } else {
+        sdk::TypedValue::Text(
+            std::str::from_utf8(raw)
+                .map_err(|error| error.to_string())?
+                .to_owned(),
+        )
+    };
+    row.insert("scalar_text", spelling);
+    Ok(())
+}
+
 fn complete_nullable_fields(row: &mut sdk::TypedRow, schema_key: &str) {
-    for name in ["empty_json", "prefix_json", "scalar_json", "suffix_json"] {
+    for name in [
+        "empty_json",
+        "prefix_json",
+        "scalar_json",
+        "scalar_text",
+        "suffix_json",
+    ] {
         if !row.contains_key(name) {
             row.insert(name, sdk::TypedValue::Null);
         }
@@ -2534,10 +2696,10 @@ fn insert_text(row: &mut sdk::TypedRow, name: &str, value: &str) {
     row.insert(name.to_owned(), sdk::TypedValue::Text(value.to_owned()));
 }
 
-fn rows_equal_without_layout(before: &sdk::TypedRow, after: &sdk::TypedRow) -> bool {
+pub(crate) fn rows_equal_without_layout(before: &sdk::TypedRow, after: &sdk::TypedRow) -> bool {
     let mut before = before.clone();
     let mut after = after.clone();
-    for name in ["prefix_json", "suffix_json", "empty_json"] {
+    for name in ["prefix_json", "suffix_json", "empty_json", "scalar_text"] {
         before.remove(name);
         after.remove(name);
     }
@@ -3309,13 +3471,15 @@ fn parse_row_layout(
     kind: NodeKind,
     strings: &mut HashSet<Arc<str>>,
 ) -> Result<Option<Arc<NodeLayout>>, String> {
-    let prefix_json = optional_text(row, "prefix_json")?;
+    let mut prefix_json = optional_text(row, "prefix_json")?;
     let suffix_json = optional_text(row, "suffix_json")?;
     let empty_json = optional_text(row, "empty_json")?;
 
     if let Some(prefix) = prefix_json.as_deref() {
         match identity {
-            RowIdentity::Object { key, .. } => validate_object_prefix(prefix, key)?,
+            RowIdentity::Object { key, .. } => {
+                prefix_json = Some(normalize_object_prefix(prefix, key)?);
+            }
             RowIdentity::Snapshot | RowIdentity::Array(_) => {
                 if !is_json_whitespace(prefix) {
                     return Err(
@@ -3332,9 +3496,6 @@ fn parse_row_layout(
         return Err("JSON suffix_json must contain only JSON whitespace".to_owned());
     }
     if let Some(empty) = empty_json.as_deref() {
-        if !kind.is_container() {
-            return Err("JSON scalar row cannot carry empty_json".to_owned());
-        }
         if !is_json_whitespace(empty) {
             return Err("JSON empty_json must contain only JSON whitespace".to_owned());
         }
@@ -3347,14 +3508,16 @@ fn parse_row_layout(
         suffix_json: suffix_json
             .as_deref()
             .map(|value| intern_string(strings, value)),
+        // Empty-container whitespace becomes obsolete on scalar conversion.
         empty_json: empty_json
             .as_deref()
+            .filter(|_| kind.is_container())
             .map(|value| intern_string(strings, value)),
     };
     Ok((!layout.is_empty()).then(|| Arc::new(layout)))
 }
 
-fn validate_object_prefix(prefix: &str, expected_key: &str) -> Result<(), String> {
+fn normalize_object_prefix(prefix: &str, expected_key: &str) -> Result<String, String> {
     let bytes = prefix.as_bytes();
     let mut cursor = 0usize;
     skip_json_whitespace(bytes, &mut cursor);
@@ -3363,9 +3526,6 @@ fn validate_object_prefix(prefix: &str, expected_key: &str) -> Result<(), String
         .map_err(|error| format!("invalid JSON object prefix_json: {error}"))?;
     let key: String = serde_json::from_slice(&bytes[key_start..key_end])
         .map_err(|error| format!("invalid JSON object prefix_json key: {error}"))?;
-    if key != expected_key {
-        return Err("JSON object prefix_json key does not match the row key".to_owned());
-    }
     cursor = key_end;
     skip_json_whitespace(bytes, &mut cursor);
     if bytes.get(cursor) != Some(&b':') {
@@ -3376,7 +3536,19 @@ fn validate_object_prefix(prefix: &str, expected_key: &str) -> Result<(), String
     if cursor != bytes.len() {
         return Err("JSON object prefix_json must end immediately before its value".to_owned());
     }
-    Ok(())
+    if key == expected_key {
+        return Ok(prefix.to_owned());
+    }
+    // A rename changes the semantic key, but the row may retain its old
+    // formatting hint. Keep whitespace and replace only the encoded key.
+    let encoded = serde_json::to_string(expected_key)
+        .map_err(|error| format!("failed to encode JSON object key: {error}"))?;
+    Ok(format!(
+        "{}{}{}",
+        &prefix[..key_start],
+        encoded,
+        &prefix[key_end..]
+    ))
 }
 
 fn skip_json_whitespace(bytes: &[u8], cursor: &mut usize) {

--- a/plugins/json/src/core.rs
+++ b/plugins/json/src/core.rs
@@ -2661,8 +2661,8 @@ fn set_scalar_text(row: &mut sdk::TypedRow, raw: &[u8]) -> Result<(), String> {
     let Some(sdk::TypedValue::Jsonb(value)) = row.get("scalar_json") else {
         return Err("missing scalar_json".to_owned());
     };
-    let canonical = serde_json::to_vec(value).map_err(|error| error.to_string())?;
-    let spelling = if canonical == raw {
+    let canonical = value.to_json_string().map_err(|error| error.to_string())?;
+    let spelling = if canonical.as_bytes() == raw {
         sdk::TypedValue::Null
     } else {
         sdk::TypedValue::Text(

--- a/plugins/json/src/lib.rs
+++ b/plugins/json/src/lib.rs
@@ -8,12 +8,14 @@ use core::{
     IdNamespace, OBJECT_MEMBER_SCHEMA_KEY, ROOT_SCHEMA_KEY, RowChange, RowImportBuilder, RowRecord,
 };
 use lix::plugin as sdk;
+use sdk::StateOutput;
 use std::sync::OnceLock;
 
 struct JsonPlugin;
 
 const SCALAR_INDEX_STATE: &[u8] = b"json/scalar-index";
 const SCALAR_SHIFTS_STATE: &[u8] = b"json/scalar-shifts";
+const NODE_IDENTITIES_STATE: &[u8] = b"json/node-identities";
 const ID_NAMESPACE_STATE: &[u8] = b"json/id-namespace";
 const SCALAR_INDEX_MAGIC: &[u8; 4] = b"JSS3";
 const SCALAR_INDEX_HEADER_BYTES: u32 = 16;
@@ -77,10 +79,11 @@ fn cold_parse_changes(
             insert,
         })
         .collect::<Vec<_>>();
-    let (_, changes) = document
+    let (successor, changes) = document
         .file_changed(&splices, create_namespace)
         .map_err(sdk::Error::invalid_input)?;
     sink.put_state(ID_NAMESPACE_STATE, &accepted_namespace.0[..12])?;
+    store_scalar_state(sink, &successor)?;
     emit_changes(changes.into_iter().map(Ok), update.creates, sink)?;
     Ok(())
 }
@@ -119,15 +122,14 @@ impl sdk::FileProjection for JsonPlugin {
         let namespace = read_namespace(&update.before, ID_NAMESPACE_STATE)?
             .or_else(|| namespace_from_changes(&changes))
             .unwrap_or_else(|| IdNamespace::from_halves(0, 0));
-        let document = Document::open_file(before, Some(update.path), namespace)
-            .map(|(document, _)| document)
-            .map_err(sdk::Error::invalid_input)?;
-        let (_, edits) = document
+        let document = open_cached_document(&update.before, before, namespace)?;
+        let (successor, edits) = document
             .rows_changed(&changes)
             .map_err(sdk::Error::invalid_input)?;
-        for edit in edits {
-            sink.replace(edit.offset, edit.delete_len, &edit.insert)?;
+        if !edits.is_empty() {
+            sink.replace_all(&successor.bytes())?;
         }
+        store_scalar_state(sink, &successor)?;
         Ok(())
     }
 
@@ -203,23 +205,10 @@ impl sdk::FileProjection for JsonPlugin {
         }
 
         let before_bytes = update.before.read_all()?;
-        let document =
-            Document::open_file(before_bytes, Some(update.before_path), accepted_namespace)
-                .map(|(document, _)| document)
-                .map_err(sdk::Error::invalid_input)?;
+        let document = open_cached_document(&update.before, before_bytes, accepted_namespace)?;
         let (successor, changes) = document
             .file_changed(&splices, create_namespace)
             .map_err(sdk::Error::invalid_input)?;
-        let (old_index_page_count, old_scalar_page_count) =
-            scalar_page_counts_root(&update.before)?;
-        sink.delete_state(SCALAR_INDEX_STATE)?;
-        for ordinal in 0..old_index_page_count {
-            sink.delete_state(&scalar_index_page_key(ordinal))?;
-        }
-        for ordinal in 0..old_scalar_page_count {
-            sink.delete_state(&scalar_page_key(ordinal))?;
-        }
-        sink.delete_state(SCALAR_SHIFTS_STATE)?;
         store_scalar_state(sink, &successor)?;
         emit_changes(changes.into_iter().map(Ok), update.creates, sink)?;
         Ok(())
@@ -303,12 +292,73 @@ fn apply_file_splices(mut bytes: Vec<u8>, splices: &[FileEdit<'_>]) -> sdk::Resu
     Ok(bytes)
 }
 
+fn identity_page_key(ordinal: usize) -> Vec<u8> {
+    let mut key = b"json/node-identity-page/".to_vec();
+    key.extend_from_slice(&(ordinal as u64).to_le_bytes());
+    key
+}
+
+fn store_identity_checkpoint(sink: &mut impl StateOutput, document: &Document) -> sdk::Result<()> {
+    let bytes = serde_json::to_vec(&document.identity_checkpoint())
+        .map_err(|error| sdk::Error::invalid_input(error.to_string()))?;
+    sink.delete_state_prefix(b"json/node-identity-page/")?;
+    sink.put_state(NODE_IDENTITIES_STATE, &(bytes.len() as u64).to_le_bytes())?;
+    for (ordinal, page) in bytes.chunks(STATE_PAGE_BYTES).enumerate() {
+        sink.put_state(&identity_page_key(ordinal), page)?;
+    }
+    Ok(())
+}
+
+fn open_cached_document(
+    before: &sdk::Snapshot<'_>,
+    bytes: Vec<u8>,
+    namespace: IdNamespace,
+) -> sdk::Result<Document> {
+    let Some(header) = before.get_state(NODE_IDENTITIES_STATE)? else {
+        return Document::open_file(bytes, None, namespace)
+            .map(|(document, _)| document)
+            .map_err(sdk::Error::invalid_input);
+    };
+    let length = u64::from_le_bytes(
+        header
+            .as_slice()
+            .try_into()
+            .map_err(|_| sdk::Error::invalid_input("invalid JSON identity checkpoint length"))?,
+    );
+    let length = usize::try_from(length)
+        .map_err(|_| sdk::Error::limit_exceeded("JSON identities exceed guest address space"))?;
+    let mut payload = Vec::new();
+    payload
+        .try_reserve_exact(length)
+        .map_err(|_| sdk::Error::limit_exceeded("JSON identity allocation failed"))?;
+    for ordinal in 0..length.div_ceil(STATE_PAGE_BYTES) {
+        let expected = (length - payload.len()).min(STATE_PAGE_BYTES);
+        let page = before
+            .read_state_range(&identity_page_key(ordinal), 0, expected as u32)?
+            .ok_or_else(|| sdk::Error::invalid_input("JSON identity checkpoint page is missing"))?;
+        if page.len() != expected {
+            return Err(sdk::Error::invalid_input(
+                "JSON identity checkpoint page is truncated",
+            ));
+        }
+        payload.extend_from_slice(&page);
+    }
+    let checkpoint: Vec<(Option<String>, String)> = serde_json::from_slice(&payload)
+        .map_err(|error| sdk::Error::invalid_input(format!("invalid JSON identities: {error}")))?;
+    Document::open_file_with_checkpoint(bytes, namespace, &checkpoint)
+        .map_err(sdk::Error::invalid_input)
+}
+
 fn store_scalar_state(successor: &mut impl StateOutput, document: &Document) -> sdk::Result<()> {
     let state = encode_scalar_state(
         &document
             .arena_scalars()
             .map_err(sdk::Error::invalid_input)?,
     )?;
+    successor.delete_state_prefix(b"json/scalar-index-page/")?;
+    successor.delete_state_prefix(b"json/scalar-page/")?;
+    successor.delete_state(SCALAR_SHIFTS_STATE)?;
+    store_identity_checkpoint(successor, document)?;
     successor.put_state(SCALAR_INDEX_STATE, &state.manifest)?;
     for (ordinal, page) in state.index_pages.iter().enumerate() {
         successor.put_state(&scalar_index_page_key(ordinal as u32), page)?;
@@ -337,7 +387,9 @@ fn sparse_scalar_change(
         .before
         .read_state_range(SCALAR_INDEX_STATE, 0, SCALAR_INDEX_HEADER_BYTES)?
         .ok_or_else(|| sdk::Error::invalid_input("JSON scalar index disappeared"))?;
-    if header.get(..4) != Some(SCALAR_INDEX_MAGIC) {
+    if header.len() != SCALAR_INDEX_HEADER_BYTES as usize
+        || header.get(..4) != Some(SCALAR_INDEX_MAGIC)
+    {
         return Err(sdk::Error::invalid_input("unsupported JSON scalar index"));
     }
     let count = u32::from_le_bytes(header[4..8].try_into().expect("fixed JSON index header"));
@@ -386,6 +438,8 @@ fn sparse_scalar_change(
         .ok_or_else(|| sdk::Error::invalid_input("JSON scalar page disappeared"))?;
     let metadata = decode_scalar_metadata(&metadata)?;
     let mut scalar = update.before.read_range(start, length)?;
+    let prior = Document::scalar_change_from_arena(metadata.clone(), &scalar)
+        .map_err(sdk::Error::invalid_input)?;
     let local_start = usize::try_from(edit.offset - start)
         .map_err(|_| sdk::Error::invalid_input("JSON edit offset exceeds guest memory"))?;
     let local_end = local_start
@@ -395,11 +449,16 @@ fn sparse_scalar_change(
         )
         .ok_or_else(|| sdk::Error::invalid_input("JSON edit range overflowed"))?;
     scalar.splice(local_start..local_end, insert.iter().copied());
-    let Some(change) =
+    let Some(mut change) =
         Document::scalar_change_from_arena(metadata, &scalar).map_err(sdk::Error::invalid_input)?
     else {
         return Ok(None);
     };
+    if let (Some(before), Some(after)) = (prior.and_then(|change| change.row), &change.row) {
+        if core::rows_equal_without_layout(&before, after) {
+            change.effect = ChangeEffect::FormatOnly;
+        }
+    }
     let insert_len = u64::try_from(insert.len())
         .map_err(|_| sdk::Error::limit_exceeded("JSON insert exceeds u64"))?;
     let delta = if insert_len >= edit.delete_len {
@@ -434,7 +493,9 @@ fn sparse_semantic_changes(
     else {
         return Ok(None);
     };
-    if header.get(..4) != Some(SCALAR_INDEX_MAGIC) {
+    if header.len() != SCALAR_INDEX_HEADER_BYTES as usize
+        || header.get(..4) != Some(SCALAR_INDEX_MAGIC)
+    {
         return Err(sdk::Error::invalid_input("unsupported JSON scalar index"));
     }
     let count = u32::from_le_bytes(header[4..8].try_into().expect("scalar count"));
@@ -445,6 +506,7 @@ fn sparse_semantic_changes(
             .unwrap_or_default(),
     )?;
     let base_shifts = shifts.clone();
+    let mut seen = std::collections::HashSet::with_capacity(changes.len());
     let mut edits = Vec::with_capacity(changes.len());
     for change in changes {
         let mut matched = None;
@@ -469,11 +531,12 @@ fn sparse_semantic_changes(
             }
         }
         let Some((ordinal, entry, mut metadata)) = matched else {
-            return Err(sdk::Error::invalid_input(format!(
-                "JSON scalar index has no semantic row {}.{:?}; JSON semantic writes support existing scalar values only",
-                change.schema_key, change.row_pk,
-            )));
+            return Ok(None);
         };
+        // Even a later no-op supersedes an earlier change to the same row.
+        if !seen.insert(ordinal) {
+            return Ok(None);
+        }
         let start = effective_scalar_start(entry.start, ordinal, &base_shifts)?;
         let length = effective_scalar_length(entry.length, ordinal, &base_shifts)?;
         metadata.start = u32::try_from(start)
@@ -481,15 +544,12 @@ fn sparse_semantic_changes(
         metadata.length = u32::try_from(length)
             .map_err(|_| sdk::Error::invalid_input("JSON scalar length exceeds u32"))?;
         let current = before.read_range(start, length)?;
-        let Some(edit) =
-            Document::scalar_edit_from_arena(metadata, &current, change).map_err(|error| {
-                sdk::Error::invalid_input(format!(
-                    "JSON indexed semantic row {}.{:?}: {error}",
-                    change.schema_key, change.row_pk
-                ))
-            })?
-        else {
-            continue;
+        let edit = match Document::scalar_edit_from_arena(metadata, &current, change) {
+            Ok(Some(edit)) => edit,
+            Ok(None) => continue,
+            // Reconstruct and validate the whole row batch for changes that
+            // cannot be expressed as independent scalar replacements.
+            Err(_) => return Ok(None),
         };
         let insert_len = i64::try_from(edit.insert.len())
             .map_err(|_| sdk::Error::limit_exceeded("JSON scalar insert exceeds i64"))?;
@@ -512,6 +572,14 @@ fn sparse_semantic_changes(
         edits.push(edit);
     }
     edits.sort_unstable_by_key(|edit| edit.offset);
+    if edits.windows(2).any(|pair| {
+        pair[0]
+            .offset
+            .checked_add(pair[0].delete_len)
+            .is_none_or(|end| end > pair[1].offset)
+    }) {
+        return Ok(None);
+    }
     Ok(Some((edits, shifts)))
 }
 
@@ -814,20 +882,6 @@ fn scalar_index_page_key(ordinal: u32) -> Vec<u8> {
     key
 }
 
-fn scalar_page_counts_root(root: &sdk::Snapshot<'_>) -> sdk::Result<(u32, u32)> {
-    let Some(header) = root.read_state_range(SCALAR_INDEX_STATE, 0, SCALAR_INDEX_HEADER_BYTES)?
-    else {
-        return Ok((0, 0));
-    };
-    if header.get(..4) != Some(SCALAR_INDEX_MAGIC) {
-        return Err(sdk::Error::invalid_input("unsupported JSON scalar index"));
-    }
-    Ok((
-        u32::from_le_bytes(header[12..16].try_into().expect("index page count")),
-        u32::from_le_bytes(header[8..12].try_into().expect("scalar page count")),
-    ))
-}
-
 fn decode_scalar_shifts(bytes: &[u8]) -> sdk::Result<Vec<(u32, i64)>> {
     if bytes.len() % 12 != 0 {
         return Err(sdk::Error::invalid_input(
@@ -964,27 +1018,6 @@ fn emit_change(
         None => sink.delete(&change.schema_key, change.row_pk),
     }
 }
-
-trait StateOutput {
-    fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()>;
-    fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()>;
-}
-macro_rules! impl_state_output {
-    ($type:ty) => {
-        impl StateOutput for $type {
-            fn put_state(&mut self, key: &[u8], value: &[u8]) -> sdk::Result<()> {
-                <$type>::put_state(self, key, value)
-            }
-            fn delete_state(&mut self, key: &[u8]) -> sdk::Result<()> {
-                <$type>::delete_state(self, key)
-            }
-        }
-    };
-}
-impl_state_output!(sdk::RowOutput<'_, '_>);
-impl_state_output!(sdk::RowChangeOutput<'_, '_>);
-impl_state_output!(sdk::FileOutput<'_, '_>);
-impl_state_output!(sdk::FileEditOutput<'_, '_>);
 
 trait MutationOutput {
     fn create(&mut self, schema_key: &str, local_ref: u32, row: &sdk::TypedRow) -> sdk::Result<()>;
@@ -1332,3 +1365,12 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod adapter_qa_tests;
+
+#[cfg(test)]
+mod structural_format_qa_tests;
+
+#[cfg(test)]
+mod structural_moves_qa_tests;

--- a/plugins/json/src/structural_format_qa_tests.rs
+++ b/plugins/json/src/structural_format_qa_tests.rs
@@ -1,0 +1,273 @@
+use super::*;
+use sdk::testing::{Harness, Snapshot};
+
+fn parse(source: &[u8]) -> (Snapshot, Vec<sdk::TypedRowRecord>) {
+    let creates = sdk::CreateContext::from_namespace_bytes([0x52; 12]);
+    let parsed = Harness::<JsonPlugin>::default()
+        .parse(
+            &Snapshot {
+                file_id: "format-qa".into(),
+                path: "qa.json".into(),
+                bytes: source.into(),
+                ..Snapshot::default()
+            },
+            creates,
+        )
+        .unwrap();
+    let rows = parsed
+        .row_changes
+        .iter()
+        .filter_map(|change| {
+            let mut row = change.row.clone()?;
+            let primary_key = change.local_ref.map_or_else(
+                || change.primary_key.clone(),
+                |local| vec![sdk::TypedValue::Uuid(creates.id(local))],
+            );
+            if change.local_ref.is_some() {
+                row.insert("id", primary_key[0].clone());
+            }
+            Some(sdk::TypedRowRecord {
+                schema_key: change.schema_key.clone(),
+                schema_fingerprint: change.schema_fingerprint,
+                primary_key,
+                row,
+            })
+        })
+        .collect();
+    (parsed.into_snapshot(), rows)
+}
+
+fn upsert(record: &sdk::TypedRowRecord) -> sdk::TypedRowChange {
+    sdk::TypedRowChange {
+        schema_key: record.schema_key.clone(),
+        schema_fingerprint: record.schema_fingerprint,
+        primary_key: record.primary_key.clone(),
+        row: Some(record.row.clone()),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    }
+}
+fn member<'a>(rows: &'a [sdk::TypedRowRecord], key: &str) -> &'a sdk::TypedRowRecord {
+    rows.iter()
+        .find(|r| r.row.get("key") == Some(&sdk::TypedValue::Text(key.into())))
+        .unwrap()
+}
+fn apply(rows: &mut Vec<sdk::TypedRowRecord>, changes: &[sdk::TypedRowChange]) {
+    for change in changes {
+        rows.retain(|r| r.schema_key != change.schema_key || r.primary_key != change.primary_key);
+        if let Some(row) = &change.row {
+            rows.push(sdk::TypedRowRecord {
+                schema_key: change.schema_key.clone(),
+                schema_fingerprint: change.schema_fingerprint,
+                primary_key: change.primary_key.clone(),
+                row: row.clone(),
+            });
+        }
+    }
+}
+fn cold(file: &Snapshot, rows: &[sdk::TypedRowRecord]) -> Snapshot {
+    Harness::<JsonPlugin>::default()
+        .serialize(&file.file_id, &file.path, rows, None)
+        .unwrap()
+        .into_snapshot()
+}
+
+#[test]
+fn structural_format_qa_same_row_last_upsert_wins_even_when_original() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(b"{\"a\":1.00,\"b\":2}");
+    let original = upsert(member(&rows, "a"));
+    let mut changed = original.clone();
+    changed.row.as_mut().unwrap().insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(7).into()),
+    );
+    let result = harness
+        .serialize_changes(&file, &[changed, original])
+        .unwrap();
+    assert_eq!(result.snapshot().bytes, file.bytes);
+}
+
+#[test]
+fn structural_format_qa_rename_formatted_key_preserves_other_bytes() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, mut rows) =
+        parse(b" \r\n{\n  \"\\u0061\" \t: 1.2300e+04 ,\n  \"keep\": \"\\u0041\"\n}\t");
+    let original = member(&rows, "a");
+    let mut deletion = upsert(original);
+    deletion.row = None;
+    let mut renamed = upsert(original);
+    renamed.primary_key[1] = sdk::TypedValue::Text("new".into());
+    renamed
+        .row
+        .as_mut()
+        .unwrap()
+        .insert("key", sdk::TypedValue::Text("new".into()));
+    let changes = [deletion, renamed];
+    let transition = harness.serialize_changes(&file, &changes).unwrap();
+    let output = transition.snapshot();
+    let value: serde_json::Value = serde_json::from_slice(&output.bytes).unwrap();
+    assert_eq!(value, serde_json::json!({"new":12300.0,"keep":"A"}));
+    let text = std::str::from_utf8(&output.bytes).unwrap();
+    assert!(text.contains("1.2300e+04"));
+    assert!(text.contains("\n  \"keep\": \"\\u0041\"\n"));
+    assert!(text.starts_with(" \r\n{"));
+    assert!(text.ends_with("}\t"));
+    apply(&mut rows, &changes);
+    assert_eq!(cold(output, &rows).bytes, output.bytes);
+}
+
+#[test]
+fn structural_format_qa_deletions_preserve_remaining_layout_and_followup_edits() {
+    let harness = Harness::<JsonPlugin>::default();
+    for removed in ["first", "middle", "last"] {
+        let (file, mut rows) = parse(
+            b" \n{\r\n \"first\" : 1.00 \t, \"middle\":\"\\u0041\"\n,\t\"last\" : -0 \r\n}\t",
+        );
+        let mut deletion = upsert(member(&rows, removed));
+        deletion.row = None;
+        let changes = [deletion];
+        let transition = harness.serialize_changes(&file, &changes).unwrap();
+        apply(&mut rows, &changes);
+        let mut file = transition.into_snapshot();
+        assert_eq!(cold(&file, &rows).bytes, file.bytes);
+        let kept = if removed == "first" { "last" } else { "first" };
+        let mut scalar = upsert(member(&rows, kept));
+        scalar.row.as_mut().unwrap().insert(
+            "scalar_json",
+            sdk::TypedValue::Jsonb(serde_json::json!(200).into()),
+        );
+        let transition = harness
+            .serialize_changes(&file, std::slice::from_ref(&scalar))
+            .unwrap();
+        assert!(transition.file_replacement.is_none());
+        apply(&mut rows, &[scalar]);
+        file = transition.into_snapshot();
+        assert_eq!(cold(&file, &rows).bytes, file.bytes);
+        let value: serde_json::Value = serde_json::from_slice(&file.bytes).unwrap();
+        assert!(value.get(removed).is_none());
+        assert_eq!(value[kept], 200);
+        assert!(file.bytes.starts_with(b" \n{"));
+        assert!(file.bytes.ends_with(b"}\t"));
+    }
+}
+
+#[test]
+fn structural_format_qa_empty_container_to_scalar_ignores_obsolete_layout() {
+    let harness = Harness::<JsonPlugin>::default();
+    for source in [b" \n{ \t }\r\n".as_slice(), b" \n[ \t ]\r\n"] {
+        let (file, mut rows) = parse(source);
+        let mut scalar = upsert(&rows[0]);
+        let row = scalar.row.as_mut().unwrap();
+        row.insert("kind", sdk::TypedValue::Text("boolean".into()));
+        row.insert(
+            "scalar_json",
+            sdk::TypedValue::Jsonb(serde_json::json!(true).into()),
+        );
+        let result = harness
+            .serialize_changes(&file, std::slice::from_ref(&scalar))
+            .unwrap();
+        assert_eq!(result.snapshot().bytes, b" \ntrue\r\n");
+        apply(&mut rows, &[scalar]);
+        assert_eq!(
+            cold(result.snapshot(), &rows).bytes,
+            result.snapshot().bytes
+        );
+    }
+}
+
+#[test]
+fn structural_format_qa_reordering_array_retains_each_value_and_layout() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, mut rows) = parse(b"\t[\n 1.00 \t,\r\n \"\\u0041\" , -0\n]\r\n");
+    let mut items: Vec<_> = rows
+        .iter()
+        .filter(|r| r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY)
+        .cloned()
+        .collect();
+    let orders: Vec<_> = items
+        .iter()
+        .map(|r| r.row.get("order_key").unwrap().clone())
+        .collect();
+    for (item, order) in items.iter_mut().zip(orders.into_iter().rev()) {
+        item.row.insert("order_key", order);
+    }
+    let changes: Vec<_> = items.iter().map(upsert).collect();
+    let result = harness.serialize_changes(&file, &changes).unwrap();
+    assert_eq!(
+        result.snapshot().bytes,
+        b"\t[ -0\n,\r\n \"\\u0041\" ,\n 1.00 \t]\r\n"
+    );
+    apply(&mut rows, &changes);
+    let mut file = cold(result.snapshot(), &rows);
+    let changed_index = rows
+        .iter()
+        .position(|r| {
+            r.row.get("scalar_json") == Some(&sdk::TypedValue::Jsonb(serde_json::json!(1.0).into()))
+        })
+        .unwrap();
+    rows[changed_index].row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(123456).into()),
+    );
+    file = harness
+        .serialize_changes(&file, &[upsert(&rows[changed_index])])
+        .unwrap()
+        .into_snapshot();
+    assert_eq!(file.bytes, b"\t[ -0\n,\r\n \"\\u0041\" ,\n 123456 \t]\r\n");
+    assert_eq!(cold(&file, &rows).bytes, file.bytes);
+}
+
+#[test]
+fn structural_format_qa_escaped_rename_updates_only_key_token() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, mut rows) = parse(b"{\n  \"a\"\t : \"\\u0041\" \n}");
+    let original = member(&rows, "a");
+    let mut deletion = upsert(original);
+    deletion.row = None;
+    let mut renamed = upsert(original);
+    renamed.primary_key[1] = sdk::TypedValue::Text("new\"\\\n雪".into());
+    renamed
+        .row
+        .as_mut()
+        .unwrap()
+        .insert("key", renamed.primary_key[1].clone());
+    let changes = [deletion, renamed];
+    let result = harness.serialize_changes(&file, &changes).unwrap();
+    assert_eq!(
+        std::str::from_utf8(&result.snapshot().bytes).unwrap(),
+        "{\n  \"new\\\"\\\\\\n雪\"\t : \"\\u0041\" \n}"
+    );
+    apply(&mut rows, &changes);
+    assert_eq!(
+        cold(result.snapshot(), &rows).bytes,
+        result.snapshot().bytes
+    );
+}
+
+#[test]
+fn structural_format_qa_invalid_layout_cannot_inject_json_on_rebuild() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(b"{\"a\":1,\"b\":2}");
+    let mut deletion = upsert(member(&rows, "b"));
+    deletion.row = None;
+    for (field, text) in [
+        ("prefix_json", "\"a\":1,\"injected\":"),
+        ("prefix_json", "\"a\" 1"),
+        ("prefix_json", "\"\\uD800\":"),
+        ("prefix_json", "\"a\":/* comment */"),
+        ("suffix_json", ",\"injected\":2"),
+        ("empty_json", "injected"),
+    ] {
+        let mut changed = upsert(member(&rows, "a"));
+        changed
+            .row
+            .as_mut()
+            .unwrap()
+            .insert(field, sdk::TypedValue::Text(text.into()));
+        let saved = file.clone();
+        let result = harness.serialize_changes(&file, &[deletion.clone(), changed]);
+        assert!(result.is_err(), "accepted {field}={text:?}");
+        assert_eq!(file, saved);
+    }
+}

--- a/plugins/json/src/structural_moves_qa_tests.rs
+++ b/plugins/json/src/structural_moves_qa_tests.rs
@@ -1,0 +1,422 @@
+use super::*;
+use sdk::testing::{Harness, Snapshot};
+
+fn parse(source: &[u8]) -> (Snapshot, Vec<sdk::TypedRowRecord>) {
+    let creates = sdk::CreateContext::from_namespace_bytes([0x29; 12]);
+    let transition = Harness::<JsonPlugin>::default()
+        .parse(
+            &Snapshot {
+                file_id: "moves-qa".into(),
+                path: "moves.json".into(),
+                bytes: source.to_vec(),
+                ..Snapshot::default()
+            },
+            creates,
+        )
+        .unwrap();
+    let rows = transition
+        .row_changes
+        .iter()
+        .filter_map(|change| {
+            let mut row = change.row.clone()?;
+            let primary_key = change.local_ref.map_or_else(
+                || change.primary_key.clone(),
+                |local| vec![sdk::TypedValue::Uuid(creates.id(local))],
+            );
+            if change.local_ref.is_some() {
+                row.insert("id", primary_key[0].clone());
+            }
+            Some(sdk::TypedRowRecord {
+                schema_key: change.schema_key.clone(),
+                schema_fingerprint: change.schema_fingerprint,
+                primary_key,
+                row,
+            })
+        })
+        .collect();
+    (transition.into_snapshot(), rows)
+}
+
+fn upsert(row: &sdk::TypedRowRecord) -> sdk::TypedRowChange {
+    sdk::TypedRowChange {
+        schema_key: row.schema_key.clone(),
+        schema_fingerprint: row.schema_fingerprint,
+        primary_key: row.primary_key.clone(),
+        row: Some(row.row.clone()),
+        local_ref: None,
+        effect: sdk::ChangeEffect::Content,
+    }
+}
+fn delete(row: &sdk::TypedRowRecord) -> sdk::TypedRowChange {
+    sdk::TypedRowChange {
+        row: None,
+        ..upsert(row)
+    }
+}
+fn text(value: &str) -> sdk::TypedValue {
+    sdk::TypedValue::Text(value.into())
+}
+fn array_id(row: &sdk::TypedRowRecord) -> sdk::TypedValue {
+    match &row.primary_key[0] {
+        sdk::TypedValue::Uuid(id) => text(&id.to_string()),
+        _ => panic!("array item expected"),
+    }
+}
+fn apply(rows: &mut Vec<sdk::TypedRowRecord>, changes: &[sdk::TypedRowChange]) {
+    for change in changes {
+        rows.retain(|row| {
+            row.schema_key != change.schema_key || row.primary_key != change.primary_key
+        });
+        if let Some(row) = &change.row {
+            rows.push(sdk::TypedRowRecord {
+                schema_key: change.schema_key.clone(),
+                schema_fingerprint: change.schema_fingerprint,
+                primary_key: change.primary_key.clone(),
+                row: row.clone(),
+            });
+        }
+    }
+}
+fn cold_bytes(file: &Snapshot, rows: &[sdk::TypedRowRecord]) -> Vec<u8> {
+    Harness::<JsonPlugin>::default()
+        .serialize(&file.file_id, &file.path, rows, None)
+        .unwrap()
+        .snapshot()
+        .bytes
+        .clone()
+}
+
+#[test]
+fn structural_moves_nested_array_then_scalar_and_cold_roundtrip() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (mut file, mut rows) = parse(br#"[[[1.00e+02]],[],3]"#);
+    let mut top: Vec<_> = rows
+        .iter()
+        .filter(|r| {
+            r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY
+                && r.row.get("parent_id") == Some(&text("root"))
+        })
+        .cloned()
+        .collect();
+    top.sort_by_key(|r| match r.row.get("order_key").unwrap() {
+        sdk::TypedValue::Text(t) => t.clone(),
+        _ => panic!(),
+    });
+    let mut inner = rows
+        .iter()
+        .find(|r| r.row.get("parent_id") == Some(&array_id(&top[0])))
+        .unwrap()
+        .clone();
+    let mut leaf = rows
+        .iter()
+        .find(|r| r.row.get("parent_id") == Some(&array_id(&inner)))
+        .unwrap()
+        .clone();
+    for round in 0..12 {
+        let target = if round % 2 == 0 { &top[1] } else { &top[0] };
+        inner.row.insert("parent_id", array_id(target));
+        let changes = [upsert(&inner)];
+        file = harness
+            .serialize_changes(&file, &changes)
+            .unwrap()
+            .into_snapshot();
+        apply(&mut rows, &changes);
+        assert_eq!(cold_bytes(&file, &rows), file.bytes);
+        let expected = if round == 0 {
+            serde_json::json!([[], [[100.0]], 3])
+        } else if round % 2 == 0 {
+            serde_json::json!([[], [[round - 1]], 3])
+        } else {
+            serde_json::json!([[[round - 1]], [], 3])
+        };
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&file.bytes).unwrap(),
+            expected
+        );
+        if round == 0 {
+            assert!(String::from_utf8_lossy(&file.bytes).contains("1.00e+02"));
+        }
+        leaf.row.insert(
+            "scalar_json",
+            sdk::TypedValue::Jsonb(serde_json::json!(round).into()),
+        );
+        let changes = [upsert(&leaf)];
+        let updated = harness.serialize_changes(&file, &changes).unwrap();
+        assert!(updated.file_replacement.is_none());
+        file = updated.into_snapshot();
+        apply(&mut rows, &changes);
+        assert_eq!(cold_bytes(&file, &rows), file.bytes);
+    }
+}
+
+#[test]
+fn structural_moves_parent_deleted_while_nested_subtree_survives() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, mut rows) = parse(br#"[[{"deep":[1,2]}],[]]"#);
+    let top: Vec<_> = rows
+        .iter()
+        .filter(|r| {
+            r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY
+                && r.row.get("parent_id") == Some(&text("root"))
+        })
+        .cloned()
+        .collect();
+    let parent = top
+        .iter()
+        .find(|r| {
+            rows.iter()
+                .any(|c| c.row.get("parent_id") == Some(&array_id(r)))
+        })
+        .unwrap();
+    let destination = top
+        .iter()
+        .find(|r| r.primary_key != parent.primary_key)
+        .unwrap();
+    let mut moved = rows
+        .iter()
+        .find(|r| r.row.get("parent_id") == Some(&array_id(parent)))
+        .unwrap()
+        .clone();
+    moved.row.insert("parent_id", array_id(destination));
+    let changes = [delete(parent), upsert(&moved)];
+    let updated = harness.serialize_changes(&file, &changes).unwrap();
+    apply(&mut rows, &changes);
+    assert_eq!(updated.snapshot().bytes, br#"[[{"deep":[1,2]}]]"#);
+    assert_eq!(
+        cold_bytes(updated.snapshot(), &rows),
+        updated.snapshot().bytes
+    );
+}
+
+#[test]
+fn structural_moves_invalid_graphs_reject_with_scalar_update_atomically() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(br#"[[1],{},2]"#);
+    let scalar = rows
+        .iter()
+        .find(|r| {
+            r.row.get("scalar_json") == Some(&sdk::TypedValue::Jsonb(serde_json::json!(2).into()))
+        })
+        .unwrap();
+    let array = rows
+        .iter()
+        .find(|r| {
+            r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY
+                && r.row.get("kind") == Some(&text("array"))
+        })
+        .unwrap();
+    let object = rows
+        .iter()
+        .find(|r| r.row.get("kind") == Some(&text("object")))
+        .unwrap();
+    let mut child = rows
+        .iter()
+        .find(|r| r.row.get("parent_id") == Some(&array_id(array)))
+        .unwrap()
+        .clone();
+    let mut scalar_update = scalar.clone();
+    scalar_update.row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(999).into()),
+    );
+    let saved = file.clone();
+    for parent in [
+        array_id(scalar),
+        array_id(object),
+        text("missing"),
+        array_id(&child),
+    ] {
+        child.row.insert("parent_id", parent);
+        assert!(
+            harness
+                .serialize_changes(&file, &[upsert(&scalar_update), upsert(&child)])
+                .is_err()
+        );
+        assert_eq!(file, saved);
+    }
+    assert_eq!(
+        harness
+            .serialize_changes(&file, &[])
+            .unwrap()
+            .snapshot()
+            .bytes,
+        saved.bytes
+    );
+}
+
+#[test]
+fn structural_moves_repeated_identity_batch_uses_final_state() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, mut rows) = parse(br#"[[1],[]]"#);
+    let mut child = rows
+        .iter()
+        .find(|r| r.row.get("kind") == Some(&text("number")))
+        .unwrap()
+        .clone();
+    let final_parent = rows
+        .iter()
+        .find(|r| {
+            r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY
+                && r.row.get("kind") == Some(&text("array"))
+                && Some(&array_id(r)) != child.row.get("parent_id")
+        })
+        .unwrap();
+    child.row.insert("parent_id", text("temporarily-missing"));
+    let intermediate = upsert(&child);
+    child.row.insert("parent_id", array_id(final_parent));
+    child.row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(8).into()),
+    );
+    let changes = [intermediate, delete(&child), upsert(&child)];
+    let transition = harness.serialize_changes(&file, &changes).unwrap();
+    apply(&mut rows, &changes);
+    assert_eq!(transition.snapshot().bytes, b"[[],[8]]");
+    assert_eq!(
+        cold_bytes(transition.snapshot(), &rows),
+        transition.snapshot().bytes
+    );
+}
+
+#[test]
+fn structural_moves_delete_reinsert_container_changes_kind_in_final_batch() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, mut rows) = parse(b"[[1],[]]");
+    let leaf = rows
+        .iter()
+        .find(|r| r.row.get("kind") == Some(&text("number")))
+        .unwrap()
+        .clone();
+    let container = rows
+        .iter()
+        .find(|r| {
+            r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY
+                && Some(&array_id(r)) == leaf.row.get("parent_id")
+        })
+        .unwrap()
+        .clone();
+    let mut converted = container.clone();
+    converted.row.insert("kind", text("object"));
+    let (_, source) = parse(br#"{"x":2}"#);
+    let mut member = source
+        .iter()
+        .find(|r| r.schema_key.as_ref() == OBJECT_MEMBER_SCHEMA_KEY)
+        .unwrap()
+        .clone();
+    member.primary_key[0] = array_id(&container);
+    member
+        .row
+        .insert("parent_id", member.primary_key[0].clone());
+    let changes = [
+        delete(&container),
+        upsert(&member),
+        upsert(&converted),
+        delete(&leaf),
+    ];
+    let updated = harness.serialize_changes(&file, &changes).unwrap();
+    apply(&mut rows, &changes);
+    assert_eq!(updated.snapshot().bytes, br#"[{"x":2},[]]"#);
+    assert_eq!(
+        cold_bytes(updated.snapshot(), &rows),
+        updated.snapshot().bytes
+    );
+    member.row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(12345).into()),
+    );
+    let updated = harness
+        .serialize_changes(updated.snapshot(), &[upsert(&member)])
+        .unwrap();
+    assert_eq!(updated.snapshot().bytes, br#"[{"x":12345},[]]"#);
+    assert!(updated.file_replacement.is_none());
+}
+
+#[test]
+fn structural_moves_equal_order_keys_are_deterministic_across_batch_orders() {
+    let harness = Harness::<JsonPlugin>::default();
+    for source in [br#"{"z":1,"b":2,"a":3}"#.as_slice(), b"[1,2,3]"] {
+        let (file, mut rows) = parse(source);
+        let mut changes = Vec::new();
+        for row in &mut rows {
+            if row.schema_key.as_ref() != ROOT_SCHEMA_KEY {
+                row.row.insert("order_key", text("80"));
+                changes.push(upsert(row));
+            }
+        }
+        let expected = cold_bytes(&file, &rows);
+        for _ in 0..6 {
+            let updated = harness.serialize_changes(&file, &changes).unwrap();
+            assert_eq!(updated.snapshot().bytes, expected);
+            rows.rotate_left(1);
+            assert_eq!(cold_bytes(&file, &rows), expected);
+            changes.rotate_left(1);
+            changes.reverse();
+        }
+        if source[0] == b'{' {
+            assert_eq!(expected, br#"{"a":3,"b":2,"z":1}"#);
+        }
+    }
+}
+
+#[test]
+fn structural_moves_nested_object_rekey_updates_container_chain_and_keeps_array_id() {
+    let harness = Harness::<JsonPlugin>::default();
+    let (file, rows) = parse(br#"{"old":{"nested":{"list":[1.00]}}}"#);
+    let (_, target_rows) = parse(br#"{"new":{"nested":{"list":[1.00]}}}"#);
+    let mut changes: Vec<_> = rows
+        .iter()
+        .filter(|r| r.schema_key.as_ref() == OBJECT_MEMBER_SCHEMA_KEY)
+        .map(delete)
+        .collect();
+    let outer = target_rows
+        .iter()
+        .find(|r| r.row.get("key") == Some(&text("new")))
+        .unwrap();
+    let old_outer = rows
+        .iter()
+        .find(|r| r.row.get("key") == Some(&text("old")))
+        .unwrap();
+    // Moving only the outer object would leave descendants at its old container ID.
+    assert!(
+        harness
+            .serialize_changes(&file, &[delete(old_outer), upsert(outer)])
+            .is_err()
+    );
+    changes.extend(
+        target_rows
+            .iter()
+            .filter(|r| r.schema_key.as_ref() != ROOT_SCHEMA_KEY)
+            .map(upsert),
+    );
+    let old_leaf = rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY)
+        .unwrap();
+    let mut leaf = target_rows
+        .iter()
+        .find(|r| r.schema_key.as_ref() == ARRAY_ITEM_SCHEMA_KEY)
+        .unwrap()
+        .clone();
+    assert_eq!(old_leaf.primary_key, leaf.primary_key);
+    let updated = harness.serialize_changes(&file, &changes).unwrap();
+    assert_eq!(
+        updated.snapshot().bytes,
+        br#"{"new":{"nested":{"list":[1.00]}}}"#
+    );
+    assert_eq!(
+        cold_bytes(updated.snapshot(), &target_rows),
+        updated.snapshot().bytes
+    );
+    leaf.row.insert(
+        "scalar_json",
+        sdk::TypedValue::Jsonb(serde_json::json!(999).into()),
+    );
+    let updated = harness
+        .serialize_changes(updated.snapshot(), &[upsert(&leaf)])
+        .unwrap();
+    assert!(updated.file_replacement.is_none());
+    assert_eq!(
+        updated.snapshot().bytes,
+        br#"{"new":{"nested":{"list":[999]}}}"#
+    );
+}


### PR DESCRIPTION
JSON row writes previously rejected structural edits, and rebuilding JSON/Excalidraw files could lose scalar spelling, object formatting, or usable indexes. JSON now supports insertion, deletion, reordering, moves, and scalar/container conversion. Scalar changes keep the byte-splice path; structural batches validate the final tree and stream a complete replacement.

JSON preserves scalar spelling and array identities through later edits and reopen. Excalidraw preserves untouched object formatting, embedded files, and unknown fields. Optional source hints, canonical schema fixtures, and fingerprints are updated together; rebuilt indexes clear obsolete pages and offsets.

Independent QA found and fixed repeated-upsert ordering, stale formatting hints on rename/conversion, and nondeterministic row-delta ordering that rejected valid concurrent edits. Seventeen additional regression tests cover nested moves, malformed trees, formatting, deletion/upsert concurrency, rollback, and cold reopen. Repeated QA and independent re-review finished clean.

Behavior to review:
- Deleting a container requires deleting or moving its descendants in the same plugin row batch; there is no implicit cascade.
- SQL projects each statement separately. Object-key renames use delete/insert.
- Existing row last-write-wins semantics permit a later upsert to recreate a deleted key. Orphaned writes reject atomically; obsolete observations can require reread/retry.

Validation:
- 42 JSON native tests and 27 Excalidraw tests.
- 50 schema tests.
- 90 compiled-component integration tests passed; 7 ignored.
- Independent formatting/moves QA repeated 20 times; concurrency QA completed 80 successful executions across 20 repetitions.
- Strict JSON plugin Clippy and formatting/diff checks passed.

Uses the plugin-authoring harness merged in #1710. This PR now targets main and contains only the JSON/Excalidraw changes.

PR review follow-up: preserve decimal spellings normalized by JSONB (for example `1.0`), with a failing-before/passing-after native regression and a compiled structural-rebuild/reopen test.
