### PR TITLE
Fix epoch migrations for sync-owned repositories

### DIFF
--- a/.changenotes/fix-owned-repository-migration.md
+++ b/.changenotes/fix-owned-repository-migration.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed migrations failing when opening repositories connected to sync.
+
+Existing server repositories and local replicas now retain their sync ownership while migrating, allowing previously failed opens to be retried without deleting repository data.

--- a/.changenotes/migration-error-diagnostics.md
+++ b/.changenotes/migration-error-diagnostics.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+Server migration failures now return a safe diagnostic message and the originating migration error code when available, including failures returned to later callers. Copy destination precondition conflicts are identified explicitly; other failures direct operators to the full server logs without exposing storage credentials. HTTP status codes and retry behavior are unchanged.

--- a/packages/lix/src/migration/epoch.rs
+++ b/packages/lix/src/migration/epoch.rs
@@ -831,16 +831,16 @@ where
         let candidate_result = async {
             clear_bank(&target).await?;
             let _ = copy_repository(&migration_source, &target).await?;
-            let mut marker_write = target.new_write_set();
-            marker_write.put(
+            write_candidate_page(
+                &target,
                 crate::init::REPOSITORY_PROTOCOL_SPACE,
-                crate::init::REPOSITORY_PROTOCOL_KEY,
-                original_marker.as_ref(),
-            );
-            target
-                .commit_write_set(marker_write, durable_candidate_write_options())
-                .await
-                .map_err(|error| epoch_error(format!("candidate marker write failed: {error}")))?;
+                single_put(
+                    crate::init::REPOSITORY_PROTOCOL_KEY,
+                    original_marker.clone(),
+                ),
+            )
+            .await
+            .map_err(|error| epoch_error(format!("candidate marker write failed: {error}")))?;
             super::migrate_lix_with_adapter(
                 storage.clone(),
                 target.clone(),
@@ -1149,15 +1149,19 @@ where
                     .key
                     .clone(),
             );
-            let mut writes = target.new_write_set();
+            let mut batch = PutBatch {
+                entries: Vec::with_capacity(entries.len()),
+            };
             for entry in entries {
                 let ProjectedValue::FullValue(value) = entry.value else {
                     return Err(epoch_error("full-value epoch scan returned a key-only row"));
                 };
-                writes.put(space, entry.key, StoredValue { bytes: value });
+                batch.entries.push(PutEntry {
+                    key: entry.key,
+                    value: StoredValue { bytes: value },
+                });
             }
-            target
-                .commit_write_set(writes, durable_candidate_write_options())
+            write_candidate_page(target, space, batch)
                 .await
                 .map_err(|error| epoch_error(format!("copy target write failed: {error}")))?;
             if !has_more {
@@ -1167,6 +1171,23 @@ where
         }
     }
     Ok(revision)
+}
+
+// Copying an existing sync role is not an ordinary repository mutation. Its
+// replica/authority marker must not fence subsequent candidate writes. The
+// migration write retains the exact epoch claim and durable publication rules.
+async fn write_candidate_page<S: Storage>(
+    target: &StorageAdapter<S>,
+    space: StorageSpace,
+    batch: PutBatch,
+) -> Result<(), StorageError> {
+    let mut write = target
+        .begin_migration_write(durable_candidate_write_options())
+        .await?;
+    write.put_many(space, batch).await?;
+    crate::storage_adapter::stage_mutation_revision(&mut write).await?;
+    write.commit().await?;
+    Ok(())
 }
 
 async fn read_copy_page<S>(
@@ -2460,6 +2481,145 @@ mod tests {
         });
         publish_pointer_absent(storage, &active).await.unwrap();
         active
