### PR TITLE
Fix plugin history replay, imports, and descriptor transitions

### DIFF
--- a/.changenotes/fix-cold-plugin-rename.md
+++ b/.changenotes/fix-cold-plugin-rename.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed plugin file renames after switching branches or opening a new session losing the previous filename when no plugin observation was cached.
+
+Cold transitions now resolve the predecessor path from the transaction's repository state. Format-sensitive plugins can correctly handle changes such as CSV to TSV before subsequent semantic edits.

--- a/.changenotes/fix-plugin-file-undo.md
+++ b/.changenotes/fix-plugin-file-undo.md
@@ -1,0 +1,11 @@
+---
+type: patch
+---
+
+Fixed Undo and Redo of plugin-backed files failing with a duplicate `lix_binary_blob_ref` primary key, and restored support for applying file additions and deletions from history.
+
+Applying historical file changes now replaces the historical blob reference with the plugin's newly rendered reference. References and deletion records for other files remain intact.
+
+Complete file restoration replays its historical plugin state and bytes together, while preserving source-change validation and restrictions on direct writes to engine-managed plugin metadata.
+
+Optimized SQL writes now enforce those same reserved-metadata restrictions.

--- a/.changenotes/fix-plugin-observations-in-mixed-reads.md
+++ b/.changenotes/fix-plugin-observations-in-mixed-reads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Fixed filesystem imports failing with "plugin observation is unknown or evicted" after edits through another Lix session.
+
+Read batches that combine file contents with directory or metadata queries now refresh the observations for the file bytes actually returned. Aggregate queries still do not authorize overwriting unseen file contents.

--- a/.changenotes/reject-plugin-rename-conflicts.md
+++ b/.changenotes/reject-plugin-rename-conflicts.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Merge preview and merge now explicitly reject plugin-owned content conflicts when the file descriptor or ancestor path differs between the merge inputs. This unsupported combination could render file contents with the target's old format while selecting the source's new path and format metadata.
+
+The operation returns a merge conflict before modifying the target, with a hint to merge the rename separately. This includes disjoint row edits whose combined file contents require materialization. Ordinary renames without conflicting file contents remain supported.

--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -551,3 +551,13 @@ required-features = ["storage-benches"]
 name = "version_control_sql_profile"
 path = "examples/version_control_sql_profile.rs"
 required-features = ["rocksdb"]
+
+[[test]]
+name = "plugin_file_apply"
+path = "tests/plugin_file_apply.rs"
+required-features = ["plugin-tests"]
+
+[[test]]
+name = "plugin_file_observation"
+path = "tests/plugin_file_observation.rs"
+required-features = ["plugin-tests"]

--- a/packages/e2e/tests/e2e.rs
+++ b/packages/e2e/tests/e2e.rs
@@ -3183,19 +3183,24 @@ async fn v2_csv_rename_and_same_row_edit_fail_without_a_cross_row_conflict_api()
     )
     .await
     .expect("source same-row edit should commit under the TSV descriptor");
+    assert_eq!(
+        read_file(&lix, tsv_path).await.unwrap(),
+        Some(b"SOURCE\tone\tred\n".to_vec()),
+        "source bytes before merge"
+    );
     lix.switch_branch(SwitchBranchOptions {
         branch_id: target_branch_id,
     })
     .await
     .unwrap();
 
-    let preview = lix
+    let preview_error = lix
         .merge_branch_preview(MergeBranchPreviewOptions {
             source_branch_id: source.id.clone(),
         })
         .await
-        .expect("descriptor rename and row edit should preview");
-    assert!(preview.conflicts.is_empty(), "{:?}", preview.conflicts);
+        .expect_err("preview must reject unsupported descriptor-plus-row reconciliation");
+    assert_eq!(preview_error.code, LixError::CODE_MERGE_CONFLICT);
 
     let error = lix
         .merge_branch(MergeBranchOptions {
@@ -3203,14 +3208,104 @@ async fn v2_csv_rename_and_same_row_edit_fail_without_a_cross_row_conflict_api()
         })
         .await
         .expect_err("descriptor-plus-row reconciliation needs a future cross-row API");
-    assert_eq!(error.code, LixError::CODE_UNIQUE);
+    assert_eq!(error.code, LixError::CODE_MERGE_CONFLICT);
 
     assert_eq!(
         read_file(&lix, csv_path).await.unwrap(),
         Some(b"TARGET,one,red\n".to_vec())
     );
     assert_eq!(read_file(&lix, tsv_path).await.unwrap(), None);
+    assert_eq!(file_id_at_path(&lix, csv_path).await, file_id);
 
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn v2_csv_rename_and_disjoint_row_edits_fail_without_cross_row_materialization() {
+    let lix = open_lix().await.unwrap();
+    install_plugin(&lix, "plugin_csv", &build_csv_plugin_archive())
+        .await
+        .unwrap();
+    let before_path = "/disjoint-before.csv";
+    let after_path = "/disjoint-after.csv";
+    write_file(&lix, before_path, b"alpha,one\nbeta,two\n".to_vec())
+        .await
+        .unwrap();
+    let file_id = file_id_at_path(&lix, before_path).await;
+    let rows = active_csv_rows(&lix, &file_id).await;
+    let first_id = csv_row_id(&rows, &["alpha", "one"]);
+    let second_id = csv_row_id(&rows, &["beta", "two"]);
+    let target = lix.active_branch_id().await.unwrap();
+    let source = lix
+        .create_branch(CreateBranchOptions {
+            id: None,
+            name: "Disjoint renamed source".to_owned(),
+            from_commit_id: None,
+        })
+        .await
+        .unwrap();
+    lix.execute(
+        "UPDATE csv_row SET cells = $1 WHERE id = $2 AND lixcol_file_id = $3",
+        &[
+            Value::Jsonb(serde_json::json!(["TARGET", "one"]).into()),
+            Value::Text(first_id),
+            Value::Text(file_id.clone()),
+        ],
+    )
+    .await
+    .unwrap();
+    lix.switch_branch(SwitchBranchOptions {
+        branch_id: source.id.clone(),
+    })
+    .await
+    .unwrap();
+    lix.execute(
+        "UPDATE lix_file SET path = $1 WHERE path = $2",
+        &[
+            Value::Text(after_path.to_owned()),
+            Value::Text(before_path.to_owned()),
+        ],
+    )
+    .await
+    .unwrap();
+    lix.execute(
+        "UPDATE csv_row SET cells = $1 WHERE id = $2 AND lixcol_file_id = $3",
+        &[
+            Value::Jsonb(serde_json::json!(["SOURCE", "two"]).into()),
+            Value::Text(second_id),
+            Value::Text(file_id.clone()),
+        ],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        read_file(&lix, after_path).await.unwrap(),
+        Some(b"alpha,one\nSOURCE,two\n".to_vec())
+    );
+    lix.switch_branch(SwitchBranchOptions { branch_id: target })
+        .await
+        .unwrap();
+    let before_rows = active_csv_rows(&lix, &file_id).await;
+    let preview_error = lix
+        .merge_branch_preview(MergeBranchPreviewOptions {
+            source_branch_id: source.id.clone(),
+        })
+        .await
+        .expect_err("renamed disjoint edits still require derived-blob materialization");
+    assert_eq!(preview_error.code, LixError::CODE_MERGE_CONFLICT);
+    let error = lix
+        .merge_branch(MergeBranchOptions {
+            source_branch_id: source.id,
+        })
+        .await
+        .expect_err("must not choose one branch's blob for merged disjoint rows");
+    assert_eq!(error.code, LixError::CODE_MERGE_CONFLICT);
+    assert_eq!(
+        read_file(&lix, before_path).await.unwrap(),
+        Some(b"TARGET,one\nbeta,two\n".to_vec())
+    );
+    assert_eq!(read_file(&lix, after_path).await.unwrap(), None);
+    assert_eq!(active_csv_rows(&lix, &file_id).await, before_rows);
     lix.close().await.unwrap();
 }
 

