### PR TITLE
Seed .lix documentation and directories in main bootstrap

### DIFF
--- a/packages/lix/src/init.rs
+++ b/packages/lix/src/init.rs
@@ -28,9 +28,8 @@ use crate::storage_adapter::{
     StorageSpaceId, StorageWriteSet, ValueSemantics,
 };
 use crate::tracked_state::{
-    CommitStateManifest, CommitStateMutationInventory, CommitStateReplayDebt,
-    TrackedStateCommitDeltaRef, TrackedStateContext, TrackedStateDeltaRef,
-    stage_commit_deltas_for_commit_state,
+    CommitStateManifest, CommitStateReplayDebt, TrackedStateCommitDeltaRef, TrackedStateContext,
+    TrackedStateDeltaRef, stage_commit_deltas_for_commit_state,
 };
 use bytes::Bytes;
 use serde_json::json;
@@ -238,6 +237,7 @@ pub(crate) struct InitSeedPlan {
     global_commit: InitSeedCommit,
     main_commit: InitSeedCommit,
     changes: Vec<InitSeedChange>,
+    main_changes: Vec<InitSeedChange>,
     branch_controls: Vec<InitBranchHeadControl>,
     pub(crate) receipt: InitReceipt,
 }
@@ -255,6 +255,7 @@ struct InitSeedCommit {
 struct InitSeedChange {
     id: ChangeId,
     row_pk: RowPk,
+    file_id: Option<String>,
     schema_key: String,
     #[cfg(test)]
     snapshot_content: serde_json::Value,
@@ -331,6 +332,7 @@ pub(crate) fn plan_init_seed_with_main_branch_id(
         .map(|seed| InitSeedChange {
             id: ChangeId::from(functions.call_uuid_v7()),
             row_pk: seed.row_pk.clone(),
+            file_id: None,
             schema_key: REGISTERED_SCHEMA_KEY.to_owned(),
             #[cfg(test)]
             snapshot_content: seed.snapshot_content.clone(),
@@ -467,6 +469,7 @@ pub(crate) fn plan_init_seed_with_main_branch_id(
                 anonymous_account_change,
             ])
             .collect(),
+        main_changes: plan_main_files(&functions, timestamp)?,
         branch_controls: vec![global_branch_control, main_branch_control],
         receipt: InitReceipt {
             lix_id,
@@ -476,6 +479,60 @@ pub(crate) fn plan_init_seed_with_main_branch_id(
             initial_commit_id: initial_commit_id.to_string(),
         },
     })
+}
+
+const LIX_README: &[u8] = include_bytes!("init_readme.md");
+
+/// Repository content belongs to main, so edits and deletions follow ordinary
+/// branch history rather than changing repository-wide global metadata.
+fn plan_main_files(
+    functions: &FunctionProviderHandle,
+    timestamp: LixTimestamp,
+) -> Result<Vec<InitSeedChange>, LixError> {
+    let directory_id = functions.call_uuid_v7();
+    let mut changes = Vec::new();
+    for (id, name, parent_id) in [
+        (directory_id, ".lix", None),
+        (functions.call_uuid_v7(), "app_data", Some(directory_id)),
+        (functions.call_uuid_v7(), "plugins", Some(directory_id)),
+    ] {
+        changes.push(canonical_change(
+            functions.call_uuid_v7(),
+            RowPk::uuid_from_canonical(&id.to_string())
+                .expect("generated directory ID is a canonical UUID"),
+            "lix_directory_descriptor",
+            json!({ "id": id.to_string(), "name": name, "parent_id": parent_id.map(|id| id.to_string()) }),
+            timestamp,
+        )?);
+    }
+    let file_id = functions.call_uuid_v7().to_string();
+    for (schema_key, snapshot) in [
+        (
+            "lix_file_descriptor",
+            json!({
+                "id": file_id, "directory_id": directory_id.to_string(), "name": "README.md",
+            }),
+        ),
+        (
+            "lix_binary_blob_ref",
+            json!({
+                "id": file_id,
+                "blob_hash": crate::binary_cas::BlobId::from_content(LIX_README).to_hex(),
+                "size_bytes": LIX_README.len(),
+            }),
+        ),
+    ] {
+        let mut change = canonical_change(
+            functions.call_uuid_v7(),
+            RowPk::uuid_from_canonical(&file_id).expect("generated file ID is a canonical UUID"),
+            schema_key,
+            snapshot,
+            timestamp,
+        )?;
+        change.file_id = Some(file_id.clone());
+        changes.push(change);
+    }
+    Ok(changes)
 }
 
 /// Initializes an empty engine repository in one storage transaction.
@@ -518,6 +575,15 @@ where
         .iter()
         .map(seed_change_to_change_record)
         .collect::<Result<Vec<_>, _>>()?;
+    let main_changes = plan
+        .main_changes
+        .iter()
+        .map(seed_change_to_change_record)
+        .collect::<Result<Vec<_>, _>>()?;
+    crate::binary_cas::BinaryCasContext::new()
+        .writer_skipping_existing_chunks(&read, &mut writes)
+        .stage_payload(&crate::binary_cas::BlobPayload::from_bytes(LIX_README))
+        .await?;
     let branch_ref_ledger_changes = plan
         .branch_controls
         .iter()
@@ -542,6 +608,13 @@ where
         &plan,
         branch_ref_ledger_changes.clone(),
         &init_touched_scopes,
+        &main_changes
+            .iter()
+            .map(|change| crate::changelog::CommitScopeKey {
+                schema_key: change.schema_key.clone(),
+                file_id: change.file_id.clone(),
+            })
+            .collect::<Vec<_>>(),
     )
     .await?;
 
@@ -606,9 +679,9 @@ where
             &read,
             &mut writes,
             &mut row_pk_index_overlay,
-                None,
-                &initial_members,
-                plan.global_commit.id,
+            None,
+            &initial_members,
+            plan.global_commit.id,
         )
         .await?;
         let physical_publication =
