### PR TITLE
Rebuild clean replicas instead of migrating sparse history

### DIFF
--- a/.changenotes/rebuild-clean-replicas.md
+++ b/.changenotes/rebuild-clean-replicas.md
@@ -1,0 +1,9 @@
+---
+type: patch
+---
+
+Rebuild supported clean local replicas from the server during format upgrades,
+avoiding historical migrations over sparse downloaded data. The replacement is
+prepared and validated in a separate epoch before publication. Replicas with
+pending local work or an unproven recovery state are preserved and report
+`LIX_ERROR_REPLICA_UPGRADE_BLOCKED` instead of being reset.

--- a/docs/collaboration-and-sync.md
+++ b/docs/collaboration-and-sync.md
@@ -68,6 +68,29 @@ starting behind the server.
 Offline, cached reads and local writes work; undownloaded history and binary
 content are unavailable. Pending commits upload after reconnect.
 
+### Replica format upgrades
+
+When an older local replica needs a supported format upgrade, Lix first checks
+whether its local work is acknowledged by the server. A clean replica downloads
+current server state into a separate storage epoch instead of migrating its
+partial history. The new epoch becomes active only after bootstrap and validation
+succeed. The previous epoch is retained, and an unsuccessful download leaves it
+intact for retry. Upgrading this way requires the server to be reachable.
+
+If local work is pending, or Lix cannot prove that replacing the replica is safe,
+opening returns `LIX_ERROR_REPLICA_UPGRADE_BLOCKED`. Keep the local storage and
+recover that work before upgrading. Do not delete browser storage or change its
+name to bypass the error. This path does not automatically translate pending
+work between formats. Standalone and server repositories still migrate their
+stored history.
+
+The current rebuild proof supports format v77. It requires matching acknowledged
+head and checkpoint coordinates for all branches, including the global branch,
+and rejects pending restores, local-only rows (including tombstones), incomplete
+uploads, and checkpoint recovery references. Unknown older replica metadata is
+preserved and blocked. Supporting a future format requires checking its receipt
+and local-work representation; a format number alone never permits a reset.
+
 ## Receive collaborative updates
 
 Both remote and sync clients can observe queries:

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -31,7 +31,7 @@ await lix.close();
 | Neither | Fresh in-memory repository |
 | `storage` | Local repository, initialized if empty |
 | `server` | Execute against an existing hosted repository |
-| `storage` and `server` | Synchronized local reads; mutations execute on the server |
+| `storage` and `server` | Local reads and writes with background synchronization |
 
 Creation and deletion are explicit server operations:
 
@@ -64,8 +64,8 @@ execution do not require streaming uploads.
 
 ## Synchronized local repositories
 
-Combine storage with a server to keep a synchronized local read replica.
-Certified current-state reads can execute locally; mutations execute on the
+Combine storage with a server to keep a synchronized local replica. Reads and
+writes execute locally; background synchronization exchanges changes with the
 server:
 
 ```ts
@@ -83,11 +83,27 @@ const lix = await openLix({
 });
 ```
 
-A successful mutation confirms server acceptance. The local replica receives
-the resulting certified state automatically; older history and binary content
-load when needed. Connected mutations require the server, and cached reads may
-also need fresh server certification.
+A successful mutation confirms a local commit; it does not confirm server
+acceptance. Pending commits upload in the background. Cached reads and local
+writes work offline; older history and binary content load when needed.
 See [Collaboration and Sync](https://lix.dev/docs/collaboration-and-sync).
+
+### Upgrading a local replica
+
+Keep using the same storage name across SDK upgrades. When a supported older
+replica needs a format upgrade, Lix checks its durable synchronization receipts
+before replacing downloaded data. A replica whose local work is fully
+acknowledged is bootstrapped from the same server into a separate storage epoch.
+The replacement becomes active only after bootstrap and validation succeed;
+the previous epoch is retained. This requires a connection to the server.
+
+If Lix cannot prove that local work is safe to replace, opening fails with
+`LIX_ERROR_REPLICA_UPGRADE_BLOCKED`. Preserve the storage and arrange recovery
+of the local work before upgrading. Do not catch this error by deleting the
+storage or changing its name: that can abandon unsynchronized changes.
+Automatic conversion of pending local work is not part of this upgrade path.
+Standalone and authoritative repositories continue to use history-preserving
+format migrations.
 
 ## Remote repositories
 

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -250,7 +250,8 @@ where
             let wasm_runtime = self.wasm_runtime.clone();
             let telemetry = self.telemetry.clone();
             async move {
-                let admission = ensure_current_repository(&storage, Some(&open_progress)).await?;
+                let admission =
+                    ensure_current_repository(&storage, Some(&open_progress), None).await?;
                 let migrated_from = admission
                     .report
                     .migration
@@ -1143,7 +1144,8 @@ where
         None => None,
     };
     let open_progress: Arc<dyn OpenProgressSink> = retained_progress.clone();
-    let admission = ensure_current_repository(&storage, Some(&open_progress)).await?;
+    let admission =
+        ensure_current_repository(&storage, Some(&open_progress), server.as_ref()).await?;
     let mut open_report = admission.report;
     retained_progress.retain_initialized(open_report.initialized);
     let migrated_from = open_report.migration.map(|migration| migration.from_format);
@@ -1229,6 +1231,36 @@ where
     Ok(lix)
 }
 
+// Builds a private candidate without starting a sync worker or publishing an
+// epoch. The migration owner validates and publishes only after this returns.
+pub(crate) async fn new_replica_migration_candidate<S>(
+    adapter: crate::storage_adapter::StorageAdapter<S>,
+    default_branch_id: &str,
+) -> Result<Lix<S>, LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let adapter = adapter.with_session().await?;
+    let (engine, _) =
+        open_or_initialize_engine_with_adapter(adapter, None, None, None, Some(default_branch_id))
+            .await?;
+    let session = engine.open_session().await?;
+    Ok(Lix {
+        engine: Arc::new(engine),
+        session: Arc::new(session),
+        transaction_lifecycle: Arc::default(),
+        primary_switch_gate: Some(Arc::new(tokio::sync::Mutex::new(()))),
+        sync_lease: None,
+        sync_demand_tx: None,
+        server: None,
+        open_report: Arc::new(OpenReport {
+            format: crate::init::CURRENT_FORMAT_VERSION,
+            initialized: false,
+            migration: None,
+        }),
+    })
+}
+
 struct RepositoryAdmission<StorageImpl> {
     adapter: crate::storage_adapter::StorageAdapter<StorageImpl>,
     report: OpenReport,
@@ -1237,6 +1269,7 @@ struct RepositoryAdmission<StorageImpl> {
 async fn ensure_current_repository<StorageImpl>(
     storage: &StorageImpl,
     progress: Option<&Arc<dyn OpenProgressSink>>,
+    server: Option<&ServerOptions>,
 ) -> Result<RepositoryAdmission<StorageImpl>, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
@@ -1252,7 +1285,8 @@ where
             total: None,
         },
     );