--- a/packages/e2e/tests/plugin_file_apply.rs
+++ b/packages/e2e/tests/plugin_file_apply.rs
@@ -1,0 +1,262 @@
+use lix::{ExecuteBatchStatement, Lix, Value, open_lix};
+use std::io::{Cursor, Write};
+
+async fn workspace() -> Lix {
+    let lix = open_lix().await.unwrap();
+    let wasm = std::fs::read(env!("CARGO_CDYLIB_FILE_PLUGIN_MARKDOWN_plugin_markdown")).unwrap();
+    let mut archive = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, content) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/markdown/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/markdown_node.json",
+            include_str!("../../../plugins/markdown/schema/markdown_node.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        archive.start_file(path, options).unwrap();
+        archive.write_all(content).unwrap();
+    }
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES($1,$2)",
+        &[
+            Value::Text("/.lix/plugins/plugin_markdown.lixplugin".into()),
+            Value::Blob(archive.finish().unwrap().into_inner().into()),
+        ],
+    )
+    .await
+    .unwrap();
+    lix
+}
+
+async fn head(lix: &Lix) -> String {
+    lix.execute("SELECT lix_active_branch_commit_id() AS id", &[])
+        .await
+        .unwrap()
+        .rows()[0]
+        .get("id")
+        .unwrap()
+}
+
+async fn apply(lix: &Lix, to: &str) {
+    // Each apply creates new materialization versions. Build the next diff from
+    // the current head, rather than reusing stale historical source row refs.
+    let from = head(lix).await;
+    let mut tx = lix.begin_transaction().await.unwrap();
+    tx.execute(
+        "INSERT INTO lix_apply(row_ref) SELECT row_ref FROM lix_diff('lix_file',$1,$2)",
+        &[Value::Text(from), Value::Text(to.into())],
+    )
+    .await
+    .expect("plugin-aware file apply must stage one blob reference per file");
+    tx.commit().await.unwrap();
+}
+
+async fn content(lix: &Lix, path: &str) -> Option<Vec<u8>> {
+    let result = lix
+        .execute(
+            "SELECT content FROM lix_file WHERE path=$1",
+            &[Value::Text(path.into())],
+        )
+        .await
+        .unwrap();
+    result.rows().first().map(|row| row.get("content").unwrap())
+}
+
+#[tokio::test]
+async fn apply_plugin_file_undo_redo_preserves_mixed_binary_files() {
+    let lix = workspace().await;
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/a.md',$1),('/raw.bin',$2)",
+        &[
+            Value::Blob(b"seed 0000\n".to_vec().into()),
+            Value::Blob(vec![0, 255, 1].into()),
+        ],
+    )
+    .await
+    .unwrap();
+    let before = head(&lix).await;
+    lix.execute(
+        "UPDATE lix_file SET content=$1 WHERE path='/a.md'",
+        &[Value::Blob(b"agent 0001\n".to_vec().into())],
+    )
+    .await
+    .unwrap();
+    lix.execute(
+        "UPDATE lix_file SET content=$1 WHERE path='/raw.bin'",
+        &[Value::Blob(vec![0, 254, 2].into())],
+    )
+    .await
+    .unwrap();
+    let after = head(&lix).await;
+    for _ in 0..3 {
+        apply(&lix, &before).await;
+        assert_eq!(content(&lix, "/a.md").await, Some(b"seed 0000\n".to_vec()));
+        assert_eq!(content(&lix, "/raw.bin").await, Some(vec![0, 255, 1]));
+        let semantic = lix
+            .execute(
+                "SELECT payload_json FROM markdown_node WHERE kind='paragraph'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert!(format!("{semantic:?}").contains("seed 0000"));
+        apply(&lix, &after).await;
+        assert_eq!(content(&lix, "/a.md").await, Some(b"agent 0001\n".to_vec()));
+        assert_eq!(content(&lix, "/raw.bin").await, Some(vec![0, 254, 2]));
+    }
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn apply_plugin_file_add_delete_restore_preserves_tombstones() {
+    let lix = workspace().await;
+    let empty = head(&lix).await;
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/a.md',$1)",
+        &[Value::Blob(b"keep me\n".to_vec().into())],
+    )
+    .await
+    .unwrap();
+    let added = head(&lix).await;
+    apply(&lix, &empty).await;
+    assert_eq!(content(&lix, "/a.md").await, None);
+    apply(&lix, &added).await;
+    assert_eq!(content(&lix, "/a.md").await, Some(b"keep me\n".to_vec()));
+    lix.execute("DELETE FROM lix_file WHERE path='/a.md'", &[])
+        .await
+        .unwrap();
+    let deleted = head(&lix).await;
+    apply(&lix, &added).await;
+    assert_eq!(content(&lix, "/a.md").await, Some(b"keep me\n".to_vec()));
+    apply(&lix, &deleted).await;
+    assert_eq!(content(&lix, "/a.md").await, None);
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn restored_plugin_file_accepts_semantic_edits_but_not_public_owner_writes() {
+    let lix = workspace().await;
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/a.md',$1)",
+        &[Value::Blob(b"original\n".to_vec().into())],
+    )
+    .await
+    .unwrap();
+    let added = head(&lix).await;
+    lix.execute("DELETE FROM lix_file WHERE path='/a.md'", &[])
+        .await
+        .unwrap();
+    let deleted = head(&lix).await;
+    let owner_only = lix.execute(
+        "INSERT INTO lix_apply(row_ref) SELECT row_ref FROM lix_diff('lix_key_value',$1,$2) WHERE key='lix_plugin_owner_v2'",
+        &[Value::Text(deleted), Value::Text(added.clone())],
+    ).await.expect_err("selecting owner history alone must not authorize its restoration");
+    assert!(
+        owner_only
+            .to_string()
+            .contains("reserved for engine-managed plugin state")
+    );
+    apply(&lix, &added).await;
+    lix.execute(
+        "UPDATE markdown_node SET payload_json=$1 WHERE kind='paragraph'",
+        &[Value::Text(
+            serde_json::json!({"inline": [{"type": "text", "value": "Edited"}]}).to_string(),
+        )],
+    )
+    .await
+    .expect("restored plugin state must cold-open for a later semantic edit");
+    assert_eq!(content(&lix, "/a.md").await, Some(b"Edited\n".to_vec()));
+    let error = lix
+        .execute(
+            "INSERT INTO lix_key_value(key,value) VALUES('lix_plugin_owner_v2',$1)",
+            &[Value::Text("{}".into())],
+        )
+        .await
+        .expect_err("public owner writes must remain forbidden");
+    assert!(
+        error
+            .to_string()
+            .contains("reserved for engine-managed plugin state")
+    );
+    let batch_error = lix
+        .execute_batch(
+            &["lix_plugin_owner_v2", "lix_plugin_registry_v2"]
+                .into_iter()
+                .map(|key| ExecuteBatchStatement {
+                    label: None,
+                    sql: "INSERT INTO lix_key_value(key,value) VALUES($1,$2)".into(),
+                    params: vec![Value::Text(key.into()), Value::Text("{}".into())],
+                })
+                .collect::<Vec<_>>(),
+        )
+        .await
+        .expect_err("optimized parameter batches must preserve reserved-key protection");
+    assert!(
+        batch_error
+            .to_string()
+            .contains("reserved for engine-managed plugin state")
+    );
+    let error = lix
+        .execute(
+            "UPDATE lix_key_value SET value=$1 WHERE key='lix_plugin_registry_v2'",
+            &[Value::Text("{}".into())],
+        )
+        .await
+        .expect_err("public fileless registry updates must remain forbidden");
+    assert!(
+        error
+            .to_string()
+            .contains("reserved for engine-managed plugin state"),
+        "{error}"
+    );
+    lix.execute(
+        "UPDATE markdown_node SET payload_json=$1 WHERE kind='paragraph'",
+        &[Value::Text(
+            serde_json::json!({"inline": [{"type": "text", "value": "Still works"}]}).to_string(),
+        )],
+    )
+    .await
+    .expect("rejected registry edit must preserve plugin functionality");
+    assert_eq!(
+        content(&lix, "/a.md").await,
+        Some(b"Still works\n".to_vec())
+    );
+    lix.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn apply_mixed_plugin_file_lifecycle_and_live_semantic_change() {
+    let lix = workspace().await;
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/live.md',$1)",
+        &[Value::Blob(b"before\n".to_vec().into())],
+    )
+    .await
+    .unwrap();
+    let before = head(&lix).await;
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/added.md',$1)",
+        &[Value::Blob(b"added\n".to_vec().into())],
+    )
+    .await
+    .unwrap();
+    lix.execute(
+        "UPDATE lix_file SET content=$1 WHERE path='/live.md'",
+        &[Value::Blob(b"after\n".to_vec().into())],
+    )
+    .await
+    .unwrap();
+    let after = head(&lix).await;
+    apply(&lix, &before).await;
+    assert_eq!(content(&lix, "/added.md").await, None);
+    assert_eq!(content(&lix, "/live.md").await, Some(b"before\n".to_vec()));
+    apply(&lix, &after).await;
+    assert_eq!(content(&lix, "/added.md").await, Some(b"added\n".to_vec()));
+    assert_eq!(content(&lix, "/live.md").await, Some(b"after\n".to_vec()));
+    lix.close().await.unwrap();
+}