@@ -638,14 +711,37 @@ where
                 &physical_publication,
             )?;
 
-        // Main starts as an empty immutable overlay pinned to the global
-        // genesis snapshot. Its causal parent is global, but its physical
-        // state root deliberately has no parent: the base edge supplies the
-        // global half of the effective state.
-        let empty_deltas = Vec::<TrackedStateDeltaRef<'_>>::new();
+        // Main's bootstrap content is a local overlay pinned to global genesis.
+        let main_deltas = main_changes
+            .iter()
+            .map(|change| TrackedStateDeltaRef {
+                schema_key: &change.schema_key,
+                file_id: change.file_id.as_deref(),
+                row_pk: &change.row_pk,
+                change_id: change.change_id,
+                commit_id: plan.main_commit.id,
+                deleted: false,
+                created_at: change.created_at,
+                updated_at: change.created_at,
+            })
+            .collect::<Vec<_>>();
+        let main_commit_deltas = main_changes
+            .iter()
+            .zip(main_deltas.iter().copied())
+            .map(|(change, delta)| TrackedStateCommitDeltaRef {
+                delta,
+                metadata: change.metadata.as_ref(),
+                snapshot: change.snapshot.as_deref(),
+                origin_key: change.origin_key.as_deref(),
+                base_coordinate: None,
+                authored: true,
+            })
+            .collect::<Vec<_>>();
+        let staged_main = stage_commit_deltas_for_commit_state(&mut writes, &main_commit_deltas)?;
+        crate::tracked_state::stage_change_locators(&mut writes, &staged_main.locators);
         let mut tracked_writer = tracked_state.writer(&read, &mut writes);
         tracked_writer
-            .stage_commit_root(&receipt.initial_commit_id, None, empty_deltas)
+            .stage_commit_root(&receipt.initial_commit_id, None, main_deltas)
             .await?;
         let main_snapshot_root = tracked_writer
             .staged_commit_roots()
@@ -657,8 +753,20 @@ where
                     "repository initialization did not stage the main overlay root",
                 )
             })?;
-        let main_mutations = CommitStateMutationInventory::default();
-        let main_members = Vec::new();
+        let main_mutations = staged_main.mutation_inventory().clone();
+        let main_segments = crate::tracked_state::staged_commit_delta_segment_bytes(
+            &writes,
+            plan.main_commit.id,
+            &main_mutations,
+        )?;
+        let main_members = crate::tracked_state::staged_commit_delta_members(
+            &read,
+            plan.main_commit.id,
+            &plan.main_commit.account_id,
+            &main_mutations,
+            main_segments,
+        )
+        .await?;
         let mut main_row_pk_overlay = crate::tracked_state::TrackedStateChunkOverlay::new();
         let main_row_pk_index_root_id = crate::tracked_state::stage_row_pk_index_from_members(
             &read,
@@ -696,18 +804,25 @@ where
         )?;
 
         // Seed global with its complete state. Main's physical generation is
-        // only the local overlay plus the registered-schema serving cache;
+        // the bootstrap files plus the registered-schema serving cache;
         // ordinary values are resolved through its pinned global base.
         let tracked_head_deltas = authored_changes
             .iter()
             .zip(&plan.changes)