-    let admission = crate::migration::admit_repository(storage, progress).await?;
+    let admission =
+        crate::migration::admit_repository_with_server(storage, progress, server).await?;
     Ok(RepositoryAdmission {
         adapter: admission.adapter,
         report: admission.report,

--- a/packages/lix/src/migration/epoch.rs
+++ b/packages/lix/src/migration/epoch.rs
@@ -380,6 +380,17 @@ pub(crate) async fn admit_repository<S>(
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    admit_repository_with_server(storage, progress, None).await
+}
+
+pub(crate) async fn admit_repository_with_server<S>(
+    storage: &S,
+    progress: Option<&Arc<dyn OpenProgressSink>>,
+    server: Option<&crate::ServerOptions>,
+) -> Result<EpochAdmission<S>, LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
     'admission: loop {
         match load_pointer(storage).await? {
             Some((
@@ -398,8 +409,12 @@ where
                     )));
                 }
                 if format < crate::init::CURRENT_FORMAT_VERSION {
-                    return migrate_active(storage, bank, generation, format, bytes, progress)
-                        .await;
+                    // Keep cold migration/bootstrap state off the ordinary
+                    // open future's stack, including for filesystem adapters.
+                    return Box::pin(migrate_active(
+                        storage, bank, generation, format, bytes, progress, server,
+                    ))
+                    .await;
                 }
                 if generation >= 2 {
                     let _ = schedule_legacy_retirement(storage.clone(), bytes.clone());
@@ -464,7 +479,7 @@ where
                     }
                 }
             }
-            None => return admit_legacy(storage, progress).await,
+            None => return Box::pin(admit_legacy(storage, progress, server)).await,
         }
     }
 }
@@ -667,6 +682,7 @@ where
 async fn admit_legacy<S>(
     storage: &S,
     progress: Option<&Arc<dyn OpenProgressSink>>,
+    server: Option<&crate::ServerOptions>,
 ) -> Result<EpochAdmission<S>, LixError>
 where
     S: Storage + Clone + Send + Sync + 'static,
@@ -692,7 +708,7 @@ where
         });
         if let Err(error) = publish_migration_claim_absent(storage, &migrating_bytes).await {
             if is_admission_race(&error) {
-                return Box::pin(admit_repository(storage, progress)).await;
+                return Box::pin(admit_repository_with_server(storage, progress, server)).await;
             }
             return Err(storage_error(error));
         }
@@ -784,7 +800,7 @@ where
     let source_revision = match source.load_mutation_revision().await {
         Ok(revision) => revision,
         Err(error) if is_admission_race(&error) => {
-            return Box::pin(admit_repository(storage, progress)).await;
+            return Box::pin(admit_repository_with_server(storage, progress, server)).await;
         }
         Err(error) => return Err(storage_error(error)),
     };
@@ -800,7 +816,7 @@ where
         claim_legacy(storage, source_revision, &original_marker, &migrating_bytes).await
     {
         if is_admission_race(&error) {
-            return Box::pin(admit_repository(storage, progress)).await;
+            return Box::pin(admit_repository_with_server(storage, progress, server)).await;
         }
         return Err(storage_error(error));
     }
@@ -829,24 +845,40 @@ where
             .await
             .map_err(storage_error)?;
         let candidate_result = async {
-            clear_bank(&target).await?;
-            let _ = copy_repository(&migration_source, &target).await?;
-            write_candidate_page(
-                &target,
-                crate::init::REPOSITORY_PROTOCOL_SPACE,
-                single_put(
-                    crate::init::REPOSITORY_PROTOCOL_KEY,
-                    original_marker.clone(),
-                ),
-            )
-            .await
-            .map_err(|error| epoch_error(format!("candidate marker write failed: {error}")))?;
-            super::migrate_lix_with_adapter(
-                storage.clone(),
-                target.clone(),
-                super::MigrationOptions::automatic(),
-            )
+            let replica = Box::pin(inspect_replica_rebuild(
+                &migration_source,
+                from_format,
+                server,
+            ))
             .await?;
+            clear_bank(&target).await?;
+            if let Some((proof, server)) = replica {
+                Box::pin(crate::sync::rebuild_replica_candidate(
+                    target.clone(),
+                    server,
+                    &proof.repository_id,
+                    &proof.account_id,
+                ))
+                .await?;
+            } else {
+                let _ = copy_repository(&migration_source, &target).await?;
+                write_candidate_page(
+                    &target,
+                    crate::init::REPOSITORY_PROTOCOL_SPACE,
+                    single_put(
+                        crate::init::REPOSITORY_PROTOCOL_KEY,
+                        original_marker.clone(),
+                    ),
+                )
+                .await
+                .map_err(|error| epoch_error(format!("candidate marker write failed: {error}")))?;
+                super::migrate_lix_with_adapter(
+                    storage.clone(),
+                    target.clone(),
+                    super::MigrationOptions::automatic(),
+                )
+                .await?;
+            }
             emit_validating(progress, from_format);
             match super::inspect_lix_with_adapter(&target).await? {
                 super::MigrationStatus::Current { .. } => {}
@@ -905,6 +937,7 @@ async fn migrate_active<S>(
     from_format: u32,
     active_source_bytes: Bytes,
     progress: Option<&Arc<dyn OpenProgressSink>>,
+    server: Option<&crate::ServerOptions>,
 ) -> Result<EpochAdmission<S>, LixError>
 where
     S: Storage + Clone + Send + Sync + 'static,
@@ -925,7 +958,7 @@ where
     let source_revision = match source.load_mutation_revision().await {
         Ok(revision) => revision,
         Err(error) if is_admission_race(&error) => {
-            return Box::pin(admit_repository(storage, progress)).await;
+            return Box::pin(admit_repository_with_server(storage, progress, server)).await;
         }
         Err(error) => return Err(storage_error(error)),
     };
@@ -949,7 +982,7 @@ where
     {
         Ok(claim) => claim,
         Err(error) if is_admission_race(&error) => {
-            return Box::pin(admit_repository(storage, progress)).await;
+            return Box::pin(admit_repository_with_server(storage, progress, server)).await;
         }
         Err(error) => return Err(storage_error(error)),
     };
@@ -963,7 +996,7 @@ where
         resolve_exact_pointer_commit(storage, claim.commit().await, &migrating_bytes).await
     {
         if is_admission_race(&error) {
-            return Box::pin(admit_repository(storage, progress)).await;
+            return Box::pin(admit_repository_with_server(storage, progress, server)).await;
         }
         return Err(storage_error(error));
     }
@@ -988,14 +1021,30 @@ where
         );
 
         let candidate_result = async {
-            clear_bank(&target).await?;
-            let _ = copy_repository(&migration_source, &target).await?;
-            super::migrate_lix_with_adapter(
-                storage.clone(),
-                target.clone(),
-                super::MigrationOptions::automatic(),
-            )
+            let replica = Box::pin(inspect_replica_rebuild(
+                &migration_source,
+                from_format,
+                server,
+            ))
             .await?;
+            clear_bank(&target).await?;
+            if let Some((proof, server)) = replica {
+                Box::pin(crate::sync::rebuild_replica_candidate(
+                    target.clone(),
+                    server,
+                    &proof.repository_id,
+                    &proof.account_id,
+                ))
+                .await?;
+            } else {
+                let _ = copy_repository(&migration_source, &target).await?;
+                super::migrate_lix_with_adapter(
+                    storage.clone(),
+                    target.clone(),
+                    super::MigrationOptions::automatic(),
+                )
+                .await?;
+            }
             emit_validating(progress, from_format);
             let engine = Engine::new_with_adapter(target.clone(), EngineOptions::new()).await?;
             drop(engine);
@@ -1100,6 +1149,31 @@ where
         .map_err(storage_error)?;
     write.commit().await.map_err(storage_error)?;
     Ok(())
+}
+
+async fn inspect_replica_rebuild<'a, S>(
+    source: &StorageAdapter<S>,
+    source_format: u32,
+    server: Option<&'a crate::ServerOptions>,
+) -> Result<Option<(crate::sync::CleanReplicaProof, &'a crate::ServerOptions)>, LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    // A current-format repository in the legacy physical layout only needs an
+    // epoch copy. It must retain its existing offline replica admission; there
+    // is no historical format migration to replace with a server rebuild.
+    if source_format == crate::init::CURRENT_FORMAT_VERSION {
+        return Ok(None);
+    }
+    // The exact migration claim already fences ordinary writers. Prove the
+    // entire replica is clean in one source snapshot before any candidate work.
+    let read = source.begin_read(ReadOptions::default()).await?;
+    let Some(proof) = crate::sync::inspect_replica_rebuild_safety(&read, source_format).await?
+    else {
+        return Ok(None);
+    };
+    let server = server.ok_or_else(|| crate::sync::replica_upgrade_blocked("server_required"))?;
+    Ok(Some((proof, server)))
 }
 
 async fn clear_bank<S>(adapter: &StorageAdapter<S>) -> Result<(), LixError>