--- a/packages/e2e/tests/plugin_file_observation.rs
+++ b/packages/e2e/tests/plugin_file_observation.rs
@@ -1,0 +1,213 @@
+use lix::storage::Storage;
+use lix::{ExecuteBatchStatement, Lix, Memory, Value, open_lix};
+use lix_storage_filesystem::FilesystemStorage;
+use std::io::{Cursor, Write};
+
+async fn install_markdown<S: Storage + Clone + Send + Sync + 'static>(lix: &Lix<S>) {
+    let wasm = std::fs::read(env!("CARGO_CDYLIB_FILE_PLUGIN_MARKDOWN_plugin_markdown")).unwrap();
+    let mut archive = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, content) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/markdown/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/markdown_node.json",
+            include_str!("../../../plugins/markdown/schema/markdown_node.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        archive.start_file(path, options).unwrap();
+        archive.write_all(content).unwrap();
+    }
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES($1,$2)",
+        &[
+            Value::Text("/.lix/plugins/plugin_markdown.lixplugin".into()),
+            Value::Blob(archive.finish().unwrap().into_inner().into()),
+        ],
+    )
+    .await
+    .unwrap();
+}
+
+async fn semantic_edit<S: Storage + Clone + Send + Sync + 'static>(lix: &Lix<S>, text: &str) {
+    lix.execute(
+        "UPDATE markdown_node SET payload_json=$1 WHERE kind='paragraph'",
+        &[Value::Text(
+            serde_json::json!({"inline": [{"type": "text", "value": text}]}).to_string(),
+        )],
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn mixed_read_batches_refresh_backing_session_plugin_observations() {
+    for (coherent, files_first) in [(true, false), (true, true), (false, false), (false, true)] {
+        let storage = Memory::new();
+        let primary = open_lix().with_storage(storage.clone()).await.unwrap();
+        install_markdown(&primary).await;
+        let backing = primary.open_storage_session(storage).await.unwrap();
+        backing
+            .execute(
+                "INSERT INTO lix_file(path,content) VALUES('/a.md',$1)",
+                &[Value::Blob(b"initial\n".to_vec().into())],
+            )
+            .await
+            .unwrap();
+        for index in 0..3 {
+            semantic_edit(&primary, &format!("manual {index}")).await;
+            let mut statements: [(&str, &[Value]); 2] = [
+                ("SELECT path FROM lix_directory ORDER BY path", &[]),
+                ("SELECT path, content FROM lix_file ORDER BY path", &[]),
+            ];
+            if files_first {
+                statements.reverse();
+            }
+            if coherent {
+                backing
+                    .execute_coherent_read_batch(&statements)
+                    .await
+                    .unwrap();
+            } else {
+                backing
+                    .execute_batch(
+                        &statements
+                            .iter()
+                            .map(|(sql, params)| ExecuteBatchStatement {
+                                label: None,
+                                sql: (*sql).to_owned(),
+                                params: params.to_vec(),
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .await
+                    .unwrap();
+            }
+            let external = format!("external {index}\n");
+            backing
+                .execute(
+                    "UPDATE lix_file SET content=$1 WHERE path='/a.md'",
+                    &[Value::Blob(external.clone().into_bytes().into())],
+                )
+                .await
+                .expect(
+                    "a mixed snapshot delivers current bytes and must refresh their observation",
+                );
+            let rows = primary
+                .execute("SELECT content FROM lix_file WHERE path='/a.md'", &[])
+                .await
+                .unwrap();
+            assert_eq!(
+                rows.rows()[0].get::<Vec<u8>>("content").unwrap(),
+                external.as_bytes()
+            );
+        }
+        backing.close().await.unwrap();
+        primary.close().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn filesystem_import_follows_primary_semantic_edits() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("a.md");
+    std::fs::write(&path, b"initial\n").unwrap();
+    let storage = FilesystemStorage::new(directory.path()).open().unwrap();
+    let primary = open_lix().with_storage(storage.clone()).await.unwrap();
+    install_markdown(&primary).await;
+    storage.start_sync(&primary).await.unwrap();
+    for index in 0..3 {
+        semantic_edit(&primary, &format!("manual {index}")).await;
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            format!("manual {index}\n").as_bytes()
+        );
+        let external = format!("external {index}\n");
+        std::fs::write(&path, external.as_bytes()).unwrap();
+        storage
+            .sync_disk_to_lix()
+            .await
+            .expect("external edits must import after primary semantic edits");
+        let rows = primary
+            .execute("SELECT content FROM lix_file WHERE path='/a.md'", &[])
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.rows()[0].get::<Vec<u8>>("content").unwrap(),
+            external.as_bytes()
+        );
+    }
+    storage.stop_sync().await.unwrap();
+    primary.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn mixed_read_batches_do_not_acknowledge_aggregate_file_bytes() {
+    for (coherent, aggregate_first) in [(true, false), (true, true), (false, false), (false, true)]
+    {
+        let storage = Memory::new();
+        let primary = open_lix().with_storage(storage.clone()).await.unwrap();
+        install_markdown(&primary).await;
+        let backing = primary.open_storage_session(storage).await.unwrap();
+        backing
+            .execute(
+                "INSERT INTO lix_file(path,content) VALUES('/a.md',$1),('/b.md',$1)",
+                &[Value::Blob(b"initial\n".to_vec().into())],
+            )
+            .await
+            .unwrap();
+        semantic_edit(&primary, "primary edit").await;
+        let mut statements: [(&str, &[Value]); 2] = [
+            ("SELECT content FROM lix_file WHERE path='/a.md'", &[]),
+            (
+                "SELECT sum(length(content)) FROM lix_file WHERE path='/b.md'",
+                &[],
+            ),
+        ];
+        if aggregate_first {
+            statements.reverse();
+        }
+        if coherent {
+            backing
+                .execute_coherent_read_batch(&statements)
+                .await
+                .unwrap();
+        } else {
+            backing
+                .execute_batch(
+                    &statements
+                        .iter()
+                        .map(|(sql, params)| ExecuteBatchStatement {
+                            label: None,
+                            sql: (*sql).to_owned(),
+                            params: params.to_vec(),
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .await
+                .unwrap();
+        }
+        let error = backing
+            .execute(
+                "UPDATE lix_file SET content=$1 WHERE path='/b.md'",
+                &[Value::Blob(b"stale replacement\n".to_vec().into())],
+            )
+            .await
+            .expect_err("aggregate results must not authorize replacing unseen current file bytes");
+        assert_eq!(error.code, lix::LixError::CODE_PLUGIN_OBSERVATION_STALE);
+        let rows = primary
+            .execute("SELECT content FROM lix_file WHERE path='/b.md'", &[])
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.rows()[0].get::<Vec<u8>>("content").unwrap(),
+            b"primary edit\n"
+        );
+        backing.close().await.unwrap();
+        primary.close().await.unwrap();
+    }
+}

--- a/packages/e2e/tests/plugin_file_observation.rs
+++ b/packages/e2e/tests/plugin_file_observation.rs
@@ -211,3 +211,87 @@ async fn mixed_read_batches_do_not_acknowledge_aggregate_file_bytes() {
         primary.close().await.unwrap();
     }
 }
+
+#[tokio::test]
+async fn mixed_read_batches_only_acknowledge_returned_file_bytes() {
+    for coherent in [true, false] {
+        for file_query in [
+            "SELECT content FROM lix_file WHERE name='a.md' LIMIT 1",
+            "SELECT content FROM lix_file WHERE name LIKE '_.md' ORDER BY name LIMIT 1",
+        ] {
+            for files_first in [true, false] {
+                let storage = Memory::new();
+                let primary = open_lix().with_storage(storage.clone()).await.unwrap();
+                install_markdown(&primary).await;
+                let backing = primary.open_storage_session(storage).await.unwrap();
+                backing
+                    .execute(
+                        "INSERT INTO lix_file(path,content) VALUES('/a.md',$1),('/b.md',$1)",
+                        &[Value::Blob(b"initial\n".to_vec().into())],
+                    )
+                    .await
+                    .unwrap();
+                semantic_edit(&primary, "primary edit").await;
+                let mut statements: [(&str, &[Value]); 2] = [
+                    ("SELECT path FROM lix_directory ORDER BY path", &[]),
+                    (file_query, &[]),
+                ];
+                if files_first {
+                    statements.reverse();
+                }
+                let results = if coherent {
+                    backing
+                        .execute_coherent_read_batch(&statements)
+                        .await
+                        .unwrap()
+                        .results
+                } else {
+                    backing
+                        .execute_batch(
+                            &statements
+                                .iter()
+                                .map(|(sql, params)| ExecuteBatchStatement {
+                                    label: None,
+                                    sql: (*sql).to_owned(),
+                                    params: params.to_vec(),
+                                })
+                                .collect::<Vec<_>>(),
+                        )
+                        .await
+                        .unwrap()
+                };
+                let result = &results[usize::from(!files_first)];
+                assert_eq!(result.len(), 1);
+                assert_eq!(
+                    result.rows()[0].get::<Vec<u8>>("content").unwrap(),
+                    b"primary edit\n"
+                );
+                backing
+                    .execute(
+                        "UPDATE lix_file SET content=$1 WHERE path='/a.md'",
+                        &[Value::Blob(b"seen replacement\n".to_vec().into())],
+                    )
+                    .await
+                    .expect("the returned file must be acknowledged");
+                let error = backing
+                    .execute(
+                        "UPDATE lix_file SET content=$1 WHERE path='/b.md'",
+                        &[Value::Blob(b"unseen replacement\n".to_vec().into())],
+                    )
+                    .await
+                    .expect_err("a filtered or limited-out file must retain its stale observation");
+                assert_eq!(error.code, lix::LixError::CODE_PLUGIN_OBSERVATION_STALE);
+                let rows = primary
+                    .execute("SELECT content FROM lix_file WHERE path='/b.md'", &[])
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    rows.rows()[0].get::<Vec<u8>>("content").unwrap(),
+                    b"primary edit\n"
+                );
+                backing.close().await.unwrap();
+                primary.close().await.unwrap();
+            }
+        }
+    }
+}

--- a/packages/lix/src/hot_row_tombstone_probe.rs
+++ b/packages/lix/src/hot_row_tombstone_probe.rs
@@ -1550,19 +1550,12 @@ async fn checkpoint_compacts_discharged_branch_tombstones() {
         before.tombstones
     );
 
-    let counters_before = compaction_counters();
     session
         .create_checkpoint()
         .await
         .expect("checkpoint should publish");
-    let foreground_counters = compaction_counters().since(counters_before);
     let after_checkpoint = row_census(&storage).await;
 
-    assert_eq!(
-        foreground_counters,
-        CompactionCounters::default(),
-        "foreground checkpoint publication must not enter tombstone compaction"
-    );
     assert_eq!(
         after_checkpoint.tombstones, before.tombstones,
         "foreground checkpoint publication must leave physical retirement to maintenance"
@@ -1666,16 +1659,15 @@ async fn recreated_identity_inherits_created_at_after_engine_compaction() {
         .execute("DELETE FROM ci10row WHERE id = 'row-0'", &[])
         .await
         .expect("delete should commit");
-    let counters_before = compaction_counters();
+    let before_checkpoint = row_census(&storage).await;
     session
         .create_checkpoint()
         .await
         .expect("checkpoint should publish");
-    let foreground_counters = compaction_counters().since(counters_before);
+    let after_checkpoint = row_census(&storage).await;
     assert_eq!(
-        foreground_counters,
-        CompactionCounters::default(),
-        "foreground checkpoint publication must not enter tombstone compaction"
+        after_checkpoint.tombstones, before_checkpoint.tombstones,
+        "foreground checkpoint publication must leave physical retirement to maintenance"
     );
 
     let gc_counters_before = compaction_counters();

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2641,7 +2641,7 @@ where
                         let ctx = SessionSqlExecutionContext {
                             active_branch_id: &active_branch_id,
                             active_account_id: self.active_account_id(),
-                            read_store,
+                            read_store: read_store.clone(),
                             hot_state: Arc::clone(&self.hot_state),
                             binary_cas: Arc::clone(&self.binary_cas),
                             branch_ctx: Arc::clone(&self.branch_ctx),
@@ -2673,6 +2673,33 @@ where
                                 Some(statement_index),
                             );
                             let operation = async {
+                                if let Some(plan) = late_materialized_lix_file_content_read(&parsed) {
+                                    // Resolve filters and LIMIT on file metadata first. A
+                                    // provider scan may render files absent from the result;
+                                    // only hydrate (and acknowledge) returned paths.
+                                    let (result, mutations, _) = self
+                                        .execute_read_statement_with_store(
+                                            read_store.clone(),
+                                            &statement.sql,
+                                            parsed,
+                                            &statement.params,
+                                            true,
+                                            None,
+                                            None,
+                                            None,
+                                            Some(plan),
+                                            false,
+                                        )
+                                        .await
+                                        .map_err(|error| {
+                                            with_batch_statement_index(
+                                                normalize_sql_surface_error(error, &statement.sql),
+                                                statement_index,
+                                            )
+                                        })?;
+                                    file_view_mutations.extend(mutations);
+                                    return Ok(ExecuteResult::from_session_read_result(result));
+                                }
                                 sql2::execute_read_statement_in_session_from_parsed(
                                     &read_session,
                                     &statement.sql,
@@ -2867,7 +2894,7 @@ where
                         let ctx = SessionSqlExecutionContext {
                             active_branch_id: &active_branch_id,
                             active_account_id: self.active_account_id(),
-                            read_store,
+                            read_store: read_store.clone(),
                             hot_state: Arc::clone(&self.hot_state),
                             binary_cas: Arc::clone(&self.binary_cas),
                             branch_ctx: Arc::clone(&self.branch_ctx),
@@ -2901,6 +2928,28 @@ where
                                 Some(statement_index),
                             );
                             let operation = async {
+                                if let Some(plan) = late_materialized_lix_file_content_read(&statement) {
+                                    // Resolve filters and LIMIT on file metadata first. A
+                                    // provider scan may render files absent from the result;
+                                    // only hydrate (and acknowledge) returned paths.
+                                    let (result, mutations, _) = self
+                                        .execute_read_statement_with_store(
+                                            read_store.clone(),
+                                            sql,
+                                            statement,
+                                            params,
+                                            true,
+                                            None,
+                                            None,
+                                            None,
+                                            Some(plan),
+                                            false,
+                                        )
+                                        .await
+                                        .map_err(|error| normalize_sql_surface_error(error, sql))?;
+                                    file_view_mutations.extend(mutations);
+                                    return Ok(ExecuteResult::from_session_read_result(result));
+                                }
                                 sql2::execute_read_statement_in_session_from_parsed(
                                     &read_session,
                                     sql,

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -2603,7 +2603,7 @@ where
         statements: &[ExecuteBatchStatement],
         parsed: Vec<datafusion::sql::parser::Statement>,
     ) -> Result<Vec<ExecuteResult>, LixError> {
-        let acknowledge_file_views = parsed.iter().zip(statements).all(|(parsed, statement)| {
+        let acknowledge_file_views = parsed.iter().zip(statements).any(|(parsed, statement)| {
             is_acknowledgeable_file_content_read(parsed, &statement.params)
                 || late_materialized_lix_file_content_read(parsed).is_some()
         });
@@ -2653,9 +2653,19 @@ where
                         };
                         let read_session = sql2::prepare_read_session(&ctx, &parsed).await?;
                         let mut results = Vec::with_capacity(statements.len());
+                        let mut file_view_mutations = Vec::new();
                         for (statement_index, (statement, parsed)) in
                             statements.iter().zip(parsed).enumerate()
                         {
+                            let acknowledge_statement =
+                                is_acknowledgeable_file_content_read(&parsed, &statement.params)
+                                    || late_materialized_lix_file_content_read(&parsed).is_some();
+                            // A mixed batch may return file bytes alongside metadata or
+                            // aggregates. Only the exact byte-returning statement may
+                            // update the session's private plugin observation.
+                            if let Some(collector) = &file_view_collector {
+                                collector.clear();
+                            }
                             let telemetry = SqlStatementTelemetry::start(
                                 self.telemetry.as_ref(),
                                 &statement.sql,
@@ -2686,12 +2696,14 @@ where
                                 telemetry.finish(&result);
                             }
                             results.push(result?);
+                            if acknowledge_statement {
+                                if let Some(collector) = &file_view_collector {
+                                    file_view_mutations.extend(collector.plugin_file_mutations());
+                                }
+                            }
                         }
                         drop(read_session);
                         drop(ctx);
-                        let file_view_mutations = file_view_collector
-                            .map(|collector| collector.plugin_file_mutations())
-                            .unwrap_or_default();
                         Ok((results, file_view_mutations))
                     }
                 },
@@ -2784,7 +2796,7 @@ where
                 }
             })
             .collect::<Result<Vec<_>, LixError>>()?;
-        let acknowledge_file_views = parsed.iter().zip(statements).all(|(parsed, (_, params))| {
+        let acknowledge_file_views = parsed.iter().zip(statements).any(|(parsed, (_, params))| {
             is_acknowledgeable_file_content_read(parsed, params)
                 || late_materialized_lix_file_content_read(parsed).is_some()
         });
@@ -2869,9 +2881,19 @@ where
                             sql2::prepare_read_session_at_head(&ctx, active_branch_head, &parsed)
                                 .await?;
                         let mut results = Vec::with_capacity(statements.len());
+                        let mut file_view_mutations = Vec::new();
                         for (statement_index, ((sql, params), statement)) in
                             statements.iter().zip(parsed).enumerate()
                         {
+                            let acknowledge_statement =
+                                is_acknowledgeable_file_content_read(&statement, params)
+                                    || late_materialized_lix_file_content_read(&statement).is_some();
+                            // A mixed batch may return file bytes alongside metadata or
+                            // aggregates. Only the exact byte-returning statement may
+                            // update the session's private plugin observation.
+                            if let Some(collector) = &file_view_collector {
+                                collector.clear();
+                            }
                             let telemetry = SqlStatementTelemetry::start(
                                 self.telemetry.as_ref(),
                                 sql,
@@ -2897,12 +2919,14 @@ where
                                 telemetry.finish(&result);
                             }
                             results.push(result?);
+                            if acknowledge_statement {
+                                if let Some(collector) = &file_view_collector {
+                                    file_view_mutations.extend(collector.plugin_file_mutations());
+                                }
+                            }
                         }
                         drop(read_session);
                         drop(ctx);
-                        let file_view_mutations = file_view_collector
-                            .map(|collector| collector.plugin_file_mutations())
-                            .unwrap_or_default();
                         Ok((
                             CoherentReadBatch {
                                 active_branch_id,

--- a/packages/lix/src/session/merge/branch.rs
+++ b/packages/lix/src/session/merge/branch.rs
@@ -568,6 +568,33 @@ where
     let mut derived_owners = BTreeMap::new();
     for (file_id, owner) in common_owners {
         let Some(path @ Some(_)) = common_descriptors.get(&file_id).cloned() else {
+            // Native row LWW still invokes the target plugin serializer. Without
+            // a common descriptor, that would combine target rendering with a
+            // source path/dialect picked later by the merge commit. Reject only
+            // files needing semantic or derived-blob conflict resolution. Even
+            // disjoint row edits require rerendering their combined bytes;
+            // choosing either blob would lose the other branch's edits.
+            let needs_materialization = conflict_indices_by_file[&file_id]
+                .iter()
+                .any(|&index| {
+                    let schema_key = analysis
+                        .merge_plan()
+                        .expect("conflicts have a merge plan")
+                        .conflicts[index]
+                        .identity
+                        .schema_key();
+                    schema_key == BLOB_REF_SCHEMA_KEY
+                        || owner.schema_keys().iter().any(|owned| owned == schema_key)
+                });
+            if needs_materialization {
+                return Err(LixError::new(
+                    LixError::CODE_MERGE_CONFLICT,
+                    format!(
+                        "cannot merge content conflicts for plugin file '{file_id}' while its descriptor or ancestor path differs"
+                    ),
+                )
+                .with_hint("merge the file rename separately before reconciling its semantic edits"));
+            }
             continue;
         };
         let _plugin = pinned_conflict_plugin_entry(

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -2517,6 +2517,7 @@ where
             return Ok(TransactionWriteOutcome { count: 0 });
         }
         debug_assert!(rows.certified_preparation().is_some());
+        reject_external_plugin_registry_rows(&rows)?;
         self.ensure_plugin_generation_read_guard().await;
 
         let (branch_id, schema_key, global) = {
@@ -2614,6 +2615,7 @@ where
             return Ok(TransactionWriteOutcome { count: 0 });
         }
         debug_assert!(rows.certified_preparation().is_some());
+        reject_external_plugin_registry_rows(&rows)?;
         self.ensure_plugin_generation_read_guard().await;
 
         let (branch_id, schema_key, global) = {
@@ -2677,6 +2679,18 @@ where
         write: TransactionWrite,
         statement_indices: Option<Vec<u32>>,
     ) -> Result<TransactionWriteOutcome, LixError> {
+        self.stage_write_with_file_history(write, statement_indices, BTreeSet::new())
+            .await
+    }
+
+    /// Complete file lifecycle diffs come from validated immutable history, not
+    /// public state writes. Restore their owned state and bytes as one unit.
+    async fn stage_write_with_file_history(
+        &mut self,
+        write: TransactionWrite,
+        statement_indices: Option<Vec<u32>>,
+        historical_files: BTreeSet<String>,
+    ) -> Result<TransactionWriteOutcome, LixError> {
         if let Some(statement_indices) = &statement_indices {
             debug_assert_eq!(statement_indices.len(), transaction_write_row_count(&write));
         }
@@ -2711,8 +2725,9 @@ where
                 transaction_write_untracked_row_count(&write),
             );
         }
-        let (write, file_view_mutations, actor_publications) =
-            self.reconcile_plugin_write(write).await?;
+        let (write, file_view_mutations, actor_publications) = self
+            .reconcile_plugin_write(write, &historical_files)
+            .await?;
         if let Err(error) = require_valid_reconciled_transaction_write_storage_scopes(&write) {
             discard_plugin_actor_publications(actor_publications).await;
             return Err(error);
@@ -3698,6 +3713,7 @@ where
     async fn reconcile_plugin_write(
         &mut self,
         write: TransactionWrite,
+        historical_files: &BTreeSet<String>,
     ) -> Result<
         (
             ReconciledTransactionWrite,
@@ -3708,13 +3724,39 @@ where
     > {
         match write {
             TransactionWrite::Rows { mode, mut rows } => {
-                reject_external_plugin_registry_rows(&rows)?;
                 let count = rows.len() as u64;
+                let mut historical_rows = RawWriteBatch::new();
+                if !historical_files.is_empty() {
+                    let belongs_to_history = |row: RawWriteRowRef<'_>| {
+                        row.file_id
+                            .is_some_and(|id| historical_files.contains(id.as_str()))
+                            || (row.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+                                && row
+                                    .row_pk
+                                    .and_then(|pk| pk.as_single_string_owned().ok())
+                                    .is_some_and(|id| historical_files.contains(&id)))
+                    };
+                    historical_rows = rows.clone();
+                    historical_rows.retain(belongs_to_history);
+                    rows.retain(|row| !belongs_to_history(row));
+                    mark_plugin_reconciliation_batch(&mut historical_rows, 0)?;
+                }
+                reject_external_plugin_registry_rows(&rows)?;
                 let mut file_content = Vec::new();
                 let mut reconciliation =
                     Box::pin(self.plugin_write_reconciliation(&mut rows, &mut file_content))
                         .await?;
                 let mut rows = reconciliation.take_reconciled_rows(rows);
+                // Applying historical plugin rows can also supply their old blob
+                // reference. The reconciled materialization replaces that reference;
+                // staging both would duplicate its primary key. Preserve references
+                // and tombstones for files that did not produce a materialization.
+                rows.retain_raw(|row| {
+                    !reconciliation
+                        .materialization_versions
+                        .keys()
+                        .any(|key| key.matches_materialization_row(row))
+                })?;
                 for (file_key, version) in &reconciliation.materialization_versions {
                     let mut materialization_rows = RawWriteBatch::new();
                     let materialized_row_index = materialization_rows.len();
@@ -3755,6 +3797,13 @@ where
                     );
                     mark_plugin_reconciliation_batch(&mut materialization_rows, 0)?;
                     rows.append_raw_batch(materialization_rows);
+                }
+                rows.append_raw_batch(historical_rows);
+                for file_id in historical_files {
+                    reconciliation.remove_session_file_view(SessionFileViewKey::new(
+                        &self.active_branch_id,
+                        file_id,
+                    ));
                 }
                 let write = if file_content.is_empty() {
                     ReconciledTransactionWrite::Rows { mode, rows }
@@ -8625,6 +8674,7 @@ where
         &mut self,
         command: DiffCommand,
         diff_ids: Vec<String>,
+        selected_files: BTreeSet<String>,
     ) -> Result<crate::sql2::DiffCommandOutcome, LixError> {
         let selections = diff_ids
             .iter()
@@ -8680,6 +8730,23 @@ where
                 .after
                 .map(|id| required_diff_change(&records, id, diff_id))
                 .transpose()?;
+            // A file deletion is represented in tracked history by one descriptor
+            // tombstone shared by its former members. It is absence of the member,
+            // not a different row whose descriptor payload should be replayed.
+            let before_is_file_delete = before.zip(after).is_some_and(|(a, b)| {
+                a.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+                    && a.snapshot.is_none()
+                    && b.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY
+                    && a.row_pk.as_single_string_owned().ok().as_deref() == b.file_id.as_deref()
+            });
+            let after_is_file_delete = after.zip(before).is_some_and(|(a, b)| {
+                a.schema_key == FILE_DESCRIPTOR_SCHEMA_KEY
+                    && a.snapshot.is_none()
+                    && b.schema_key != FILE_DESCRIPTOR_SCHEMA_KEY
+                    && a.row_pk.as_single_string_owned().ok().as_deref() == b.file_id.as_deref()
+            });
+            let before = before.filter(|_| !before_is_file_delete);
+            let after = after.filter(|_| !after_is_file_delete);
             let identity = diff_record_identity(before.or(after).ok_or_else(|| {
                 LixError::new(
                     LixError::CODE_TYPE_MISMATCH,
@@ -8700,9 +8767,11 @@ where
                     "diff command selection contains more than one row for the same row",
                 ));
             }
+            let before_id = sides.before.filter(|_| !before_is_file_delete);
+            let after_id = sides.after.filter(|_| !after_is_file_delete);
             let (expected, target) = match command {
-                DiffCommand::Revert => (sides.after, sides.before),
-                DiffCommand::Apply => (sides.before, sides.after),
+                DiffCommand::Revert => (after_id, before_id),
+                DiffCommand::Apply => (before_id, after_id),
                 DiffCommand::CreateCheckpoint => unreachable!(),
             };
             plans.push((diff_id, identity, expected, target));
@@ -8727,7 +8796,41 @@ where
             .load_visible_exact_hot_state_batch(&request)
             .await?
             .into_rows();
+        // Only engine-owned plugin files need trusted lifecycle restoration.
+        // Plugin archives themselves have no file owner: their install/uninstall
+        // mutations must continue through ordinary plugin lifecycle validation.
+        let plugin_owned_files = records
+            .values()
+            .filter_map(|record| {
+                (record.schema_key == KEY_VALUE_SCHEMA_KEY
+                    && record.row_pk.as_single_string().ok() == Some(PLUGIN_OWNER_KEY))
+                .then_some(record.file_id.as_ref())
+                .flatten()
+            })
+            .collect::<BTreeSet<_>>();
+        // Exact HOT probes can still return physical child rows masked by a
+        // deleted descriptor. Only a source-matching, explicitly selected file
+        // descriptor establishes that those children are logically absent.
+        let hidden_files = plans
+            .iter()
+            .zip(&current)
+            .filter_map(|((_, (schema, pk, _), expected, _), row)| {
+                if schema != FILE_DESCRIPTOR_SCHEMA_KEY {
+                    return None;
+                }
+                let id = pk.as_single_string_owned().ok()?;
+                if !selected_files.contains(&id) || row.as_ref().is_some_and(|row| !row.deleted) {
+                    return None;
+                }
+                let matches = match expected {
+                    Some(expected) => row.as_ref().and_then(|row| row.change_id) == Some(*expected),
+                    None => true,
+                };
+                matches.then_some(id)
+            })
+            .collect::<BTreeSet<_>>();
         let mut target_change_ids = Vec::new();
+        let mut historical_files = BTreeSet::new();
         let mut rows = RawWriteBatch::with_capacity(plans.len());
         for ((diff_id, (schema_key, row_pk, file_id), expected, target), current) in
             plans.into_iter().zip(current)
@@ -8737,7 +8840,11 @@ where
                     .as_ref()
                     .and_then(|row| row.change_id)
                     .is_some_and(|change_id| change_id == expected),
-                None => current.as_ref().is_none_or(|row| row.deleted),
+                None => {
+                    current.as_ref().is_none_or(|row| row.deleted)
+                        || (schema_key != FILE_DESCRIPTOR_SCHEMA_KEY
+                            && file_id.as_ref().is_some_and(|id| hidden_files.contains(id)))
+                }
             };
             if !current_matches {
                 return Err(stale_or_unknown_diff_id().with_details(serde_json::json!({
@@ -8745,6 +8852,19 @@ where
                     "rowRef": crate::row_ref::encode_schema_identity(&schema_key, &row_pk)?
                         .as_str(),
                 })));
+            }
+            if schema_key == FILE_DESCRIPTOR_SCHEMA_KEY {
+                let id = row_pk.as_single_string_owned()?;
+                let target_deleted = target
+                    .map(|id| required_diff_change(&records, id, diff_id))
+                    .transpose()?
+                    .is_none_or(|record| record.snapshot.is_none());
+                if selected_files.contains(&id)
+                    && plugin_owned_files.contains(&id)
+                    && (current.as_ref().is_none_or(|row| row.deleted) || target_deleted)
+                {
+                    historical_files.insert(id);
+                }
             }
             if let Some(target) = target {
                 required_diff_change(&records, target, diff_id)?;
@@ -8824,10 +8944,14 @@ where
             }
         }
         if !rows.is_empty() {
-            self.stage_write(TransactionWrite::Rows {
-                mode: TransactionWriteMode::Replace,
-                rows,
-            })
+            self.stage_write_with_file_history(
+                TransactionWrite::Rows {
+                    mode: TransactionWriteMode::Replace,
+                    rows,
+                },
+                None,
+                historical_files,
+            )
             .await?;
         }
         Ok(crate::sql2::DiffCommandOutcome {
@@ -11864,10 +11988,11 @@ where
 
         let branch_id = rows.schema_scope_branch_id().to_owned();
         let schema_key = rows.schema_key().to_owned();
-        if !rows.is_fileless_typed_sql_rows()
-            && self
-                .visible_plugin_registry_owns_schema(&branch_id, &schema_key)
-                .await?
+        if schema_key == KEY_VALUE_SCHEMA_KEY
+            || (!rows.is_fileless_typed_sql_rows()
+                && self
+                    .visible_plugin_registry_owns_schema(&branch_id, &schema_key)
+                    .await?)
         {
             let mut raw = rows.into_raw()?;
             raw.revoke_certified_preparation();
@@ -11972,9 +12097,10 @@ where
         self.ensure_plugin_generation_read_guard().await;
         let branch_id = rows.schema_scope_branch_id().to_owned();
         let schema_key = rows.schema_key().to_owned();
-        if self
-            .visible_plugin_registry_owns_schema(&branch_id, &schema_key)
-            .await?
+        if schema_key == KEY_VALUE_SCHEMA_KEY
+            || self
+                .visible_plugin_registry_owns_schema(&branch_id, &schema_key)
+                .await?
         {
             let mut raw = rows.into_raw()?;
             raw.revoke_certified_preparation();
@@ -12176,7 +12302,15 @@ where
             .await?;
         let mut outcome = match command {
             DiffCommand::Revert | DiffCommand::Apply => {
-                self.execute_apply_or_revert(command, diff_ids).await
+                // A schema-row selection (including a reserved owner row) must
+                // not acquire file-lifecycle authority through dependency closure.
+                let selected_files = selections
+                    .iter()
+                    .filter(|selection| selection.relation == "lix_file")
+                    .map(|selection| selection.row_pk.as_single_string_owned())
+                    .collect::<Result<BTreeSet<_>, _>>()?;
+                self.execute_apply_or_revert(command, diff_ids, selected_files)
+                    .await
             }
             DiffCommand::CreateCheckpoint => self.execute_checkpoint_selection(diff_ids).await,
         }?;

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -5645,9 +5645,45 @@ where
                     };
                     if cold_successor_candidate {
                         let cold_limits = cold_successor_transition_limits(submitted_bytes.len());
-                        let cold_before_descriptor = acknowledged_observation
-                            .map(|observation| v2_file_descriptor_from_actor_key(observation.key()))
-                            .unwrap_or_else(|| v2_file_descriptor_from_actor_key(&actor_key));
+                        let cold_before_descriptor = if let Some(observation) =
+                            acknowledged_observation
+                        {
+                            v2_file_descriptor_from_actor_key(observation.key())
+                        } else {
+                            // The incoming write already carries the successor path. A cold
+                            // session has no observed actor key, so resolve the predecessor
+                            // from the transaction view before this write batch is staged.
+                            // Otherwise a CSV-to-TSV rename looks like TSV-to-TSV and the
+                            // plugin silently retains the old dialect.
+                            let request =
+                                FilesystemPathIndexRequest::new(vec![write.branch_id.clone()]);
+                            let path_index = self.filesystem_path_index(&request).await?;
+                            let entries = path_index
+                                .exact_file_id_entries(&write.file_id)
+                                .into_iter()
+                                .filter(|entry| {
+                                    let live = entry.live_row();
+                                    entry.kind == FilesystemPathKind::File
+                                        && entry.id() == write.file_id
+                                        && live.branch_id.as_ref() == write.branch_id
+                                        && !live.global
+                                        && live.untracked == write.untracked
+                                })
+                                .collect::<Vec<_>>();
+                            let [entry] = entries.as_slice() else {
+                                return Err(LixError::new(
+                                    LixError::CODE_CONSTRAINT_VIOLATION,
+                                    format!(
+                                        "owned component plugin file '{}' must resolve to exactly one predecessor path in its own lane; found {}",
+                                        write.file_id,
+                                        entries.len()
+                                    ),
+                                ));
+                            };
+                            let mut predecessor = v2_file_descriptor_from_actor_key(&actor_key);
+                            predecessor.path = Some(entry.path.clone());
+                            predecessor
+                        };
                         let cold_open_guard = cache.cold_open_guard().await;
                         let visible_materialization = self
                         .visible_materialization(&file_key)


### PR DESCRIPTION
## Problem

Flashtype exposed two plugin-engine failures: Undo staged the historical and newly rendered `lix_binary_blob_ref` together, and external filesystem edits after editor changes failed with `plugin observation is unknown or evicted`.

## Changes

- Replace superseded blob references during plugin-aware history replay, preserving unrelated references and deletion records.
- Replay complete plugin-file additions/deletions from validated history. Normalize descriptor cascade tombstones to child-row absence and preserve stale-source validation. Public writes to engine-managed plugin metadata remain forbidden, including optimized SQL batch paths.
- Refresh observations for file-content statements in mixed read batches. Apply metadata filters and limits before hydrating bytes so only returned files receive observations; aggregate reads cannot acknowledge unseen bytes.
- Resolve cold plugin transitions against the pre-write descriptor, preserving CSV-to-TSV rename semantics after switching branches.
- Reject unsupported plugin-content conflicts combined with descriptor/path changes before preview or merge can alter the target. Cover same-row and disjoint-row edits.
- Replace process-global zero-delta assertions in two compaction tests with repository-local tombstone checks.
- Add patch changenotes and real-plugin regressions covering repeated Undo/Redo, lifecycle restoration, mixed file changes, reserved metadata, mixed read batches, and filesystem imports.

## Validation

- `cargo nextest run -p lix --features all-simulations --no-fail-fast`: 3,545 passed, 67 skipped.
- `cargo test -p lix --features all-simulations --doc`: 10 passed.
- Eight focused real-plugin regressions.
- All 212 E2E tests verified. One timing-sensitive benchmark exceeded its limit during concurrent compilation and passed when rerun in isolation after builds completed.
- Independent source reviews.
- Flashtype's 100-operation durable workspace stress test passes with the rebuilt native SDK, including 21 Undo operations.

The independent tracked-state rebuild failure reproduced on clean main is fixed separately in #1728.