-            .map(|(change, seed)| {
+            .map(|pair| (pair, plan.global_commit.id))
+            .chain(
+                main_changes
+                    .iter()
+                    .zip(&plan.main_changes)
+                    .map(|pair| (pair, plan.main_commit.id)),
+            )
+            .map(|((change, seed), commit_id)| {
                 Ok(CurrentStateDeltaRef {
                     schema_key: &change.schema_key,
                     file_id: change.file_id.as_deref(),
                     row_pk: &change.row_pk,
                     change_id: Some(change.change_id),
-                    commit_id: Some(plan.global_commit.id),
+                    commit_id: Some(commit_id),
                     untracked: false,
                     deleted: false,
                     created_at: change.created_at,
@@ -729,11 +844,14 @@ where
         let absence_guards = std::collections::BTreeSet::default();
         for branch in &plan.branch_controls {
             let mut head_deltas = tracked_head_deltas.clone();
-            // Checkpoints and built-in accounts are global facts. Staging them
-            // onto main would turn the global snapshot into a local overlay.
-            if branch.branch_id != GLOBAL_BRANCH_ID {
-                head_deltas.retain(|delta| delta.schema_key == REGISTERED_SCHEMA_KEY);
-            }
+            head_deltas.retain(|delta| {
+                if branch.branch_id == GLOBAL_BRANCH_ID {
+                    delta.commit_id == Some(plan.global_commit.id)
+                } else {
+                    delta.commit_id == Some(plan.main_commit.id)
+                        || delta.schema_key == REGISTERED_SCHEMA_KEY
+                }
+            });
             let generation = if branch.branch_id == GLOBAL_BRANCH_ID {
                 plan.global_commit.id
             } else {
@@ -818,7 +936,7 @@ fn seed_change_to_change_record(change: &InitSeedChange) -> Result<ChangeRecord,
         account_id: crate::SYSTEM_ACCOUNT_ID.to_string(),
         row_pk: change.row_pk.clone(),
         schema_key: change.schema_key.clone(),
-        file_id: None,
+        file_id: change.file_id.clone(),
         metadata: None,
         snapshot: Some(seed_snapshot(&change.decoded_snapshot)?),
         created_at: change.created_at,
@@ -858,6 +976,7 @@ async fn stage_init_changelog_commit(
     plan: &InitSeedPlan,
     changes: Vec<ChangeRecord>,
     touched_scopes: &[crate::changelog::CommitScopeKey],
+    main_touched_scopes: &[crate::changelog::CommitScopeKey],
 ) -> Result<(), LixError> {
     let global_commit = CommitRecord {
         touched_scope_digest: crate::changelog::CommitTouchedScopeDigest::exact(touched_scopes),
@@ -872,7 +991,9 @@ async fn stage_init_changelog_commit(
         created_at: plan.global_commit.created_at,
     };
     let main_commit = CommitRecord {
-        touched_scope_digest: crate::changelog::CommitTouchedScopeDigest::exact(&[]),
+        touched_scope_digest: crate::changelog::CommitTouchedScopeDigest::exact(
+            main_touched_scopes,
+        ),
         format_version: crate::changelog::COMMIT_RECORD_FORMAT_VERSION,
         commit_id: plan.main_commit.id,
         generation: 1,
@@ -931,6 +1052,7 @@ fn canonical_change(
     Ok(InitSeedChange {
         id: ChangeId::from(id),
         row_pk,
+        file_id: None,
         schema_key: schema_key.to_string(),
         #[cfg(test)]
         snapshot_content,

--- a/packages/lix/src/init_readme.md
+++ b/packages/lix/src/init_readme.md
@@ -1,0 +1,25 @@
+# The `.lix` directory
+
+This directory contains files used by Lix and applications built on Lix.
+
+- `app_data/`: application-owned repository content. Each app uses its own
+  subdirectory, for example `app_data/atelier/extensions/` for Atelier extensions.
+- `plugins/`: installed `.lixplugin` archives that teach Lix how to track changes
+  within supported file formats. Use Lix's plugin installation and removal APIs
+  to manage these archives.
+- `README.md`: this guide, created with the repository's initial commit on `main`.
+
+These files and directories are repository content: they participate in Lix
+history, branching, and synchronization. Apps should store their files under
+`app_data/<app-name>/` to avoid conflicts with other apps and Lix.
+
+When using filesystem storage, Lix also manages local files in this directory:
+
+- `.internal/`: local database and storage internals. Let Lix manage this directory;
+  do not edit its contents manually.
+- `.gitignore`: excludes the contents of `.lix/` from Git. Lix tracks its
+  repository content independently of Git.
+
+These local storage files are not part of Lix's tracked repository content and
+may not exist when using other storage adapters. Lix creates this README only
+when initializing a new repository; reopening it does not overwrite your edits.

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -6857,13 +6857,17 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(exact_directories, relational_directories);
-        assert_eq!(exact_directories.rows().len(), 2);
+        assert_eq!(exact_directories.rows().len(), 3);
         assert_eq!(
-            exact_directories.rows()[0].get::<String>("id").unwrap(),
-            "01920000-0000-7000-8000-0000000000d2"
+            exact_directories.rows()[0].get::<String>("path").unwrap(),
+            "/.lix"
         );
         assert_eq!(
             exact_directories.rows()[1].get::<String>("id").unwrap(),
+            "01920000-0000-7000-8000-0000000000d2"
+        );
+        assert_eq!(
+            exact_directories.rows()[2].get::<String>("id").unwrap(),
             "01920000-0000-7000-8000-0000000000d1"
         );
     }
@@ -11725,7 +11729,7 @@ mod tests {
 
         assert_eq!(batch.results.len(), 3);
         assert_eq!(batch.results[0].rows()[0].get::<i64>("one").unwrap(), 1);
-        assert_eq!(batch.results[1].rows()[0].get::<i64>("files").unwrap(), 0);
+        assert_eq!(batch.results[1].rows()[0].get::<i64>("files").unwrap(), 1);
         assert!(batch.results[2].rows()[0].get::<i64>("changes").unwrap() > 0);
     }
 
@@ -11747,7 +11751,7 @@ mod tests {
             )
             .await
             .expect("nested CTE, self-join, and UNION should resolve providers");
-        assert_eq!(complex.rows()[0].get::<i64>("row_count").unwrap(), 0);
+        assert_eq!(complex.rows()[0].get::<i64>("row_count").unwrap(), 1);
 
         let catalog = session
             .execute(

--- a/packages/lix/src/session/media_upload.rs
+++ b/packages/lix/src/session/media_upload.rs
@@ -1673,7 +1673,11 @@ mod tests {
             .expect("scan CAS chunks")
             .into_parts();
         assert!(!chunks_has_more);
-        assert_eq!(chunks.len(), 2, "identical media must reuse payloads");
+        assert_eq!(
+            chunks.len(),
+            3,
+            "two media chunks plus the bootstrap README; identical media must reuse payloads"
+        );
     }
 
     #[tokio::test]

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -2388,10 +2388,19 @@ mod tests {
             .expect("default head");
         let mut snapshot_commits = BTreeMap::new();
         let mut snapshot_headers = BTreeMap::new();
-        for branch_head in branches
+        // Match production snapshot fetching: checkpoints have authored content
+        // too, including the files in main's bootstrap commit.
+        let snapshot_heads = branches
             .iter()
-            .filter_map(|branch| branch.head_commit_id.as_deref())
-        {
+            .flat_map(|branch| {
+                [
+                    branch.head_commit_id.as_deref(),
+                    branch.checkpoint_commit_id.as_deref(),
+                ]
+            })
+            .flatten()
+            .collect::<BTreeSet<_>>();
+        for branch_head in snapshot_heads {
             let page = authority
                 .sync_history(branch_head, 1)
                 .await

--- a/packages/lix/tests/integration/independent_transactions.rs
+++ b/packages/lix/tests/integration/independent_transactions.rs
@@ -2,7 +2,8 @@ use std::time::Duration;
 
 use lix::{CreateBranchOptions, ObserveEvent, ObserveEvents, SwitchBranchOptions, Value, open_lix};
 
-const FILES_SQL: &str = "SELECT path, content FROM lix_file ORDER BY path";
+const FILES_SQL: &str =
+    "SELECT path, content FROM lix_file WHERE path NOT LIKE '/.lix/%' ORDER BY path";
 
 async fn next_event(events: &mut ObserveEvents) -> ObserveEvent {
     tokio::time::timeout(Duration::from_secs(2), events.next())

--- a/packages/lix/tests/integration/restore.rs
+++ b/packages/lix/tests/integration/restore.rs
@@ -3,8 +3,7 @@ use serde_json::json;
 
 use crate::support::simulation_test::engine::SimSession;
 
-const RESTORE_SQL: &str =
-    "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id";
+const RESTORE_SQL: &str = "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id";
 
 simulation_test!(
     restore_moves_only_the_active_branch_to_an_ancestor,
@@ -15,6 +14,7 @@ simulation_test!(
             &engine,
         );
         let initial_commit_id = sim.initial_commit_id().to_string();
+        let initial_file_count = count(&session, "lix_file").await;
         session
             .execute(
                 "INSERT INTO lix_file (path, content) VALUES ('/a.txt', CAST('a' AS BYTEA))",
@@ -48,9 +48,9 @@ simulation_test!(
             .expect("ancestor restore should succeed");
         assert_eq!(head(&session).await, target_commit_id);
         assert_eq!(count(&session, "lix_commit").await, commit_count_before);
-        assert_eq!(count(&session, "lix_file").await, 1);
+        assert_eq!(count(&session, "lix_file").await, initial_file_count + 1);
         let files = session
-            .execute("SELECT path FROM lix_file ORDER BY path", &[])
+            .execute("SELECT path FROM lix_file WHERE path = '/a.txt'", &[])
             .await
             .expect("files should read");
         assert_eq!(files.rows()[0].get::<String>("path").unwrap(), "/a.txt");
@@ -78,13 +78,13 @@ simulation_test!(
             other_branch.commit_id,
             "checking out the control branch refreshes its stale global base"
         );
-        assert_eq!(count(&session, "lix_file").await, 1);
+        assert_eq!(count(&session, "lix_file").await, initial_file_count + 1);
 
         restore(&session, &initial_commit_id)
             .await
             .expect("parentless commit should be restorable");
         assert_eq!(head(&session).await, initial_commit_id);
-        assert_eq!(count(&session, "lix_file").await, 0);
+        assert_eq!(count(&session, "lix_file").await, initial_file_count);
     }
 );
 

--- a/packages/lix/tests/integration/sql/lix_directory.rs
+++ b/packages/lix/tests/integration/sql/lix_directory.rs
@@ -408,7 +408,6 @@ simulation_test!(
     }
 );
 
-
 simulation_test!(
     lix_directory_path_insert_rejects_existing_file_entry,
     |sim| async move {
@@ -900,7 +899,6 @@ simulation_test!(
         );
     }
 );
-
 
 simulation_test!(
     lix_directory_global_path_insert_reuses_existing_global_directory,
@@ -1396,8 +1394,6 @@ simulation_test!(
     }
 );
 
-
-
 simulation_test!(
     lix_directory_insert_on_conflict_path_rejects_missing_path,
     |sim| async move {
@@ -1662,7 +1658,10 @@ simulation_test!(
         );
 
         let files = session
-            .execute("SELECT id, path FROM lix_file", &[])
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("file read after recursive delete must not be poisoned by an orphan");
         assert_eq!(
@@ -1672,7 +1671,10 @@ simulation_test!(
         );
 
         let directories = session
-            .execute("SELECT id, path FROM lix_directory", &[])
+            .execute(
+                "SELECT id, path FROM lix_directory WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("directory read after recursive delete must not be poisoned by an orphan");
         assert_eq!(directories.len(), 0, "the directory must be deleted");
@@ -1722,13 +1724,19 @@ simulation_test!(
         );
 
         let files = session
-            .execute("SELECT id, path FROM lix_file", &[])
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("file read after recursive delete must not be poisoned by an orphan");
         assert_eq!(files.len(), 0, "no nested file may survive its parent tree");
 
         let directories = session
-            .execute("SELECT id, path FROM lix_directory", &[])
+            .execute(
+                "SELECT id, path FROM lix_directory WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("directory read after recursive delete must not be poisoned by an orphan");
         assert_eq!(directories.len(), 0, "the whole tree must be deleted");
@@ -1774,7 +1782,10 @@ simulation_test!(
         assert_eq!(delete_result, ExecuteResult::from_rows_affected(2));
 
         let directories = session
-            .execute("SELECT id, path FROM lix_directory", &[])
+            .execute(
+                "SELECT id, path FROM lix_directory WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("directory read after recursive delete should succeed");
         assert_eq!(directories.len(), 0);
@@ -1830,13 +1841,19 @@ simulation_test!(
         );
 
         let files = session
-            .execute("SELECT id, path FROM lix_file", &[])
+            .execute(
+                "SELECT id, path FROM lix_file WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("file read after reboot must not be poisoned by an orphan");
         assert_eq!(files.len(), 0);
 
         let directories = session
-            .execute("SELECT id, path FROM lix_directory", &[])
+            .execute(
+                "SELECT id, path FROM lix_directory WHERE path = '/docs' OR path LIKE '/docs/%'",
+                &[],
+            )
             .await
             .expect("directory read after reboot must not be poisoned by an orphan");
         assert_eq!(directories.len(), 0);

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -7,6 +7,113 @@ use serde_json::json;
 use super::assert_rows_eq;
 
 simulation_test!(
+    bootstrap_lix_files_belong_to_initial_main_commit,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+        let initial_head = engine
+            .load_branch_head_commit_id(sim.main_branch_id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(initial_head, sim.initial_commit_id());
+        let readme = include_bytes!("../../../src/init_readme.md");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT path, content FROM lix_file WHERE path = '/.lix/README.md'",
+                    &[],
+                )
+                .await
+                .unwrap(),
+            vec![vec![
+                Value::Text("/.lix/README.md".into()),
+                Value::Blob(readme.to_vec().into()),
+            ]],
+        );
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT path FROM lix_directory WHERE path LIKE '/.lix%' ORDER BY path",
+                    &[],
+                )
+                .await
+                .unwrap(),
+            vec![
+                vec![Value::Text("/.lix".into())],
+                vec![Value::Text("/.lix/app_data".into())],
+                vec![Value::Text("/.lix/plugins".into())],
+            ],
+        );
+        assert_rows_eq(
+        session.execute(
+            "SELECT content, lixcol_depth FROM lix_history('lix_file', $1) WHERE path = '/.lix/README.md'",
+            &[Value::Text(initial_head.clone())],
+        ).await.unwrap(),
+        vec![vec![Value::Blob(readme.to_vec().into()), Value::Integer(0)]],
+    );
+        assert!(
+            session
+                .execute("SELECT id FROM lix_diff('lix_file')", &[])
+                .await
+                .unwrap()
+                .rows()
+                .is_empty()
+        );
+        let global = engine
+            .open_session_at(crate::GLOBAL_BRANCH_ID)
+            .await
+            .unwrap();
+        assert!(
+            global
+                .execute("SELECT * FROM lix_file", &[])
+                .await
+                .unwrap()
+                .rows()
+                .is_empty()
+        );
+        assert!(
+            global
+                .execute("SELECT * FROM lix_directory", &[])
+                .await
+                .unwrap()
+                .rows()
+                .is_empty()
+        );
+        assert_eq!(
+            engine
+                .load_branch_head_commit_id(sim.main_branch_id())
+                .await
+                .unwrap()
+                .unwrap(),
+            initial_head
+        );
+
+        session.execute("UPDATE lix_file SET content = CAST('custom guide' AS BYTEA) WHERE path = '/.lix/README.md'", &[])
+        .await.unwrap();
+        let reopened_engine = sim.reboot_engine_from_current_snapshot().await.unwrap();
+        let reopened = reopened_engine.open_session().await.unwrap();
+        assert_rows_eq(
+            reopened
+                .execute(
+                    "SELECT content FROM lix_file WHERE path = '/.lix/README.md'",
+                    &[],
+                )
+                .await
+                .unwrap(),
+            vec![vec![Value::Blob(b"custom guide".to_vec().into())]],
+        );
+        assert_rows_eq(
+        reopened.execute(
+            "SELECT content FROM lix_history('lix_file', $1) WHERE path = '/.lix/README.md'",
+            &[Value::Text(initial_head)],
+        ).await.unwrap(),
+        vec![vec![Value::Blob(readme.to_vec().into())]],
+    );
+    }
+);
+
+simulation_test!(
     lix_file_public_timestamps_cover_descriptor_and_content_revisions,
     |sim| async move {
         let engine = sim.boot_engine().await;

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -8,7 +8,6 @@ use std::fmt::Write as _;
 use std::future::Future;
 use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -96,9 +95,7 @@ impl FilesystemStorageOptions {
 
     pub fn open(self) -> Result<FilesystemStorage, LixError> {
         let layout = prepare_filesystem_layout(&self.path)?;
-        let initial_import = !layout.lix_dir.join(".internal").exists();
         Ok(FilesystemStorage {
-            initial_import: Arc::new(AtomicBool::new(initial_import)),
             inner: open_filesystem_rocksdb(&layout)?,
             layout,
             sync_all_files: self.sync_all_files,
@@ -133,7 +130,6 @@ struct FilesystemPathFilter {
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct FilesystemStorage {
-    initial_import: Arc<AtomicBool>,
     inner: RocksDBFilesystem,
     layout: FilesystemLayout,
     sync_all_files: bool,
@@ -348,7 +344,6 @@ impl FilesystemStorage {
         Box::pin(async move {
             let startup = FilesystemSyncStartup::begin(Arc::clone(&self.sync_lifecycle))?;
             let supervisor = self.open_supervisor(lix).await?;
-            self.initial_import.store(false, Ordering::Release);
             startup.complete(supervisor);
             Ok(())
         })
@@ -421,7 +416,6 @@ impl FilesystemStorage {
             sync_lix,
             self.layout.clone(),
             FilesystemPathFilter::from_sync_all_files(self.sync_all_files),
-            self.initial_import.load(Ordering::Acquire),
         )
         .await
     }
@@ -607,7 +601,6 @@ impl FilesystemSupervisor {
         lix: Lix<RocksDBFilesystem>,
         layout: FilesystemLayout,
         path_filter: FilesystemPathFilter,
-        initial_import: bool,
     ) -> Result<Self, LixError> {
         validate_filesystem_root_directory(&layout.root)?;
         validate_filesystem_lix_directory(&layout.lix_dir)?;
@@ -619,10 +612,60 @@ impl FilesystemSupervisor {
             last_materialized: Mutex::new(None),
         });
 
+        // Storage creation is not evidence that repository content reached disk.
+        // Read completion at sync startup so separately opened handles and process
+        // restarts agree on whether missing paths can represent deletions.
+        let completion = state
+            .layout
+            .lix_dir
+            .join(".internal/filesystem-materialized");
+        let initial_import = !completion.try_exists().map_err(|error| {
+            io_error("read filesystem materialization marker", &completion, error)
+        })?;
         state
             .sync_disk_to_lix_with_initial_import(false, initial_import)
             .await?;
         state.sync_from_lix().await?;
+        if initial_import && state.path_filter().is_unfiltered() {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&completion)
+            {
+                Ok(marker) => {
+                    marker.sync_all().map_err(|error| {
+                        io_error(
+                            "persist filesystem materialization marker",
+                            &completion,
+                            error,
+                        )
+                    })?;
+                    #[cfg(unix)]
+                    {
+                        let parent = completion
+                            .parent()
+                            .expect("marker has an internal directory");
+                        std::fs::File::open(parent)
+                            .and_then(|directory| directory.sync_all())
+                            .map_err(|error| {
+                                io_error(
+                                    "persist filesystem materialization directory",
+                                    parent,
+                                    error,
+                                )
+                            })?;
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(io_error(
+                        "write filesystem materialization marker",
+                        &completion,
+                        error,
+                    ));
+                }
+            }
+        }
 
         let (event_tx, event_rx) = mpsc::channel();
         let callback_tx = event_tx.clone();
@@ -2552,7 +2595,6 @@ mod tests {
         path_filter: FilesystemPathFilter,
     ) -> FilesystemState {
         let storage = FilesystemStorage {
-            initial_import: Arc::new(AtomicBool::new(false)),
             inner: open_filesystem_rocksdb(&layout).unwrap(),
             layout: layout.clone(),
             sync_all_files: path_filter.is_unfiltered(),

--- a/packages/storage-filesystem/src/filesystem.rs
+++ b/packages/storage-filesystem/src/filesystem.rs
@@ -8,6 +8,7 @@ use std::fmt::Write as _;
 use std::future::Future;
 use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Weak, mpsc};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -95,7 +96,9 @@ impl FilesystemStorageOptions {
 
     pub fn open(self) -> Result<FilesystemStorage, LixError> {
         let layout = prepare_filesystem_layout(&self.path)?;
+        let initial_import = !layout.lix_dir.join(".internal").exists();
         Ok(FilesystemStorage {
+            initial_import: Arc::new(AtomicBool::new(initial_import)),
             inner: open_filesystem_rocksdb(&layout)?,
             layout,
             sync_all_files: self.sync_all_files,
@@ -130,6 +133,7 @@ struct FilesystemPathFilter {
 #[derive(Clone)]
 #[expect(missing_debug_implementations)]
 pub struct FilesystemStorage {
+    initial_import: Arc<AtomicBool>,
     inner: RocksDBFilesystem,
     layout: FilesystemLayout,
     sync_all_files: bool,
@@ -344,6 +348,7 @@ impl FilesystemStorage {
         Box::pin(async move {
             let startup = FilesystemSyncStartup::begin(Arc::clone(&self.sync_lifecycle))?;
             let supervisor = self.open_supervisor(lix).await?;
+            self.initial_import.store(false, Ordering::Release);
             startup.complete(supervisor);
             Ok(())
         })
@@ -416,6 +421,7 @@ impl FilesystemStorage {
             sync_lix,
             self.layout.clone(),
             FilesystemPathFilter::from_sync_all_files(self.sync_all_files),
+            self.initial_import.load(Ordering::Acquire),
         )
         .await
     }
@@ -601,6 +607,7 @@ impl FilesystemSupervisor {
         lix: Lix<RocksDBFilesystem>,
         layout: FilesystemLayout,
         path_filter: FilesystemPathFilter,
+        initial_import: bool,
     ) -> Result<Self, LixError> {
         validate_filesystem_root_directory(&layout.root)?;
         validate_filesystem_lix_directory(&layout.lix_dir)?;
@@ -612,7 +619,9 @@ impl FilesystemSupervisor {
             last_materialized: Mutex::new(None),
         });
 
-        state.sync_disk_to_lix(false).await?;
+        state
+            .sync_disk_to_lix_with_initial_import(false, initial_import)
+            .await?;
         state.sync_from_lix().await?;
 
         let (event_tx, event_rx) = mpsc::channel();
@@ -813,6 +822,15 @@ impl FilesystemState {
     }
 
     async fn sync_disk_to_lix(&self, skip_if_last_materialized: bool) -> Result<(), LixError> {
+        self.sync_disk_to_lix_with_initial_import(skip_if_last_materialized, false)
+            .await
+    }
+
+    async fn sync_disk_to_lix_with_initial_import(
+        &self,
+        skip_if_last_materialized: bool,
+        initial_import: bool,
+    ) -> Result<(), LixError> {
         let _guard = self.sync_lock.lock().await;
         let path_filter = self.path_filter();
         let local = collect_local_snapshot(&self.layout, &path_filter)?;
@@ -824,7 +842,14 @@ impl FilesystemState {
                 return Ok(());
             }
         }
-        let previous = self.last_materialized_disk();
+        // A new repository has never materialized its bootstrap content. Treat
+        // absent disk paths as not yet exported, not as user deletions. Existing
+        // disk files are still imported and take precedence at matching paths.
+        let previous = if initial_import {
+            Some(Snapshot::default())
+        } else {
+            self.last_materialized_disk()
+        };
         let lix = self
             .apply_local_snapshot_to_lix_with_filter(&local, previous.as_ref(), &path_filter)
             .await?;
@@ -2527,6 +2552,7 @@ mod tests {
         path_filter: FilesystemPathFilter,
     ) -> FilesystemState {
         let storage = FilesystemStorage {
+            initial_import: Arc::new(AtomicBool::new(false)),
             inner: open_filesystem_rocksdb(&layout).unwrap(),
             layout: layout.clone(),
             sync_all_files: path_filter.is_unfiltered(),

--- a/packages/storage-filesystem/tests/runtime_contract.rs
+++ b/packages/storage-filesystem/tests/runtime_contract.rs
@@ -31,10 +31,51 @@ fn open_and_start_sync_work_under_plain_block_on() {
             .expect("read synchronized file");
         assert_eq!(result.rows().len(), 1);
 
+        assert_eq!(
+            std::fs::read(root.path().join(".lix/README.md")).expect("bootstrap README on disk"),
+            include_bytes!("../../lix/src/init_readme.md"),
+        );
+        assert!(root.path().join(".lix/app_data").is_dir());
+        assert!(root.path().join(".lix/plugins").is_dir());
+
         storage
             .stop_sync()
             .await
             .expect("stop sync under plain block_on");
         lix.close().await.expect("close Lix");
     });
+
+    // Offline edits and deletions in an existing repository still win on reopen.
+    for content in [Some(b"custom guide".as_slice()), None] {
+        let path = root.path().join(".lix/README.md");
+        if let Some(content) = content {
+            std::fs::write(&path, content).unwrap();
+        } else {
+            std::fs::remove_file(&path).unwrap();
+        }
+        futures_lite::future::block_on(async {
+            let storage = FilesystemStorage::new(root.path()).open().unwrap();
+            let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+            storage.start_sync(&lix).await.unwrap();
+            let result = lix
+                .execute(
+                    "SELECT content FROM lix_file WHERE path = '/.lix/README.md'",
+                    &[],
+                )
+                .await
+                .unwrap();
+            if let Some(content) = content {
+                assert_eq!(
+                    result.rows()[0].values(),
+                    &[Value::Blob(content.to_vec().into())]
+                );
+                assert_eq!(std::fs::read(&path).unwrap(), content);
+            } else {
+                assert!(result.rows().is_empty());
+                assert!(!path.exists());
+            }
+            storage.stop_sync().await.unwrap();
+            lix.close().await.unwrap();
+        });
+    }
 }

--- a/packages/storage-filesystem/tests/runtime_contract.rs
+++ b/packages/storage-filesystem/tests/runtime_contract.rs
@@ -79,3 +79,106 @@ fn open_and_start_sync_work_under_plain_block_on() {
         });
     }
 }
+
+#[test]
+fn bootstrap_survives_storage_reopen_before_first_sync() {
+    let root = tempfile::tempdir().unwrap();
+    futures_lite::future::block_on(async {
+        let storage = FilesystemStorage::new(root.path()).open().unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        lix.close().await.unwrap();
+    });
+    assert!(!root.path().join(".lix/README.md").exists());
+    assert!(
+        !root
+            .path()
+            .join(".lix/.internal/filesystem-materialized")
+            .exists()
+    );
+    futures_lite::future::block_on(async {
+        let storage = FilesystemStorage::new(root.path()).open().unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        storage.start_sync(&lix).await.unwrap();
+        assert_eq!(
+            std::fs::read(root.path().join(".lix/README.md")).unwrap(),
+            include_bytes!("../../lix/src/init_readme.md")
+        );
+        assert!(root.path().join(".lix/app_data").is_dir());
+        assert!(
+            root.path()
+                .join(".lix/.internal/filesystem-materialized")
+                .is_file()
+        );
+        storage.stop_sync().await.unwrap();
+        lix.close().await.unwrap();
+    });
+}
+
+#[test]
+fn separately_opened_storage_reads_completion_when_sync_starts() {
+    let root = tempfile::tempdir().unwrap();
+    futures_lite::future::block_on(async {
+        let first = FilesystemStorage::new(root.path()).open().unwrap();
+        let second = FilesystemStorage::new(root.path()).open().unwrap();
+        let first_lix = open_lix().with_storage(first.clone()).await.unwrap();
+        let second_lix = open_lix().with_storage(second.clone()).await.unwrap();
+        second.start_sync(&second_lix).await.unwrap();
+        let readme = root.path().join(".lix/README.md");
+        assert_eq!(
+            std::fs::read(&readme).unwrap(),
+            include_bytes!("../../lix/src/init_readme.md")
+        );
+        assert!(root.path().join(".lix/app_data").is_dir());
+        second.stop_sync().await.unwrap();
+        std::fs::remove_file(&readme).unwrap();
+        // The first handle predates completion, but must now honor this deletion.
+        first.start_sync(&first_lix).await.unwrap();
+        assert!(!readme.exists());
+        assert!(
+            first_lix
+                .execute(
+                    "SELECT id FROM lix_file WHERE path = '/.lix/README.md'",
+                    &[]
+                )
+                .await
+                .unwrap()
+                .rows()
+                .is_empty()
+        );
+        first.stop_sync().await.unwrap();
+        first_lix.close().await.unwrap();
+        second_lix.close().await.unwrap();
+    });
+}
+
+#[test]
+fn failed_initial_sync_does_not_record_materialization() {
+    let root = tempfile::tempdir().unwrap();
+    futures_lite::future::block_on(async {
+        let storage = FilesystemStorage::new(root.path()).open().unwrap();
+        let lix = open_lix().with_storage(storage.clone()).await.unwrap();
+        let conflict = root.path().join(".lix/app_data");
+        std::fs::write(&conflict, b"blocks the bootstrap directory").unwrap();
+        assert!(storage.start_sync(&lix).await.is_err());
+        assert!(
+            !root
+                .path()
+                .join(".lix/.internal/filesystem-materialized")
+                .exists()
+        );
+        std::fs::remove_file(conflict).unwrap();
+        storage.start_sync(&lix).await.unwrap();
+        assert_eq!(
+            std::fs::read(root.path().join(".lix/README.md")).unwrap(),
+            include_bytes!("../../lix/src/init_readme.md")
+        );
+        assert!(root.path().join(".lix/app_data").is_dir());
+        assert!(
+            root.path()
+                .join(".lix/.internal/filesystem-materialized")
+                .is_file()
+        );
+        storage.stop_sync().await.unwrap();
+        lix.close().await.unwrap();
+    });
+}


### PR DESCRIPTION
New repositories now contain `.lix/README.md`, `.lix/app_data/`, and `.lix/plugins/` in the initial commit on `main`. The README explains application data, plugin archives, and the filesystem adapter’s local `.internal/` and `.gitignore` files. Bootstrap content is branch-local, has stored file bytes and history from the first commit, and starts with an empty working diff.

The filesystem adapter preserves this content during a new repository’s first disk import. A persistent completion marker is written only after successful full materialization and checked at sync startup, so opening storage twice or restarting before first sync cannot discard bootstrap content. Existing disk files still take precedence, and subsequent opens preserve offline README edits and deletions. Update tests that assumed an empty filesystem and align the sync-history fixture with production’s checkpoint-body fetching.

Validation:
- Engine library suite with `all-simulations`: 3,526 passed, 74 ignored (Cargo runner, serial; `cargo-nextest` is unavailable locally).
- Filesystem adapter suite: 24 unit tests and 4 runtime integration tests passed, covering bootstrap materialization, offline edits/deletions, reopen before first sync, two independently opened handles, and failed initial sync retry.
- Engine doctests: 10 passed.
- `git diff --check` passed.