@@ -2484,101 +2558,87 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn migration_preserves_sync_ownership_across_legacy_and_active_banks() {
-        let replica = Bytes::from_static(
-            br#"{
-            "activeAccountId": "migration-test",
-            "cursor": 0,
-            "authoritativeBranches": {},
-            "authorityKnownCommitIds": []
-        }"#,
-        );
-        for (ownership_key, ownership_value) in [
-            (
-                &b"authority"[..],
-                Bytes::from_static(crate::sync::AUTHORITY_STATE_VALUE),
-            ),
-            (&b"repository"[..], replica),
-        ] {
-            for bank in [EpochBank::Legacy, EpochBank::A] {
-                let storage = crate::Memory::new();
-                let active = seed_active_v75(&storage, bank, 7).await;
-                if bank == EpochBank::Legacy {
-                    delete_pointer(&storage, &active).await.unwrap();
-                }
-                let source = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
-                let mut write = source
-                    .begin_migration_write(WriteOptions::default())
-                    .await
-                    .unwrap();
-                write
-                    .put_many(
-                        crate::sync::SYNC_AUTHORITY_STATE_SPACE,
-                        single_put(ownership_key, ownership_value.clone()),
-                    )
-                    .await
-                    .unwrap();
-                // This space sorts after sync ownership, so copying it exercises
-                // the first write after the candidate acquires the source role.
-                write
-                    .put_many(
-                        crate::sync::SYNC_UPLOAD_GENERATION_SPACE,
-                        single_put(b"preserved-upload", Bytes::from_static(b"preserved-value")),
-                    )
-                    .await
-                    .unwrap();
-                write.commit().await.unwrap();
+    async fn migration_preserves_authority_ownership_across_legacy_and_active_banks() {
+        let ownership_key = &b"authority"[..];
+        let ownership_value = Bytes::from_static(crate::sync::AUTHORITY_STATE_VALUE);
+        for bank in [EpochBank::Legacy, EpochBank::A] {
+            let storage = crate::Memory::new();
+            let active = seed_active_v75(&storage, bank, 7).await;
+            if bank == EpochBank::Legacy {
+                delete_pointer(&storage, &active).await.unwrap();
+            }
+            let source = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+            let mut write = source
+                .begin_migration_write(WriteOptions::default())
+                .await
+                .unwrap();
+            write
+                .put_many(
+                    crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                    single_put(ownership_key, ownership_value.clone()),
+                )
+                .await
+                .unwrap();
+            // This space sorts after sync ownership, so copying it exercises
+            // the first write after the candidate acquires the source role.
+            write
+                .put_many(
+                    crate::sync::SYNC_UPLOAD_GENERATION_SPACE,
+                    single_put(b"preserved-upload", Bytes::from_static(b"preserved-value")),
+                )
+                .await
+                .unwrap();
+            write.commit().await.unwrap();
 
-                let admitted = admit_repository(&storage, None)
+            let admitted = admit_repository(&storage, None)
+                .await
+                .expect("owned repository must migrate");
+            assert_eq!(admitted.report.format, crate::init::CURRENT_FORMAT_VERSION);
+            for (space, key, expected) in [
+                (
+                    crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                    Bytes::from_static(ownership_key),
+                    ownership_value.clone(),
+                ),
+                (
+                    crate::sync::SYNC_UPLOAD_GENERATION_SPACE,
+                    Bytes::from_static(b"preserved-upload"),
+                    Bytes::from_static(b"preserved-value"),
+                ),
+            ] {
+                let read = admitted
+                    .adapter
+                    .begin_read(ReadOptions::default())
                     .await
-                    .expect("owned repository must migrate");
-                assert_eq!(admitted.report.format, crate::init::CURRENT_FORMAT_VERSION);
-                for (space, key, expected) in [
-                    (
-                        crate::sync::SYNC_AUTHORITY_STATE_SPACE,
-                        Bytes::from_static(ownership_key),
-                        ownership_value.clone(),
-                    ),
-                    (
-                        crate::sync::SYNC_UPLOAD_GENERATION_SPACE,
-                        Bytes::from_static(b"preserved-upload"),
-                        Bytes::from_static(b"preserved-value"),
-                    ),
-                ] {
-                    let read = admitted
-                        .adapter
-                        .begin_read(ReadOptions::default())
-                        .await
-                        .unwrap();
-                    let keys = [Key(key)];
-                    let result = read
-                        .get_many(&[GetManyRequest {
-                            space,
-                            keys: &keys,
-                            opts: GetOptions::default(),
-                        }])
-                        .await
-                        .unwrap();
-                    assert_eq!(
-                        result.values,
-                        vec![Some(ProjectedValue::FullValue(expected))]
-                    );
-                }
-                let mut ordinary = admitted.adapter.new_write_set();
-                ordinary.put(
-                    crate::json_store::JSON_SPACE,
-                    &b"forbidden"[..],
-                    &b"write"[..],
-                );
-                assert!(
-                    admitted
-                        .adapter
-                        .commit_write_set(ordinary, WriteOptions::default())
-                        .await
-                        .is_err(),
-                    "migration must not grant ordinary writers authority"
+                    .unwrap();
+                let keys = [Key(key)];
+                let result = read
+                    .get_many(&[GetManyRequest {
+                        space,
+                        keys: &keys,
+                        opts: GetOptions::default(),
+                    }])
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    result.values,
+                    vec![Some(ProjectedValue::FullValue(expected))]
                 );
             }
+            let mut ordinary = admitted.adapter.new_write_set();
+            ordinary.put(
+                crate::json_store::JSON_SPACE,
+                &b"forbidden"[..],
+                &b"write"[..],
+            );
+            assert!(
+                admitted
+                    .adapter
+                    .commit_write_set(ordinary, WriteOptions::default())
+                    .await
+                    .is_err(),
+                "migration must not grant ordinary writers authority"
+            );
         }
     }
 
@@ -3226,7 +3286,7 @@ mod tests {
             .await
             .unwrap();
 
-        let admitted = migrate_active(&storage, EpochBank::A, 7, 75, stale_active, None)
+        let admitted = migrate_active(&storage, EpochBank::A, 7, 75, stale_active, None, None)
             .await
             .expect("a losing opener should join the winner's active epoch");
 
@@ -3331,3 +3391,6 @@ mod tests {
         );
     }
 }
+
+#[cfg(all(test, feature = "server-protocol", not(target_family = "wasm")))]
+mod replica_upgrade_tests;

--- a/packages/lix/src/migration/epoch/replica_upgrade_tests.rs
+++ b/packages/lix/src/migration/epoch/replica_upgrade_tests.rs
@@ -1,0 +1,415 @@
+//! HTTP integration coverage for upgrading a persisted, sparse replica.
+use super::*;
+use crate::server_protocol::{LixServerProtocol, ServerProtocolBody, ServerProtocolContext};
+use crate::sync::SyncTransport;
+use http_body_util::BodyExt;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+struct Authority {
+    url: String,
+    stop: Arc<AtomicBool>,
+    fail_snapshot: Arc<AtomicBool>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Authority {
+    async fn new() -> Self {
+        let storage = crate::Memory::new();
+        let lix = crate::open_lix()
+            .with_storage(storage.clone())
+            .await
+            .unwrap();
+        lix.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('upgrade-test', 'preserved')",
+            &[],
+        )
+        .await
+        .unwrap();
+        lix.close().await.unwrap();
+        let protocol = crate::open_lix()
+            .with_storage(storage)
+            .serve()
+            .with_embedded_lix_id()
+            .await
+            .unwrap();
+        let id = protocol.lix_id().to_owned();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let url = format!("http://{}/lix/{id}", listener.local_addr().unwrap());
+        let stop = Arc::new(AtomicBool::new(false));
+        let fail_snapshot = Arc::new(AtomicBool::new(false));
+        let stopped = stop.clone();
+        let failing = fail_snapshot.clone();
+        let runtime = tokio::runtime::Handle::current();
+        let worker = std::thread::spawn(move || {
+            while !stopped.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((stream, _)) => serve_request(stream, &protocol, &runtime, &failing),
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(error) => panic!("test listener: {error}"),
+                }
+            }
+            runtime.block_on(protocol.close()).unwrap();
+        });
+        Self {
+            url,
+            stop,
+            fail_snapshot,
+            worker: Some(worker),
+        }
+    }
+
+    fn options(&self) -> crate::ServerOptions {
+        crate::ServerOptions {
+            url: self.url.clone(),
+            headers: Default::default(),
+        }
+    }
+}
+
+impl Drop for Authority {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.worker.take().unwrap().join().unwrap();
+    }
+}
+
+fn serve_request(
+    mut stream: std::net::TcpStream,
+    protocol: &LixServerProtocol<crate::Memory>,
+    runtime: &tokio::runtime::Handle,
+    fail: &AtomicBool,
+) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let mut header = Vec::new();
+    while !header.ends_with(b"\r\n\r\n") {
+        let mut byte = [0];
+        stream.read_exact(&mut byte).unwrap();
+        header.push(byte[0]);
+        assert!(header.len() < 65536);
+    }
+    let header = String::from_utf8(header).unwrap();
+    let mut lines = header.split("\r\n");
+    let mut start = lines.next().unwrap().split_whitespace();
+    let method = start.next().unwrap();
+    let path = start.next().unwrap();
+    let mut request = http::Request::builder().method(method).uri(path);
+    let mut length = 0;
+    for line in lines.filter(|line| !line.is_empty()) {
+        let (name, value) = line.split_once(':').unwrap();
+        if name.eq_ignore_ascii_case("content-length") {
+            length = value.trim().parse().unwrap();
+        }
+        request = request.header(name, value.trim());
+    }
+    let mut body = vec![0; length];
+    stream.read_exact(&mut body).unwrap();
+    let response = if fail.load(Ordering::Acquire) && path.contains("/sync/pull") {
+        http::Response::builder()
+            .status(503)
+            .body(ServerProtocolBody::full(
+                r#"{"error":{"code":"TEST_UNAVAILABLE","message":"snapshot unavailable"}}"#,
+            ))
+            .unwrap()
+    } else {
+        runtime.block_on(protocol.handle(
+            request.body(ServerProtocolBody::full(body)).unwrap(),
+            ServerProtocolContext::anonymous(),
+        ))
+    };
+    let (parts, body) = response.into_parts();
+    let bytes = runtime.block_on(body.collect()).unwrap().to_bytes();
+    write!(
+        stream,
+        "HTTP/1.1 {} OK\r\nContent-Length: {}\r\nConnection: close\r\n",
+        parts.status.as_u16(),
+        bytes.len()
+    )
+    .unwrap();
+    for (name, value) in &parts.headers {
+        if name != http::header::CONTENT_LENGTH && name != http::header::CONNECTION {
+            write!(stream, "{}: {}\r\n", name, value.to_str().unwrap()).unwrap();
+        }
+    }
+    stream.write_all(b"\r\n").unwrap();
+    stream.write_all(&bytes).unwrap();
+}
+
+type ReplicaStorage = crate::storage::StorageSession<crate::Memory>;
+
+async fn old_replica(authority: &Authority, bank: EpochBank) -> ReplicaStorage {
+    old_replica_with_local_data(authority, bank, false).await
+}
+
+async fn old_replica_with_local_data(
+    authority: &Authority,
+    bank: EpochBank,
+    local_only: bool,
+) -> ReplicaStorage {
+    let storage = ReplicaStorage::acquire(crate::Memory::new()).await.unwrap();
+    let adapter = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+    let server = authority.options();
+    let prepared = crate::sync::prepare_sync_bootstrap(&server).await.unwrap();
+    let mut lix = crate::handle::new_replica_migration_candidate(
+        adapter.clone(),
+        &prepared.default_branch_id,
+    )
+    .await
+    .unwrap();
+    let transport = crate::sync::install_sync_bootstrap(&mut lix, &server, prepared)
+        .await
+        .unwrap();
+    assert!(!transport.active_account_id().is_empty());
+    if local_only {
+        lix.set_sync_role(crate::sync::SyncRole::Replica).unwrap();
+        lix.execute("INSERT INTO lix_key_value (key, value, lixcol_untracked) VALUES ('local-only-upgrade-test', 'local-only', true)", &[]).await.unwrap();
+    }
+    lix.close().await.unwrap();
+    transport.close_session().await.unwrap();
+    drop(lix);
+    let mut write = adapter
+        .begin_migration_write(WriteOptions::default())
+        .await
+        .unwrap();
+    write
+        .put_many(
+            crate::init::REPOSITORY_PROTOCOL_SPACE,
+            single_put(
+                crate::init::REPOSITORY_PROTOCOL_KEY,
+                Bytes::from_static(crate::init::REPOSITORY_PROTOCOL_V77),
+            ),
+        )
+        .await
+        .unwrap();
+    // A sparse replica need not contain historical commit bodies. Deliberately
+    // remove them all: upgrading must use receipts/current state, never graph
+    // traversal or decoding the old commit record format.
+    write
+        .delete_range(
+            crate::changelog::COMMIT_SPACE,
+            KeyRange {
+                lower: Bound::Unbounded,
+                upper: Bound::Unbounded,
+            },
+        )
+        .await
+        .unwrap();
+    write.commit().await.unwrap();
+    if bank != EpochBank::Legacy {
+        publish_pointer_absent(
+            &storage,
+            &encode_pointer(PointerState::Active {
+                bank,
+                generation: 1,
+                format: 77,
+                publication: None,
+            }),
+        )
+        .await
+        .unwrap();
+    }
+    storage
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn clean_sparse_replica_bootstraps_before_publishing_new_epoch() {
+    let authority = Authority::new().await;
+    for bank in [EpochBank::Legacy, EpochBank::A] {
+        let storage = old_replica(&authority, bank).await;
+        let admitted = admit_repository_with_server(&storage, None, Some(&authority.options()))
+            .await
+            .unwrap();
+        assert_eq!(admitted.report.migration.unwrap().from_format, 77);
+        let old = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+        assert_eq!(
+            crate::migration::api::load_repository_protocol_marker(&old)
+                .await
+                .unwrap()
+                .unwrap()
+                .as_ref(),
+            if bank == EpochBank::Legacy {
+                LEGACY_FENCE
+            } else {
+                crate::init::REPOSITORY_PROTOCOL_V77
+            }
+        );
+        let lix = crate::open_lix().with_storage(storage).await.unwrap();
+        let rows = lix
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'upgrade-test'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(rows.rows().len(), 1);
+        assert_eq!(
+            rows.rows()[0].get::<serde_json::Value>("value").unwrap(),
+            "preserved"
+        );
+        lix.close().await.unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_replica_download_preserves_source_and_can_retry() {
+    let authority = Authority::new().await;
+    for bank in [EpochBank::Legacy, EpochBank::A] {
+        let storage = old_replica(&authority, bank).await;
+        let before = load_pointer(&storage)
+            .await
+            .unwrap()
+            .map(|(_, bytes)| bytes);
+        authority.fail_snapshot.store(true, Ordering::Release);
+        let error =
+            match admit_repository_with_server(&storage, None, Some(&authority.options())).await {
+                Ok(_) => panic!("download must fail"),
+                Err(error) => error,
+            };
+        assert_eq!(error.code, "TEST_UNAVAILABLE");
+        assert_eq!(
+            load_pointer(&storage)
+                .await
+                .unwrap()
+                .map(|(_, bytes)| bytes),
+            before
+        );
+        let old = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+        assert_eq!(
+            crate::migration::api::load_repository_protocol_marker(&old)
+                .await
+                .unwrap()
+                .unwrap()
+                .as_ref(),
+            crate::init::REPOSITORY_PROTOCOL_V77
+        );
+        authority.fail_snapshot.store(false, Ordering::Release);
+        admit_repository_with_server(&storage, None, Some(&authority.options()))
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unacknowledged_replica_is_preserved_without_downloading() {
+    let authority = Authority::new().await;
+    for bank in [EpochBank::Legacy, EpochBank::A] {
+        let storage = old_replica(&authority, bank).await;
+        let source = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+        let read = source.begin_read(ReadOptions::default()).await.unwrap();
+        let keys = [Key(Bytes::from_static(b"repository"))];
+        let values = read
+            .get_many(&[GetManyRequest {
+                space: crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                keys: &keys,
+                opts: GetOptions::default(),
+            }])
+            .await
+            .unwrap();
+        let Some(ProjectedValue::FullValue(raw)) = &values.values[0] else {
+            panic!("receipt");
+        };
+        let mut receipt: serde_json::Value = serde_json::from_slice(raw).unwrap();
+        // A local branch is ahead of its last server receipt.
+        receipt["authoritativeBranches"][crate::GLOBAL_BRANCH_ID]["headCommitId"] =
+            serde_json::Value::String(uuid::Uuid::now_v7().to_string());
+        drop(read);
+        let expected = Bytes::from(serde_json::to_vec(&receipt).unwrap());
+        let mut write = source
+            .begin_migration_write(WriteOptions::default())
+            .await
+            .unwrap();
+        write
+            .put_many(
+                crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                single_put(b"repository", expected.clone()),
+            )
+            .await
+            .unwrap();
+        write.commit().await.unwrap();
+        let before = load_pointer(&storage)
+            .await
+            .unwrap()
+            .map(|(_, bytes)| bytes);
+        authority.fail_snapshot.store(true, Ordering::Release);
+        let error =
+            match admit_repository_with_server(&storage, None, Some(&authority.options())).await {
+                Ok(_) => panic!("pending work must block"),
+                Err(error) => error,
+            };
+        assert_eq!(error.code, "LIX_ERROR_REPLICA_UPGRADE_BLOCKED");
+        assert_eq!(error.details.unwrap()["reason"], "pending_changes");
+        assert_eq!(
+            load_pointer(&storage)
+                .await
+                .unwrap()
+                .map(|(_, bytes)| bytes),
+            before
+        );
+        let read = source.begin_read(ReadOptions::default()).await.unwrap();
+        let values = read
+            .get_many(&[GetManyRequest {
+                space: crate::sync::SYNC_AUTHORITY_STATE_SPACE,
+                keys: &keys,
+                opts: GetOptions::default(),
+            }])
+            .await
+            .unwrap();
+        assert_eq!(values.values[0], Some(ProjectedValue::FullValue(expected)));
+        authority.fail_snapshot.store(false, Ordering::Release);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_only_data_blocks_rebuild_and_keeps_source() {
+    let authority = Authority::new().await;
+    for bank in [EpochBank::Legacy, EpochBank::A] {
+        let storage = old_replica_with_local_data(&authority, bank, true).await;
+        let before = load_pointer(&storage)
+            .await
+            .unwrap()
+            .map(|(_, bytes)| bytes);
+        let error =
+            match admit_repository_with_server(&storage, None, Some(&authority.options())).await {
+                Ok(_) => panic!("local-only data must block"),
+                Err(error) => error,
+            };
+        assert_eq!(error.code, "LIX_ERROR_REPLICA_UPGRADE_BLOCKED");
+        assert_eq!(error.details.unwrap()["reason"], "local_only_data");
+        assert_eq!(
+            load_pointer(&storage)
+                .await
+                .unwrap()
+                .map(|(_, bytes)| bytes),
+            before
+        );
+        let source = StorageAdapter::for_epoch_unfenced(storage.clone(), bank);
+        let read = source.begin_read(ReadOptions::default()).await.unwrap();
+        let hot = crate::hot_state::HotStateContext::new(
+            crate::tracked_state::TrackedStateContext::new(),
+            crate::commit_graph::CommitGraphContext::new(),
+        )
+        .reader(&read);
+        let rows = hot
+            .scan_batch(&crate::hot_state::HotStateScanRequest {
+                filter: crate::hot_state::HotStateFilter {
+                    schema_keys: vec!["lix_key_value".to_owned()],
+                    row_pks: vec![crate::row_pk::RowPk::single("local-only-upgrade-test")],
+                    untracked: Some(true),
+                    ..Default::default()
+                },
+                projection: Default::default(),
+                limit: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        let snapshot: serde_json::Value =
+            serde_json::from_str(rows.row(0).snapshot_content().unwrap().as_ref()).unwrap();
+        assert_eq!(snapshot["value"], "local-only");
+    }
+}

--- a/packages/lix/src/migration/mod.rs
+++ b/packages/lix/src/migration/mod.rs
@@ -15,6 +15,6 @@ pub(crate) use api::{
     migrate_lix_with_adapter,
 };
 pub(crate) use epoch::{
-    FreshEpochImport, admit_existing_repository, admit_repository, begin_fresh_epoch_import,
+    FreshEpochImport, admit_existing_repository, admit_repository_with_server, begin_fresh_epoch_import,
 };
 pub(crate) use registry::has_complete_migration_path;

--- a/packages/lix/src/storage_adapter/context.rs
+++ b/packages/lix/src/storage_adapter/context.rs
@@ -51,6 +51,19 @@ where
         }
     }
 
+    // Preserve epoch routing and its exact claim while constructing a private
+    // Lix handle. An already-session-bound store returns the same session token.
+    pub(crate) async fn with_session(
+        self,
+    ) -> Result<StorageAdapter<crate::storage::StorageSession<StorageImpl>>, StorageError> {
+        Ok(StorageAdapter {
+            storage: crate::storage::StorageSession::acquire(self.storage).await?,
+            routing: self.routing,
+            authority_writer: self.authority_writer,
+            replica_writer: self.replica_writer,
+        })
+    }
+
     pub(crate) fn storage(&self) -> &StorageImpl {
         &self.storage
     }

--- a/packages/lix/src/sync/README.md
+++ b/packages/lix/src/sync/README.md
@@ -26,3 +26,23 @@ and normal history imports still require their jump closure. A missing deferred
 graph node triggers ordinary bounded history demand before traversal continues.
 Known jump generations, self-jumps, invalid spans, and inventory/body identity
 mismatches are validated before publication.
+
+On a v77 replica format upgrade, epoch admission proves that every local branch
+coordinate matches a durable authority receipt, including the global branch.
+In v77 every checkpoint also authored a tracked global marker, so this checks
+off-branch checkpoint work without traversing history. Pending resets, physical
+untracked rows and tombstones, unfinished uploads, and recovery references block
+the upgrade. Unknown replica formats fail closed.
+
+A clean replica uses the existing bootstrap in a hidden epoch, checks repository
+and account identity, closes its temporary sessions, validates, and only then
+publishes the epoch. The old epoch remains intact. Standalone and authoritative
+repositories retain their normal format migration path.
+
+The safety check scans branch controls and current serving rows with a metadata
+projection. Its cost is O(B log B + R), where B is the number of branch controls
+and R is the total current rows visited across branches, plus receipt decoding.
+Peak scan memory is proportional to the largest branch's current row batch. It
+does not decode or walk historical commits. Rebuilding then pays the ordinary
+current-state bootstrap cost, including the checkpoint header inventory; it does
+not materialize historical checkpoint snapshots.

--- a/packages/lix/src/sync/bootstrap.rs
+++ b/packages/lix/src/sync/bootstrap.rs
@@ -140,8 +140,15 @@ pub(crate) async fn prepare_sync_bootstrap(
     let remote_id = server.url.as_str();
     let transport = HttpSyncTransport::connect(remote_id, &server.headers).await?;
     let (snapshot, lix_id, default_branch_id) =
-        runtime::fetch_repository_snapshot(&transport).await?;
+        match runtime::fetch_repository_snapshot(&transport).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let _ = transport.close_session().await;
+                return Err(error);
+            }
+        };
     if transport.lix_id() != lix_id {
+        let _ = transport.close_session().await;
         return Err(super::sync_repository_id_mismatch(
             &lix_id,
             transport.lix_id(),
@@ -162,6 +169,18 @@ pub(crate) async fn install_sync_bootstrap<StorageImpl>(
 ) -> Result<HttpSyncTransport, LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    install_prepared_sync_bootstrap(lix, server, &mut prepared).await?;
+    Ok(prepared.transport)
+}
+
+async fn install_prepared_sync_bootstrap<S>(
+    lix: &mut Lix<S>,
+    server: &crate::ServerOptions,
+    prepared: &mut PreparedSyncBootstrap,
+) -> Result<(), LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
 {
     if let Err(error) = runtime::register_hot_blob_manifests(
         lix,
@@ -192,30 +211,61 @@ where
         .await;
     match install {
         Ok(InitialSyncSnapshotInstall::Installed) => {
-            lix.align_repository_identity_for_sync(prepared.lix_id)?;
+            lix.align_repository_identity_for_sync(prepared.lix_id.clone())?;
             lix.align_primary_account_for_sync(prepared.transport.active_account_id())
                 .await?;
-            Ok(prepared.transport)
+            Ok(())
         }
         Ok(InitialSyncSnapshotInstall::ExistingRepository) => {
             let adapter = lix.storage_adapter();
-            let _ = inspect_sync_bootstrap_with_adapter(
-                &adapter,
-                &server.url,
-            )
-            .await?;
+            let _ = inspect_sync_bootstrap_with_adapter(&adapter, &server.url).await?;
             Err(restart_open_error())
         }
         Ok(InitialSyncSnapshotInstall::Ambiguous) => Err(ambiguous_replica_error()),
-        Err(error) => Err(
-            reconcile_install_error(
-                &lix.storage_adapter(),
-                &server.url,
-                error,
-            )
-            .await,
-        ),
+        Err(error) => {
+            Err(reconcile_install_error(&lix.storage_adapter(), &server.url, error).await)
+        }
     }
+}
+
+pub(crate) async fn rebuild_replica_candidate<S>(
+    target: StorageAdapter<S>,
+    server: &crate::ServerOptions,
+    expected_repository_id: &str,
+    expected_account_id: &str,
+) -> Result<(), LixError>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    let mut prepared = prepare_sync_bootstrap(server).await?;
+    let result = async {
+        if prepared.lix_id != expected_repository_id {
+            return Err(super::sync_repository_id_mismatch(
+                expected_repository_id,
+                &prepared.lix_id,
+            ));
+        }
+        if prepared.transport.active_account_id() != expected_account_id {
+            return Err(LixError::new(
+                "LIX_ERROR_REPLICA_UPGRADE_BLOCKED",
+                "Sign in with the account that owns this local replica before upgrading.",
+            )
+            .with_details(serde_json::json!({ "reason": "account_mismatch" })));
+        }
+        let mut candidate =
+            crate::handle::new_replica_migration_candidate(target, &prepared.default_branch_id)
+                .await?;
+        let installed =
+            install_prepared_sync_bootstrap(&mut candidate, server, &mut prepared).await;
+        let closed = candidate.close().await;
+        installed?;
+        closed?;
+        Ok(())
+    }
+    .await;
+    // No runtime takes ownership of this temporary bootstrap session.
+    let _ = prepared.transport.close_session().await;
+    result
 }
 
 async fn reconcile_install_error<StorageImpl>(

--- a/packages/lix/src/sync/http.rs
+++ b/packages/lix/src/sync/http.rs
@@ -101,6 +101,14 @@ where
         })
     }
 
+    pub(crate) async fn close_session(&self) -> Result<(), LixError> {
+        let response = self
+            .client
+            .send(self.request(Method::DELETE, "/session", "close sync session"))
+            .await?;
+        ensure_success(&response, "close sync session")
+    }
+
     pub(super) fn is_reserved_header(name: &str) -> bool {
         name.eq_ignore_ascii_case(SESSION_HEADER)
             || name.eq_ignore_ascii_case(SYNC_PROTOCOL_VERSION_HEADER)

--- a/packages/lix/src/sync/mod.rs
+++ b/packages/lix/src/sync/mod.rs
@@ -34,7 +34,7 @@ use parking_lot::RwLock;
 pub(crate) use blob::validate_sync_blob_manifest;
 pub(crate) use bootstrap::{
     SyncBootstrapAdmission, inspect_sync_bootstrap_with_adapter, install_sync_bootstrap,
-    prepare_sync_bootstrap,
+    prepare_sync_bootstrap, rebuild_replica_candidate,
 };
 pub(crate) use commit::{
     SYNC_CHECKPOINT_SOURCE_SPACE, SYNC_MATERIALIZED_STATE_ALIAS_SPACE,
@@ -66,6 +66,7 @@ pub(crate) use protocol::{
 #[cfg(feature = "server-protocol")]
 pub(crate) use repository::admit_sync_authority_storage;
 pub(crate) use repository::has_any_sync_replica_state;
+pub(crate) use repository::{CleanReplicaProof, inspect_replica_rebuild_safety, replica_upgrade_blocked};
 pub(crate) use repository::{
     AUTHORITY_STATE_VALUE, SYNC_AUTHORITY_STATE_SPACE, SYNC_REPLICA_STATE_SPACE,
     SYNC_REPOSITORY_EVENT_SPACE, SYNC_SEQUENCE_SPACE, authority_state_key,

--- a/packages/lix/src/sync/repository.rs
+++ b/packages/lix/src/sync/repository.rs
@@ -929,6 +929,220 @@ where
     ))
 }
 
+/// A conservative pre-migration proof, evaluated while the source epoch is fenced.
+/// Receipt/control inspection never reads historical commit state.
+#[derive(Debug)]
+pub(crate) struct CleanReplicaProof {
+    pub(crate) repository_id: String,
+    pub(crate) account_id: String,
+}
+
+pub(crate) fn replica_upgrade_blocked(reason: &str) -> LixError {
+    let message = match reason {
+        "pending_changes" => {
+            "This local replica has changes that the server has not acknowledged. Its local data has been preserved."
+        }
+        "local_only_data" => {
+            "This local replica contains local-only data that is not synchronized to the server. Its local data has been preserved."
+        }
+        "server_required" => {
+            "Connect this local replica to the same server to upgrade it. Its local data has been preserved."
+        }
+        _ => {
+            "The old replica metadata cannot be verified safely for an automatic upgrade. Its local data has been preserved."
+        }
+    };
+    LixError::new("LIX_ERROR_REPLICA_UPGRADE_BLOCKED", message)
+    .with_hint("Keep this replica's local storage. Contact support to recover or synchronize local changes before upgrading.")
+    .with_details(serde_json::json!({ "reason": reason }))
+}
+
+pub(crate) async fn inspect_replica_rebuild_safety(
+    read: &(impl StorageAdapterRead + ?Sized),
+    source_format: u32,
+) -> Result<Option<CleanReplicaProof>, LixError> {
+    let mut cursor = read
+        .begin_scan(
+            SYNC_REPLICA_STATE_SPACE,
+            StoragePrefix {
+                bytes: Bytes::new(),
+            }
+            .to_range()?,
+            StorageBeginScanOptions {
+                projection: StorageCoreProjection::FullValue,
+                ..Default::default()
+            },
+        )
+        .await?;
+    let (entries, has_more) = cursor.next_page(2).await?.into_parts();
+    if entries.is_empty() {
+        return Ok(None);
+    }
+    if entries.len() == 1 && entries[0].key.0.as_ref() == AUTHORITY_STATE_KEY {
+        return Ok(None);
+    }
+    if source_format != 77 || entries.len() != 1 || has_more {
+        return Err(replica_upgrade_blocked("unknown_state"));
+    }
+    let StorageProjectedValue::FullValue(raw) = &entries[0].value else {
+        return Err(replica_upgrade_blocked("unknown_state"));
+    };
+    let state: SyncReplicaState =
+        serde_json::from_slice(raw).map_err(|_| replica_upgrade_blocked("unknown_state"))?;
+    if state.active_account_id.is_empty() || state.authoritative_branches.is_empty() {
+        return Err(replica_upgrade_blocked("unknown_state"));
+    }
+    let controls = BranchHeadControlContext::new()
+        .reader(read)
+        .scan()
+        .await
+        .map_err(|_| replica_upgrade_blocked("unknown_state"))?
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    validate_clean_replica_controls(&state, &controls)?;
+    for space in [
+        crate::session::UPLOAD_STATE_SPACE,
+        crate::session::UPLOAD_MANIFEST_LEAF_SPACE,
+        crate::gc::CHECKPOINT_RECOVERY_REF_SPACE,
+    ] {
+        let mut pending = read
+            .begin_scan(
+                space,
+                StoragePrefix {
+                    bytes: Bytes::new(),
+                }
+                .to_range()?,
+                StorageBeginScanOptions {
+                    projection: StorageCoreProjection::KeyOnly,
+                    ..Default::default()
+                },
+            )
+            .await?;
+        if !pending.next_page(1).await?.is_empty() {
+            return Err(replica_upgrade_blocked("local_only_data"));
+        }
+    }
+    // Inspect physical current rows, not derived branch-ref rows. Retention
+    // is a per-row flag, so this scans current serving rows (never history).
+    // Do not apply a limit before the retention filter: a tracked row could
+    // otherwise hide a later untracked override or tombstone.
+    let current = TrackedHeadContext::new().reader(read);
+    for (branch_id, control) in &controls {
+        let local_only = current
+            .scan_live_batch_for_retention(
+                branch_id,
+                *control,
+                &TrackedStateScanRequest {
+                    filter: TrackedStateFilter {
+                        include_tombstones: true,
+                        ..Default::default()
+                    },
+                    read_columns: TrackedStateReadColumns {
+                        columns: vec!["untracked".to_owned()],
+                    },
+                    limit: None,
+                },
+                Some(true),
+            )
+            .await
+            .map_err(|_| replica_upgrade_blocked("unknown_state"))?;
+        if !local_only.is_empty() {
+            return Err(replica_upgrade_blocked("local_only_data"));
+        }
+    }
+    let hot = crate::hot_state::HotStateContext::new(
+        TrackedStateContext::new(),
+        CommitGraphContext::new(),
+    )
+    .reader(read);
+    let identity = hot
+        .scan_batch(&crate::hot_state::HotStateScanRequest {
+            filter: crate::hot_state::HotStateFilter {
+                branch_ids: vec![crate::GLOBAL_BRANCH_ID.to_owned()],
+                schema_keys: vec!["lix_key_value".to_owned()],
+                row_pks: vec![RowPk::single(crate::init::LIX_ID_KEY)],
+                file_ids: vec![crate::NullableKeyFilter::Null],
+                untracked: Some(false),
+                ..Default::default()
+            },
+            projection: Default::default(),
+            limit: Some(2),
+        })
+        .await
+        .map_err(|_| replica_upgrade_blocked("unknown_state"))?;
+    if identity.len() != 1 {
+        return Err(replica_upgrade_blocked("unknown_state"));
+    }
+    let snapshot = identity
+        .row(0)
+        .snapshot_content()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw.as_ref()).ok())
+        .ok_or_else(|| replica_upgrade_blocked("unknown_state"))?;
+    let repository_id = snapshot
+        .get("value")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| uuid::Uuid::parse_str(id).is_ok())
+        .ok_or_else(|| replica_upgrade_blocked("unknown_state"))?
+        .to_owned();
+    Ok(Some(CleanReplicaProof {
+        repository_id,
+        account_id: state.active_account_id,
+    }))
+}
+
+fn validate_clean_replica_controls(
+    state: &SyncReplicaState,
+    controls: &BTreeMap<String, BranchHeadControl>,
+) -> Result<(), LixError> {
+    if !state.pending_resets.is_empty() {
+        return Err(replica_upgrade_blocked("pending_changes"));
+    }
+    // In v77 every checkpoint marker is tracked on the global branch, so
+    // matching its receipt also covers retained off-branch checkpoint work.
+    if !matches!(
+        state.authoritative_branches.get(crate::GLOBAL_BRANCH_ID),
+        Some(AuthoritativeBranchCoordinate::Headed { .. })
+    ) {
+        return Err(replica_upgrade_blocked("unknown_state"));
+    }
+    let mut headed = 0;
+    for (branch, coordinate) in &state.authoritative_branches {
+        match coordinate {
+            AuthoritativeBranchCoordinate::Deleted => {
+                if controls.contains_key(branch) {
+                    return Err(replica_upgrade_blocked("pending_changes"));
+                }
+            }
+            AuthoritativeBranchCoordinate::Headed {
+                head_commit_id,
+                checkpoint_commit_id,
+            } => {
+                headed += 1;
+                let head = CommitId::parse_lix(head_commit_id, "replica migration receipt")
+                    .map_err(|_| replica_upgrade_blocked("unknown_state"))?;
+                let checkpoint =
+                    CommitId::parse_lix(checkpoint_commit_id, "replica migration receipt")
+                        .map_err(|_| replica_upgrade_blocked("unknown_state"))?;
+                let Some(control) = controls.get(branch) else {
+                    return Err(replica_upgrade_blocked("pending_changes"));
+                };
+                if control.head_commit_id != head
+                    || control.working_diff_checkpoint_commit_id != Some(checkpoint)
+                {
+                    return Err(replica_upgrade_blocked("pending_changes"));
+                }
+            }
+        }
+    }
+    if headed == 0 {
+        return Err(replica_upgrade_blocked("unknown_state"));
+    }
+    if controls.len() != headed {
+        return Err(replica_upgrade_blocked("pending_changes"));
+    }
+    Ok(())
+}
+
 async fn load_replica_state(
     read: &(impl StorageAdapterRead + ?Sized),
 ) -> Result<(Option<SyncReplicaState>, Option<Bytes>), LixError> {
@@ -7609,6 +7823,92 @@ mod tests {
     use std::time::Duration;
 
     const TEST_REMOTE: &str = "https://sync.example/lix/01936f4e-7b6c-7c3d-8f9a-000000000001";
+
+    #[tokio::test]
+    async fn replica_rebuild_proof_accepts_only_exact_clean_coordinates() {
+        let lix = open_lix().await.unwrap();
+        let adapter = lix.storage_adapter();
+        let read = adapter.begin_read(Default::default()).await.unwrap();
+        let controls = BranchHeadControlContext::new()
+            .reader(&read)
+            .scan()
+            .await
+            .unwrap()
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+        let mut state = SyncReplicaState {
+            active_account_id: "test-account".into(),
+            ..Default::default()
+        };
+        for (id, control) in &controls {
+            state.authoritative_branches.insert(
+                id.clone(),
+                AuthoritativeBranchCoordinate::Headed {
+                    head_commit_id: control.head_commit_id.to_string(),
+                    checkpoint_commit_id: control
+                        .working_diff_checkpoint_commit_id
+                        .unwrap()
+                        .to_string(),
+                },
+            );
+        }
+        assert!(validate_clean_replica_controls(&state, &controls).is_ok());
+        let mut changed = controls.clone();
+        let first = changed.values_mut().next().unwrap();
+        first.working_diff_checkpoint_commit_id = Some(CommitId::for_test_label("different-base"));
+        assert!(validate_clean_replica_controls(&state, &changed).is_err());
+        changed = controls.clone();
+        changed.remove(controls.keys().next().unwrap());
+        assert!(validate_clean_replica_controls(&state, &changed).is_err());
+        changed = controls.clone();
+        changed.insert(
+            "local-only-branch".into(),
+            *controls.values().next().unwrap(),
+        );
+        assert!(validate_clean_replica_controls(&state, &changed).is_err());
+        let first_id = controls.keys().next().unwrap().clone();
+        let saved = state
+            .authoritative_branches
+            .insert(first_id.clone(), AuthoritativeBranchCoordinate::Deleted)
+            .unwrap();
+        assert!(validate_clean_replica_controls(&state, &controls).is_err());
+        state.authoritative_branches.insert(first_id, saved);
+        state.pending_resets.insert(
+            "reset".into(),
+            PendingSyncReset {
+                expected_authority_head_commit_id: "head".into(),
+                expected_authority_checkpoint_commit_id: "base".into(),
+                restore_target_commit_id: "target".into(),
+                authority_known_ancestor_commit_id: None,
+                prepared_reset_head_commit_id: None,
+                prepared_reset_checkpoint_commit_id: None,
+                superseded_prepared_reset_head_commit_ids: Default::default(),
+                superseded_prepared_reset_coordinates: Default::default(),
+            },
+        );
+        assert!(validate_clean_replica_controls(&state, &controls).is_err());
+        state.pending_resets.clear();
+        drop(read);
+        let mut writes = adapter.new_write_set();
+        writes.put(
+            SYNC_REPLICA_STATE_SPACE,
+            replica_state_key(),
+            serde_json::to_vec(&state).unwrap(),
+        );
+        adapter
+            .commit_write_set(writes, Default::default())
+            .await
+            .unwrap();
+        let read = adapter.begin_read(Default::default()).await.unwrap();
+        let proof = inspect_replica_rebuild_safety(&read, 77)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(proof.repository_id, lix.lix_id());
+        assert_eq!(proof.account_id, "test-account");
+        let error = inspect_replica_rebuild_safety(&read, 76).await.unwrap_err();
+        assert_eq!(error.code, "LIX_ERROR_REPLICA_UPGRADE_BLOCKED");
+    }
 
     #[derive(Clone, Default)]
     struct SyncAccountingStorage {


### PR DESCRIPTION
Opening a v77 sparse replica could fail when checkpoint migration needed historical commits that had never been downloaded. Format upgrades now rebuild a provably clean replica from the same server in a hidden epoch, validate the result, and publish only after bootstrap completes. The source epoch is retained.

The v77 proof checks every acknowledged branch head and checkpoint, including the global branch that records v77 checkpoints, and rejects pending resets, local-only rows, unfinished uploads, recovery references, or unknown metadata. Pending work is preserved with `LIX_ERROR_REPLICA_UPGRADE_BLOCKED`; it is never automatically discarded or replayed. Current-format layout adoption and authoritative/standalone migrations retain their existing behavior.

The check scans current serving metadata, not historical commits: O(B log B + R), plus receipt decoding, with peak scan memory proportional to the largest branch batch. Rebuilding uses ordinary current-state bootstrap and checkpoint header inventory. Cold migration futures are boxed to preserve ordinary startup stack usage.

Validation:
- 3,693 engine tests passed with `all-simulations,server-protocol,server-protocol-client` (69 skipped), including both storage layouts, real HTTP bootstrap, download failure/retry, and exact preservation of blocked local work.
- 10 doctests passed; strict all-feature/all-target Clippy and formatting passed.
- Small-fixture profile: both epoch layouts plus authority/bootstrap setup completed in 211 ms in an unoptimized test build; the entire test command peaked at 206,320 KiB RSS. This is a smoke profile, not a large-repository benchmark.
- Independent sub-agent reviews covered ownership, acknowledgments, local-only data, identity checks, cancellation, and publication. Findings were addressed.
- Documentation and SDK guidance updated.

The HTTP regression fixture uses current serving rows with a v77 marker and removed commit records to verify that rebuilding does not traverse history. The proof is deliberately restricted to the reviewed v77 receipt and current-row layout; future formats need their own compatibility audit.