+    }
+
+    #[tokio::test]
+    async fn migration_preserves_sync_ownership_across_legacy_and_active_banks() {
+        let replica = Bytes::from_static(
+            br#"{
+            "activeAccountId": "migration-test",
+            "cursor": 0,
+            "authoritativeBranches": {},
+            "authorityKnownCommitIds": []
+        }"#,
+        );
+        for (ownership_key, ownership_value) in [
+            (
+                &b"authority"[..],
+                Bytes::from_static(crate::sync::AUTHORITY_STATE_VALUE),
+            ),
+            (&b"repository"[..], replica),
+        ] {
+            for bank in [EpochBank::Legacy, EpochBank::A] {
+                let storage = crate::Memory::new();
+                let active = seed_active_v75(&storage, bank, 7).await;
+                if bank == EpochBank::Legacy {
+                    delete_pointer(&storage, &active).await.unwrap();
+                }
+                let source = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+                let mut write = source
+                    .begin_migration_write(WriteOptions::default())
+                    .await
+                    .unwrap();
+                write
+                    .put_many(
+                        crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                        single_put(ownership_key, ownership_value.clone()),
+                    )
+                    .await
+                    .unwrap();
+                // This space sorts after sync ownership, so copying it exercises
+                // the first write after the candidate acquires the source role.
+                write
+                    .put_many(
+                        crate::sync::SYNC_UPLOAD_GENERATION_SPACE,
+                        single_put(b"preserved-upload", Bytes::from_static(b"preserved-value")),
+                    )
+                    .await
+                    .unwrap();
+                write.commit().await.unwrap();
+
+                let admitted = admit_repository(&storage, None)
+                    .await
+                    .expect("owned repository must migrate");
+                assert_eq!(admitted.report.format, crate::init::CURRENT_FORMAT_VERSION);
+                for (space, key, expected) in [
+                    (
+                        crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                        Bytes::from_static(ownership_key),
+                        ownership_value.clone(),
+                    ),
+                    (
+                        crate::sync::SYNC_UPLOAD_GENERATION_SPACE,
+                        Bytes::from_static(b"preserved-upload"),
+                        Bytes::from_static(b"preserved-value"),
+                    ),
+                ] {
+                    let read = admitted
+                        .adapter
+                        .begin_read(ReadOptions::default())
+                        .await
+                        .unwrap();
+                    let keys = [Key(key)];
+                    let result = read
+                        .get_many(&[GetManyRequest {
+                            space,
+                            keys: &keys,
+                            opts: GetOptions::default(),
+                        }])
+                        .await
+                        .unwrap();
+                    assert_eq!(
+                        result.values,
+                        vec![Some(ProjectedValue::FullValue(expected))]
+                    );
+                }
+                let mut ordinary = admitted.adapter.new_write_set();
+                ordinary.put(
+                    crate::json_store::JSON_SPACE,
+                    &b"forbidden"[..],
+                    &b"write"[..],
+                );
+                assert!(
+                    admitted
+                        .adapter
+                        .commit_write_set(ordinary, WriteOptions::default())
+                        .await
+                        .is_err(),
+                    "migration must not grant ordinary writers authority"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn candidate_copy_cannot_write_after_losing_its_epoch_claim() {
+        let storage = crate::Memory::new();
+        let claim = encode_pointer(PointerState::Migrating {
+            source: EpochBank::Legacy,
+            source_format: 0,
+            target: EpochBank::A,
+            generation: 1,
+            attempt: uuid::Uuid::from_u128(90),
+        });
+        publish_migration_claim_absent(&storage, &claim)
+            .await
+            .unwrap();
+        let target =
+            StorageAdapter::for_epoch_migration(storage.clone(), EpochBank::A, claim.clone());
+        delete_pointer(&storage, &claim).await.unwrap();
+        assert_eq!(
+            write_candidate_page(
+                &target,
+                crate::json_store::JSON_SPACE,
+                single_put(b"late", Bytes::from_static(b"forbidden"))
+            )
+            .await
+            .unwrap_err(),
+            StorageError::Fenced,
+        );
+        let unfenced = StorageAdapter::for_epoch_unfenced(storage, EpochBank::A);
+        let read = unfenced.begin_read(ReadOptions::default()).await.unwrap();
+        let keys = [Key(Bytes::from_static(b"late"))];
+        let result = read
+            .get_many(&[GetManyRequest {
+                space: crate::json_store::JSON_SPACE,
+                keys: &keys,
+                opts: GetOptions::default(),
+            }])
+            .await
+            .unwrap();
+        assert_eq!(result.values, vec![None]);
     }
 
     #[test]

--- a/packages/server/src/routes.rs
+++ b/packages/server/src/routes.rs
@@ -885,24 +885,30 @@ fn lix_error(error: LixRuntimeError) -> Response {
         LixRuntimeError::MigrationFailed {
             from_version,
             to_version,
+            diagnostic,
         } => protocol_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "LIX_ERROR_LIX_MIGRATION_FAILED",
-            "The lix repository migration failed.",
+            format!(
+                "The lix repository migration failed. {}",
+                diagnostic.message
+            ),
             Some("Contact the service operator to recover the repository.".to_string()),
             Some(json!({
                 "fromVersion": from_version,
                 "toVersion": to_version,
+                "sourceCode": diagnostic.source_code,
                 "operation": "lix_open",
                 "retryable": false,
             })),
         ),
-        LixRuntimeError::UpgradeFailed => protocol_error(
+        LixRuntimeError::UpgradeFailed(diagnostic) => protocol_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "LIX_ERROR_LIX_MIGRATION_FAILED",
-            "The lix repository upgrade failed.",
+            format!("The lix repository upgrade failed. {}", diagnostic.message),
             Some("Contact the service operator to recover the repository.".to_string()),
             Some(json!({
+                "sourceCode": diagnostic.source_code,
                 "operation": "lix_open",
                 "retryable": false,
             })),
@@ -1815,6 +1821,12 @@ mod tests {
     #[tokio::test]
     async fn failed_lix_migration_is_a_terminal_structured_error() {
         let response = lix_error(LixRuntimeError::MigrationFailed {
+            diagnostic: crate::store::MigrationDiagnostic::from_error(&anyhow::Error::new(
+                lix_sdk::LixError::new(
+                    "LIX_ERROR_MIGRATION_FAILED",
+                    "copy target write failed: precondition failed: private-storage-secret",
+                ),
+            )),
             from_version: 68,
             to_version: 71,
         });
@@ -1825,11 +1837,12 @@ mod tests {
             json_body(response).await["error"],
             json!({
                 "code": "LIX_ERROR_LIX_MIGRATION_FAILED",
-                "message": "The lix repository migration failed.",
+                "message": "The lix repository migration failed. The migration could not copy repository data because the destination write precondition failed.",
                 "hint": "Contact the service operator to recover the repository.",
                 "details": {
                     "fromVersion": 68,
                     "toVersion": 71,
+                    "sourceCode": "LIX_ERROR_MIGRATION_FAILED",
                     "operation": "lix_open",
                     "retryable": false,
                 },
@@ -1839,7 +1852,11 @@ mod tests {
 
     #[tokio::test]
     async fn pre_progress_upgrade_failure_is_a_terminal_structured_error() {
-        let response = lix_error(LixRuntimeError::UpgradeFailed);
+        let response = lix_error(LixRuntimeError::UpgradeFailed(
+            crate::store::MigrationDiagnostic::from_error(&anyhow::Error::new(
+                lix_sdk::LixError::new("LIX_ERROR_REPOSITORY_UPGRADE", "private-storage-secret"),
+            )),
+        ));
 
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert!(!response.headers().contains_key(header::RETRY_AFTER));
@@ -1847,9 +1864,10 @@ mod tests {
             json_body(response).await["error"],
             json!({
                 "code": "LIX_ERROR_LIX_MIGRATION_FAILED",
-                "message": "The lix repository upgrade failed.",
+                "message": "The lix repository upgrade failed. The migration could not complete. The service operator can inspect the server logs for the underlying cause.",
                 "hint": "Contact the service operator to recover the repository.",
                 "details": {
+                    "sourceCode": "LIX_ERROR_REPOSITORY_UPGRADE",
                     "operation": "lix_open",
                     "retryable": false,
                 },

--- a/packages/server/src/store.rs
+++ b/packages/server/src/store.rs
@@ -156,8 +156,44 @@ struct ManagerState {
     state_drop_probe: Option<CacheRootLeaseDropProbe>,
 }
 
+// Only expose fixed diagnostic text, never arbitrary storage errors or credentials.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MigrationDiagnostic {
+    pub source_code: Option<&'static str>,
+    pub message: &'static str,
+}
+
+impl MigrationDiagnostic {
+    pub(crate) fn from_error(error: &anyhow::Error) -> Self {
+        let source = error
+            .chain()
+            .find_map(|source| source.downcast_ref::<lix_sdk::LixError>());
+        let source_code = source.and_then(|error| match error.code.as_str() {
+            "LIX_ERROR_MIGRATION_FAILED" => Some("LIX_ERROR_MIGRATION_FAILED"),
+            "LIX_ERROR_REPOSITORY_UPGRADE" => Some("LIX_ERROR_REPOSITORY_UPGRADE"),
+            _ => None,
+        });
+        let message = match source {
+            Some(error)
+                if error.message.starts_with("copy target write failed:")
+                    && error.message.contains("precondition failed") =>
+            {
+                "The migration could not copy repository data because the destination write precondition failed."
+            }
+            _ => {
+                "The migration could not complete. The service operator can inspect the server logs for the underlying cause."
+            }
+        };
+        Self {
+            source_code,
+            message,
+        }
+    }
+}
+
 #[derive(Clone, Copy)]
 struct FailedMigration {
+    diagnostic: MigrationDiagnostic,
     from_version: u32,
     to_version: u32,
 }
@@ -165,7 +201,7 @@ struct FailedMigration {
 #[derive(Clone, Copy)]
 enum FailedUpgrade {
     Versioned(FailedMigration),
-    Unversioned,
+    Unversioned(MigrationDiagnostic),
 }
 
 #[cfg(test)]
@@ -218,9 +254,16 @@ enum CleanupState {
 #[derive(Clone)]
 enum RuntimeOpenState {
     Opening,
-    Migrating { from_version: u32, to_version: u32 },
-    MigrationFailed { from_version: u32, to_version: u32 },
-    UpgradeFailed,
+    Migrating {
+        from_version: u32,
+        to_version: u32,
+    },
+    MigrationFailed {
+        from_version: u32,
+        to_version: u32,
+        diagnostic: MigrationDiagnostic,
+    },
+    UpgradeFailed(MigrationDiagnostic),
     Ready,
     Failed(Arc<str>),
 }
@@ -245,8 +288,9 @@ fn runtime_error_from_failed_upgrade(failure: FailedUpgrade) -> LixRuntimeError 
         FailedUpgrade::Versioned(failure) => LixRuntimeError::MigrationFailed {
             from_version: failure.from_version,
             to_version: failure.to_version,
+            diagnostic: failure.diagnostic,
         },
-        FailedUpgrade::Unversioned => LixRuntimeError::UpgradeFailed,
+        FailedUpgrade::Unversioned(diagnostic) => LixRuntimeError::UpgradeFailed(diagnostic),
     }
 }
 
@@ -289,10 +333,19 @@ enum GetRuntimeAction {
 pub(crate) enum LixRuntimeError {
     InvalidId,
     NotFound,
-    AtCapacity { max: usize },
-    Migrating { from_version: u32, to_version: u32 },
-    MigrationFailed { from_version: u32, to_version: u32 },
-    UpgradeFailed,
+    AtCapacity {
+        max: usize,
+    },
+    Migrating {
+        from_version: u32,
+        to_version: u32,
+    },
+    MigrationFailed {
+        from_version: u32,
+        to_version: u32,
+        diagnostic: MigrationDiagnostic,
+    },
+    UpgradeFailed(MigrationDiagnostic),
     Recovering,
     ShuttingDown,
     Cleanup(Arc<str>),
@@ -549,14 +602,16 @@ impl LixRuntimeManager {
                         RuntimeOpenState::MigrationFailed {
                             from_version,
                             to_version,
+                            diagnostic,
                         } => {
                             return Err(LixRuntimeError::MigrationFailed {
                                 from_version,
                                 to_version,
+                                diagnostic,
                             });
                         }
-                        RuntimeOpenState::UpgradeFailed => {
-                            return Err(LixRuntimeError::UpgradeFailed);
+                        RuntimeOpenState::UpgradeFailed(diagnostic) => {
+                            return Err(LixRuntimeError::UpgradeFailed(diagnostic));
                         }
                         RuntimeOpenState::Opening => {
                             if opened.changed().await.is_err() {
@@ -603,16 +658,18 @@ impl LixRuntimeManager {
                         opener.done.send_replace(RuntimeOpenState::Ready);
                     }
                     Err(error) => {
+                        let diagnostic = MigrationDiagnostic::from_error(&error);
                         let failed_upgrade = match opener.done.borrow().clone() {
                             RuntimeOpenState::Migrating {
                                 from_version,
                                 to_version,
                             } => Some(FailedUpgrade::Versioned(FailedMigration {
+                                diagnostic,
                                 from_version,
                                 to_version,
                             })),
                             _ if is_repository_upgrade_failure(&error) => {
-                                Some(FailedUpgrade::Unversioned)
+                                Some(FailedUpgrade::Unversioned(diagnostic))
                             }
                             _ => None,
                         };
@@ -632,15 +689,18 @@ impl LixRuntimeManager {
                                     opener.done.send_replace(RuntimeOpenState::MigrationFailed {
                                         from_version: failure.from_version,
                                         to_version: failure.to_version,
+                                        diagnostic: failure.diagnostic,
                                     });
                                 }
-                                FailedUpgrade::Unversioned => {
+                                FailedUpgrade::Unversioned(diagnostic) => {
                                     tracing::error!(
                                         lix_id = %opener.lix_id,
                                         error = %error,
                                         "Lix repository upgrade failed"
                                     );
-                                    opener.done.send_replace(RuntimeOpenState::UpgradeFailed);
+                                    opener
+                                        .done
+                                        .send_replace(RuntimeOpenState::UpgradeFailed(diagnostic));
                                 }
                             }
                         }
@@ -1310,7 +1370,7 @@ async fn close_runtime_after_open(
                     .context("wait for Lix runtime opening during shutdown")?;
             }
             RuntimeOpenState::MigrationFailed { .. }
-            | RuntimeOpenState::UpgradeFailed
+            | RuntimeOpenState::UpgradeFailed(_)
             | RuntimeOpenState::Failed(_) => return Ok(()),
             RuntimeOpenState::Ready => {
                 let runtime = runtime
@@ -1344,11 +1404,12 @@ impl fmt::Display for LixRuntimeError {
             Self::MigrationFailed {
                 from_version,
                 to_version,
+                ..
             } => write!(
                 formatter,
                 "lix repository migration from v{from_version} to v{to_version} failed"
             ),
-            Self::UpgradeFailed => write!(formatter, "lix repository upgrade failed"),
+            Self::UpgradeFailed(_) => write!(formatter, "lix repository upgrade failed"),
             Self::Recovering => write!(formatter, "lix runtime is recovering"),
             Self::ShuttingDown => write!(formatter, "lix server is shutting down"),
             Self::Cleanup(error) => write!(formatter, "lix runtime cleanup: {error}"),
@@ -2137,28 +2198,35 @@ mod tests {
     #[tokio::test]
     async fn failed_migration_remains_terminal_for_every_caller() {
         let manager = memory_manager(1).await;
+        let diagnostic =
+            MigrationDiagnostic::from_error(&anyhow::Error::new(lix_sdk::LixError::new(
+                "LIX_ERROR_MIGRATION_FAILED",
+                "copy target write failed: precondition failed: secret",
+            )));
         manager.state.lock().await.failed_upgrades.insert(
             LIX_A.to_string(),
             FailedUpgrade::Versioned(FailedMigration {
+                diagnostic,
                 from_version: 68,
                 to_version: 71,
             }),
         );
 
-        assert!(matches!(
-            manager.get(LIX_A).await,
-            Err(LixRuntimeError::MigrationFailed {
-                from_version: 68,
-                to_version: 71,
-            })
-        ));
-        assert!(matches!(
-            manager.get(LIX_A).await,
-            Err(LixRuntimeError::MigrationFailed {
-                from_version: 68,
-                to_version: 71,
-            })
-        ));
+        for _ in 0..2 {
+            match manager.get(LIX_A).await {
+                Err(LixRuntimeError::MigrationFailed {
+                    from_version,
+                    to_version,
+                    diagnostic: actual,
+                }) => {
+                    assert_eq!((from_version, to_version), (68, 71));
+                    assert_eq!(actual.source_code, Some("LIX_ERROR_MIGRATION_FAILED"));
+                    assert_eq!(actual.message, diagnostic.message);
+                    assert!(!actual.message.contains("secret"));
+                }
+                _ => panic!("expected terminal migration error with diagnostic"),
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Epoch migrations of sync authorities and local replicas failed after copying their ownership metadata: subsequent candidate writes used ordinary-writer admission and were rejected by the newly copied ownership fence. This reproduced the production `copy target write failed: precondition failed: [PreconditionFailure { index: 1 }]` error that prevented `@opral/monorepo` from opening.

Copy candidate pages and restore the candidate format marker through the existing migration-only write capability. Exact epoch-claim fencing, durable writes, mutation revisions, source checks and ordinary-writer rejection remain intact. Copying remains linear in stored rows with bounded pages. A regression covers authority and replica migrations in legacy and active banks, plus rejection after losing the migration claim.

Server migration failures also retain a safe diagnostic through opening and cached failure states. Known copy conflicts return a specific explanation; arbitrary storage error text stays in private logs. Existing HTTP statuses and protocol error codes remain unchanged.

Validation: deterministic regression failed with the exact production error before the fix; 3,688 engine tests passed (69 skipped), 10 doctests and all 82 server tests passed. Independent reviews covered migration fences and safe diagnostics. Strict all-feature/all-target Clippy and formatting also passed. [Hosted CI 34379204420](https://github.com/opral/lix/actions/runs/34379204420) passed on the exact final head; merged as `c7c24f14826384f9636ea727847e92533566c513`.
