### PR TITLE
fix(lix): retry transient reconnect validation reads

### DIFF
--- a/.changenotes/retry-sync-reconnect-validation.md
+++ b/.changenotes/retry-sync-reconnect-validation.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed concurrent browser writes interrupting synchronization during reconnect.
+
+Transient local read conflicts now retry without terminating live queries. Repository identity and account mismatches continue to stop synchronization.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,8 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
+    - ubicloud-standard-2-ubuntu-2404
+    - ubicloud-standard-30-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-16vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404

--- a/.github/release-flow.md
+++ b/.github/release-flow.md
@@ -38,3 +38,37 @@ Existing release PRs created before this change must be returned to draft and
 refreshed through **Release PR** once to pick up the workflow changes. Do not
 merge based on an older green run that skipped validation. Adding the job to YAML
 alone does not make it a required GitHub check.
+
+## Build exact artifacts for a consumer
+
+Draft PRs defer full CI. To prepare the browser SDK and Linux server image for a
+consumer such as LixRay, explicitly dispatch CI from the source branch or tag:
+
+```sh
+source_revision=$(git rev-parse HEAD)
+gh workflow run ci.yml --repo opral/lix --ref codex/my-branch \
+  -f artifacts_only=true -f source_revision="$source_revision"
+```
+
+The full lowercase SHA must equal the dispatched ref's commit. If the branch
+advanced, the run fails before either producer starts; update the SHA and dispatch
+again. The workflow file must be available on the selected ref. Arbitrary historical
+SHAs are not supported: use a branch or tag pointing at the intended commit.
+
+The run uses the existing Browser SDK build and functional tests, then uploads
+`lix-browser-sdk-<SHA>` (90-day retention), including SDK/OPFS distributions and
+`ci-artifact/browser.json`. It also uses the existing Linux x64 Docker producer,
+verifies the image revision label, and uploads
+`lix-server-image-linux-x64-<SHA>` (14-day retention), containing the image tar and
+`ci-artifact/server-linux-x64.json`. Both manifests retain their normal exact-source
+provenance. Download from this completed successful run, for example:
+
+```sh
+gh run download RUN_ID --repo opral/lix --name "lix-browser-sdk-$source_revision"
+gh run download RUN_ID --repo opral/lix --name "lix-server-image-linux-x64-$source_revision"
+```
+
+Artifact-only runs have separate concurrency and do not emit **Release ready**,
+run the native SDK or full Rust validation, publish packages, or deploy anything.
+They are preparation for consumer testing, not release approval. Ordinary PR,
+main-push, and default manual CI validation retain their existing behavior.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,15 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      artifacts_only:
+        description: Build tested browser SDK and server artifacts without full release validation
+        type: boolean
+        default: false
+      source_revision:
+        description: Exact 40-character commit SHA at the dispatched ref (required for artifacts_only)
+        type: string
+        required: false
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
   push:
@@ -12,7 +21,7 @@ on:
 concurrency:
   # A rerun retains its original event payload. Draft reruns must never cancel
   # ready-candidate validation, even when they reference the same head commit.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.draft && 'draft' || 'ready' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.pull_request.draft && 'draft' || 'ready' }}-${{ inputs.artifacts_only && 'artifacts' || 'validation' }}
   cancel-in-progress: true
 
 permissions:
@@ -27,8 +36,8 @@ defaults:
 jobs:
   release-ready:
     # Draft reruns must not overwrite the required ready-candidate check.
-    name: ${{ github.event.pull_request.draft && 'Draft - full CI deferred' || 'Release ready' }}
-    if: always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    name: ${{ inputs.artifacts_only && 'Artifacts only - not release validation' || github.event.pull_request.draft && 'Draft - full CI deferred' || 'Release ready' }}
+    if: always() && inputs.artifacts_only != true && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     needs: [merge-reuse, promote-browser-sdk, changelog, cargo-config, cargo, js-sdk-test, preview-artifact-changes, preview-server-image]
     runs-on: ubicloud-standard-2-ubuntu-2404
     timeout-minutes: 5
@@ -67,6 +76,20 @@ jobs:
       revision: ${{ steps.reuse.outputs.revision }}
     steps:
       - uses: actions/checkout@v4
+      - name: Validate explicit artifact source
+        uses: actions/github-script@v7
+        env:
+          ARTIFACTS_ONLY: ${{ inputs.artifacts_only || false }}
+          SOURCE_REVISION: ${{ inputs.source_revision }}
+        with:
+          script: |
+            const { assertArtifactRequest } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/ci-artifact-request.mjs`);
+            assertArtifactRequest({
+              artifactsOnly: process.env.ARTIFACTS_ONLY === 'true',
+              eventName: context.eventName,
+              requestedRevision: process.env.SOURCE_REVISION,
+              workflowRevision: context.sha,
+            });
       - name: Find successful PR validation of the exact merged tree
         id: reuse
         uses: actions/github-script@v7
@@ -122,7 +145,7 @@ jobs:
   changelog:
     name: Changelog
     needs: merge-reuse
-    if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: inputs.artifacts_only != true && needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubicloud-standard-2-ubuntu-2404
     outputs:
       rust: ${{ steps.scope.outputs.rust }}
@@ -173,7 +196,7 @@ jobs:
   cargo-config:
     name: Cargo config (${{ matrix.name }})
     needs: merge-reuse
-    if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: inputs.artifacts_only != true && needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -199,7 +222,7 @@ jobs:
     # Large Rust builds need memory and parallel compilation to target <10 min.
     name: Cargo ${{ matrix.name }}
     needs: changelog
-    if: needs.changelog.outputs.rust != 'false' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    if: inputs.artifacts_only != true && needs.changelog.outputs.rust != 'false' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
@@ -449,10 +472,10 @@ jobs:
           free -h
 
   js-sdk-test:
-    name: JS SDK ${{ matrix.name }} Test
+    name: JS SDK ${{ matrix.runtime == 'browser' && 'Browser' || 'Native' }} Test
     needs: merge-reuse
     if: needs.merge-reuse.outputs.reuse != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubicloud-standard-30-ubuntu-2404
     timeout-minutes: 45
     env:
       # Pull request workflows normally check out GitHub's synthetic merge
@@ -462,13 +485,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: Native
-            runtime: native
-            runner: ubicloud-standard-30-ubuntu-2404
-          - name: Browser
-            runtime: browser
-            runner: ubicloud-standard-30-ubuntu-2404
+        runtime: ${{ fromJSON(inputs.artifacts_only && '["browser"]' || '["native", "browser"]') }}
 
     steps:
       - name: Checkout repository
@@ -694,7 +711,8 @@ jobs:
 
   preview-artifact-changes:
     name: Select preview artifacts
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || inputs.artifacts_only == true
+    needs: merge-reuse
     runs-on: ubicloud-standard-2-ubuntu-2404
     outputs:
       server: ${{ steps.changes.outputs.server }}
@@ -704,14 +722,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Detect reference server inputs
         id: changes
         env:
+          ARTIFACTS_ONLY: ${{ inputs.artifacts_only || false }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          if [ "$ARTIFACTS_ONLY" = true ]; then
+            echo 'server=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
             .github/workflows/ci.yml \
             .github/workflows/publish-packages.yml \
@@ -739,7 +762,7 @@ jobs:
     runs-on: ubicloud-standard-30-ubuntu-2404
     timeout-minutes: 45
     env:
-      LIX_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+      LIX_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
     steps:
       - name: Checkout feature revision

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -419,7 +419,13 @@ where
     let remote_id = server.url.clone();
     let headers = server.headers.clone();
     if let Some(transport) = initial_transport.as_ref() {
-        validate_connected_authority(lix, &remote_id, transport).await?;
+        validate_connected_authority(
+            lix,
+            &remote_id,
+            transport.lix_id(),
+            transport.active_account_id(),
+        )
+        .await?;
     }
     lix.set_sync_replica_remote_id(&remote_id)?;
     lix.storage_adapter().admit_sync_replica_writer();
@@ -488,9 +494,41 @@ where
             };
             match connected {
                 Ok(connected) => {
-                    if let Err(error) =
-                        validate_connected_authority(&lix, &remote_id, &connected).await
-                    {
+                    let validation = {
+                        let validation = validate_connected_authority(
+                            &lix,
+                            &remote_id,
+                            connected.lix_id(),
+                            connected.active_account_id(),
+                        )
+                        .fuse();
+                        let shutdown = shutdown_rx.changed().fuse();
+                        futures_util::pin_mut!(validation, shutdown);
+                        select_biased! {
+                            _ = shutdown => break,
+                            result = validation => result,
+                        }
+                    };
+                    if let Err(error) = validation {
+                        // Validation reads the local receipt. Exhausting its
+                        // bounded coherent-read retry budget is not evidence
+                        // that the remote identity or account changed.
+                        {
+                            let close = connected.close_session().fuse();
+                            let shutdown = shutdown_rx.changed().fuse();
+                            futures_util::pin_mut!(close, shutdown);
+                            select_biased! {
+                                _ = shutdown => break,
+                                _ = close => {},
+                            }
+                        }
+                        if is_retryable_authority_validation_error(&error) {
+                            tracing::warn!(error = ?error, "sync authority validation read expired");
+                            if !wait_for_sync_retry(&mut retry_backoff, &mut shutdown_rx).await {
+                                break;
+                            }
+                            continue;
+                        }
                         tracing::error!(error = ?error, "sync authority identity changed");
                         lix.fail_observers_for_sync(error.clone());
                         terminal_error = Some(error);
@@ -625,15 +663,38 @@ where
 async fn validate_connected_authority<StorageImpl>(
     lix: &Lix<StorageImpl>,
     remote_id: &str,
-    transport: &HttpSyncTransport,
+    authority_lix_id: &str,
+    active_account_id: &str,
 ) -> Result<(), LixError>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
-    validate_authority_lix_id(lix.lix_id(), transport.lix_id())?;
-    lix.validate_sync_repository_account(remote_id, transport.active_account_id())
-        .await?;
-    lix.validate_sync_hot_state_authoritative().await
+    validate_authority_lix_id(lix.lix_id(), authority_lix_id)?;
+    let mut retry = crate::common::ExpiredReadRetryState::default();
+    loop {
+        let result = async {
+            lix.validate_sync_repository_account(remote_id, active_account_id)
+                .await?;
+            lix.validate_sync_hot_state_authoritative().await
+        }
+        .await;
+        match result {
+            Err(error) => {
+                let Some(delay) = retry.next_delay(&error) else {
+                    return Err(error);
+                };
+                tokio::task::yield_now().await;
+                if !delay.is_zero() {
+                    sleep(delay).await;
+                }
+            }
+            result => return result,
+        }
+    }
+}
+
+fn is_retryable_authority_validation_error(error: &LixError) -> bool {
+    error.code == LixError::CODE_STORAGE_READ_EXPIRED
 }
 
 fn validate_authority_lix_id(local: &str, authority: &str) -> Result<(), LixError> {
@@ -1982,6 +2043,8 @@ fn stopped_error() -> LixError {
 
 #[cfg(test)]
 mod tests {
+    mod reconnect_validation_tests;
+
     use super::*;
     use base64::Engine as _;
     use std::sync::Mutex;

--- a/packages/lix/src/sync/runtime/tests/reconnect_validation_tests.rs
+++ b/packages/lix/src/sync/runtime/tests/reconnect_validation_tests.rs
@@ -1,0 +1,158 @@
+use super::super::*;
+use crate::storage::{Memory, MemoryRead, MemoryWrite, ReadOptions, StorageError, WriteOptions};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Clone)]
+struct ExpiringStorage {
+    inner: Memory,
+    expirations: Arc<AtomicUsize>,
+    reads_before_expiry: Arc<AtomicUsize>,
+    reads: Arc<AtomicUsize>,
+}
+
+impl Storage for ExpiringStorage {
+    type Read<'a> = MemoryRead;
+    type Write<'a> = MemoryWrite;
+
+    async fn acquire_session(&self) -> Result<crate::storage::StorageSessionToken, StorageError> {
+        self.inner.acquire_session().await
+    }
+    async fn begin_read(&self, options: ReadOptions) -> Result<MemoryRead, StorageError> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        let skip_expiry = self
+            .reads_before_expiry
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+            .is_ok();
+        if !skip_expiry
+            && self
+                .expirations
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                .is_ok()
+        {
+            return Err(StorageError::ReadExpired);
+        }
+        self.inner.begin_read(options).await
+    }
+    async fn begin_write(&self, options: WriteOptions) -> Result<MemoryWrite, StorageError> {
+        self.inner.begin_write(options).await
+    }
+}
+
+async fn replica() -> (Lix<ExpiringStorage>, ExpiringStorage) {
+    let storage = ExpiringStorage {
+        inner: Memory::new(),
+        expirations: Arc::default(),
+        reads_before_expiry: Arc::default(),
+        reads: Arc::default(),
+    };
+    let lix = crate::open_lix()
+        .with_storage(storage.clone())
+        .await
+        .unwrap();
+    let adapter = lix.storage_adapter();
+    let mut writes = adapter.new_write_set();
+    writes.put(
+        super::super::super::SYNC_REPLICA_STATE_SPACE,
+        &b"repository"[..],
+        serde_json::to_vec(&serde_json::json!({
+            "activeAccountId": lix.active_account_id(), "cursor": 0,
+            "authoritativeBranches": {}, "certifiedBranchRoots": {},
+            "authorityKnownCommitIds": []
+        }))
+        .unwrap(),
+    );
+    adapter
+        .commit_write_set(writes, WriteOptions::default())
+        .await
+        .unwrap();
+    (lix, storage)
+}
+
+#[tokio::test]
+async fn reconnect_validation_retries_a_concurrent_receipt_read_expiry() {
+    let (lix, storage) = replica().await;
+    // Exercise both the account receipt read and the HOT certificate read.
+    for successful_reads in [0, 1] {
+        storage
+            .reads_before_expiry
+            .store(successful_reads, Ordering::SeqCst);
+        storage.expirations.store(1, Ordering::SeqCst);
+        validate_connected_authority(
+            &lix,
+            "https://sync.example/lix/repository",
+            lix.lix_id(),
+            lix.active_account_id(),
+        )
+        .await
+        .expect("a concurrent commit must not be mistaken for changed authority");
+        assert_eq!(storage.expirations.load(Ordering::SeqCst), 0);
+    }
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn reconnect_validation_preserves_authority_mismatches_without_retry() {
+    let (lix, storage) = replica().await;
+    storage.reads.store(0, Ordering::SeqCst);
+    let error = validate_connected_authority(
+        &lix,
+        "https://sync.example/lix/repository",
+        lix.lix_id(),
+        "different-account",
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.code, LixError::CODE_INVALID_PARAM);
+    assert!(!is_retryable_authority_validation_error(&error));
+    assert_eq!(storage.reads.load(Ordering::SeqCst), 1);
+    let error = validate_connected_authority(
+        &lix,
+        "https://sync.example/lix/repository",
+        "00000000-0000-4000-8000-000000000001",
+        lix.active_account_id(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(
+        error.code,
+        super::super::super::SYNC_REPOSITORY_ID_MISMATCH_CODE
+    );
+    assert!(!is_retryable_authority_validation_error(&error));
+    assert_eq!(
+        storage.reads.load(Ordering::SeqCst),
+        1,
+        "identity mismatch is checked before local reads"
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn reconnect_validation_caps_persistent_expired_reads() {
+    let (lix, storage) = replica().await;
+    storage.expirations.store(100_000, Ordering::SeqCst);
+    storage.reads.store(0, Ordering::SeqCst);
+    let error = tokio::time::timeout(
+        Duration::from_secs(6),
+        validate_connected_authority(
+            &lix,
+            "https://sync.example/lix/repository",
+            lix.lix_id(),
+            lix.active_account_id(),
+        ),
+    )
+    .await
+    .expect("validation must finish within its bounded read retry budget")
+    .unwrap_err();
+    assert_eq!(error.code, LixError::CODE_STORAGE_READ_EXPIRED);
+    assert!(
+        is_retryable_authority_validation_error(&error),
+        "exhaustion must back off rather than poison observers"
+    );
+    let reads = storage.reads.load(Ordering::SeqCst);
+    assert!(
+        reads > 1 && reads < 1_000,
+        "retry backoff must bound storage work: {reads}"
+    );
+    storage.expirations.store(0, Ordering::SeqCst);
+    lix.close().await.unwrap();
+}

--- a/scripts/ci-artifact-request.mjs
+++ b/scripts/ci-artifact-request.mjs
@@ -1,0 +1,13 @@
+/** An artifact dispatch must build the exact source attached to its run. */
+export function assertArtifactRequest({ artifactsOnly, eventName, requestedRevision, workflowRevision }) {
+	if (!artifactsOnly) return;
+	if (eventName !== "workflow_dispatch") {
+		throw new Error("Artifact-only builds require explicit workflow_dispatch.");
+	}
+	if (!/^[0-9a-f]{40}$/.test(requestedRevision ?? "")) {
+		throw new Error("Artifact-only builds require source_revision as a full lowercase commit SHA.");
+	}
+	if (requestedRevision !== workflowRevision) {
+		throw new Error("The dispatched ref no longer matches source_revision. Dispatch the intended branch/tag again with its exact current SHA.");
+	}
+}

--- a/scripts/ci-artifact-request.test.mjs
+++ b/scripts/ci-artifact-request.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertArtifactRequest } from "./ci-artifact-request.mjs";
+const sha = "a".repeat(40);
+const request = { artifactsOnly: true, eventName: "workflow_dispatch", requestedRevision: sha, workflowRevision: sha };
+test("explicit dispatch accepts an exact ref, including a draft PR branch", () => {
+	assert.doesNotThrow(() => assertArtifactRequest(request));
+});
+for (const revision of [undefined, "", "main", "a".repeat(7), "A".repeat(40)]) {
+	test(`rejects a missing or mutable revision: ${revision}`, () => {
+		assert.throws(() => assertArtifactRequest({ ...request, requestedRevision: revision }));
+	});
+}
+test("a branch advancing before dispatch cannot produce misleading provenance", () => {
+	assert.throws(() => assertArtifactRequest({ ...request, workflowRevision: "b".repeat(40) }), /no longer matches/);
+});
+test("artifact mode cannot run on implicit PR/push events", () => {
+	for (const eventName of ["push", "pull_request"]) {
+		assert.throws(() => assertArtifactRequest({ ...request, eventName }), /explicit/);
+	}
+});
+test("ordinary validation retains its existing behavior and needs no source input", () => {
+	for (const eventName of ["push", "pull_request", "workflow_dispatch"]) {
+		assert.doesNotThrow(() => assertArtifactRequest({ artifactsOnly: false, eventName }));
+	}
+});

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -63,7 +63,7 @@ test("Rust scope gates only Rust jobs and keeps both SDK integration suites", ()
 		.split("\n  cargo:\n")[1]
 		.split("\n  js-sdk-test:\n")[0];
 	assert.match(cargo, /needs: changelog/);
-	assert.match(cargo, /if: needs\.changelog\.outputs\.rust != 'false'/);
+	assert.match(cargo, /if: inputs\.artifacts_only != true && needs\.changelog\.outputs\.rust != 'false'/);
 	const sdk = workflow
 		.split("\n  js-sdk-test:\n")[1]
 		.split("\n  preview-artifact-changes:\n")[0];
@@ -116,19 +116,10 @@ test("short Linux support jobs use small Ubicloud runners", () => {
 	}
 });
 
-test("SDK CI uses large Ubicloud runners for native and browser compilation", () => {
-	assert.match(
-		workflow,
-		/- name: Native\n\s+runtime: native\n\s+runner: ubicloud-standard-30-ubuntu-2404/,
-	);
-	assert.match(
-		workflow,
-		/- name: Browser\n\s+runtime: browser\n\s+runner: ubicloud-standard-30-ubuntu-2404/,
-	);
-	assert.match(
-		workflow,
-		/name: JS SDK \$\{\{ matrix\.name \}\} Test[\s\S]*?runs-on: \$\{\{ matrix\.runner \}\}/,
-	);
+test("SDK CI uses a large Ubicloud runner for both runtime modes", () => {
+    const sdk = workflow.split("\n  js-sdk-test:\n")[1].split("\n  preview-artifact-changes:\n")[0];
+    assert.match(sdk, /runs-on: ubicloud-standard-30-ubuntu-2404/);
+    assert.match(sdk, /runtime: .*\["native", "browser"\]/);
 });
 
 test("green SDK jobs retain exact-revision artifacts for submodule consumers", () => {
@@ -338,4 +329,21 @@ test("ARM64 release artifacts are tested on ARM hardware before publishing", () 
 	assert.match(armTest, /npx vitest run src\/binding\.node\.test\.ts/);
 	const rustPublish = publishWorkflow.split("\n  publish-rust-crates:\n")[1].split("\n  publish-js-sdk:\n")[0];
 	assert.match(rustPublish, /needs:[\s\S]*?- build-js-sdk-arm64/);
+});
+
+
+test("explicit artifact mode reuses producers without emitting release readiness", () => {
+    assert.match(workflow, /artifacts_only:\n\s+description:/);
+    assert.match(workflow, /source_revision:/);
+    assert.match(workflow, /Artifacts only - not release validation/);
+    assert.match(workflow, /if: always\(\) && inputs\.artifacts_only != true/);
+    assert.match(workflow, /'artifacts' \|\| 'validation'/);
+    assert.match(workflow, /assertArtifactRequest/);
+    const sdk = workflow.split("\n  js-sdk-test:\n")[1].split("\n  preview-artifact-changes:\n")[0];
+    assert.match(sdk, /runtime: .*inputs\.artifacts_only && '\["browser"\]'/);
+    assert.doesNotMatch(sdk, /include:/);
+    const selector = workflow.split("\n  preview-artifact-changes:\n")[1].split("\n  preview-server-image:\n")[0];
+    assert.match(selector, /needs: merge-reuse/);
+    assert.match(selector, /inputs\.artifacts_only == true/);
+    assert.match(selector, /echo 'server=true'/);
 });


### PR DESCRIPTION
A concurrent local commit can expire either receipt read while the sync worker validates a newly connected authority. Previously that error followed the same terminal path as a changed repository identity or account, stopping sync and failing every observer with `LIX_STORAGE_READ_EXPIRED`.

Validation now retries only expired coherent reads using the existing three-second budget and bounded backoff. If that budget expires, reconnect backs off without poisoning observers. Repository/account mismatches and other validation failures remain terminal. Both validation and cleanup race shutdown, and rejected temporary sessions are closed before reconnecting.

Validation:
- A deterministic Memory-backed regression failed before the fix with the exact error `the coherent storage read was invalidated by a concurrent commit`.
- Focused tests pass for expiry on either receipt read, unchanged account/repository mismatch rejection, and persistent expiry bounded at approximately three seconds.
- Full engine gate: 3,696 passed, 69 skipped (`all-simulations,server-protocol,server-protocol-client`); 10 doctests passed.
- Strict all-features/all-targets Clippy, formatting, and independent review passed.

This defect was identified while investigating the same error in the fresh-storage, two-tab browser sync test. The deterministic core defect is confirmed. LixRay’s built-image navigation, editing, and offline/checkpoint history scenarios passed with this exact SDK in https://github.com/opral/lixray/actions/runs/34400019140. The prior run on the old SDK failed the strict runtime-error assertion with this read-expiry error. This PR remains draft and unmerged; the artifact-only producer run is not full release validation.



Consumer artifact builds can now be explicitly requested for an exact branch/tag head, including a draft PR, with `gh workflow run ci.yml --ref BRANCH -f artifacts_only=true -f source_revision=SHA`. This reuses the tested browser SDK and server-image producers. The run rejects a moved ref, preserves exact-source manifests, and has separate concurrency and check names so it cannot cancel or satisfy release validation. Ordinary CI remains unchanged. The operator workflow is documented in `.github/release-flow.md`; 66 CI/release script tests and actionlint pass.

