### PR TITLE
refactor: share single and batch idempotency recovery

### DIFF
--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -6260,6 +6260,7 @@ mod tests {
     #[derive(Clone)]
     struct PostCommitUnknownStorage {
         inner: Memory,
+        durable_reads: bool,
         fail_next_commit: Arc<AtomicBool>,
     }
 
@@ -6267,6 +6268,7 @@ mod tests {
         fn new() -> Self {
             Self {
                 inner: Memory::new(),
+                durable_reads: false,
                 fail_next_commit: Arc::new(AtomicBool::new(false)),
             }
         }
@@ -6295,7 +6297,14 @@ mod tests {
             self.inner.acquire_session().await
         }
 
-        async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        async fn begin_read(
+            &self,
+            mut options: ReadOptions,
+        ) -> Result<Self::Read<'_>, StorageError> {
+            if self.durable_reads {
+                // Same test-only durable tier as DurableMemoryStorage above.
+                options.durability = ReadDurability::Visible;
+            }
             self.inner.begin_read(options).await
         }
 
@@ -7612,58 +7621,115 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn keyed_write_without_durable_receipt_proof_is_not_acknowledged() {
-        let storage = PostCommitUnknownStorage::new();
-        let server = open_lix()
-            .with_storage(storage.clone())
-            .serve()
-            .with_embedded_lix_id()
-            .await
-            .expect("serve Lix");
-        let router = handler(server);
-        let (session_id, _) = new_session(&router).await;
-        let headers = [(IDEMPOTENCY_KEY_HEADER, "memory-has-no-durable-proof")];
+    async fn single_and_batch_writes_recover_and_replay_a_durable_ambiguous_commit() {
+        for batch in [false, true] {
+            let storage = PostCommitUnknownStorage {
+                durable_reads: true,
+                ..PostCommitUnknownStorage::new()
+            };
+            let router = router_with_storage(storage.clone()).await;
+            let (session_id, _) = new_session(&router).await;
+            let headers = [(IDEMPOTENCY_KEY_HEADER, "recover-once")];
+            let sql = "INSERT INTO lix_key_value (key, value) VALUES ('recovered-once', 'value') RETURNING key";
+            let (path, body) = if batch {
+                (
+                    "/lix/v1/execute-batch",
+                    json!({"statements": [{"sql": sql}]}),
+                )
+            } else {
+                ("/lix/v1/execute", json!({"sql": sql}))
+            };
+            storage.fail_next_commit();
+            let recovered = request_with_headers(
+                &router,
+                "POST",
+                path,
+                Some(&session_id),
+                &headers,
+                Some(body.clone()),
+            )
+            .await;
+            assert_eq!(recovered.status(), StatusCode::OK, "{path}");
+            let recovered = response_json(recovered).await;
+            let replay = request_with_headers(
+                &router,
+                "POST",
+                path,
+                Some(&session_id),
+                &headers,
+                Some(body),
+            )
+            .await;
+            assert_eq!(replay.status(), StatusCode::OK, "{path}");
+            assert_eq!(response_json(replay).await, recovered);
+            let count = request(&router, "POST", "/lix/v1/execute", Some(&session_id), Some(json!({
+                "sql": "SELECT COUNT(*) FROM lix_history('lix_key_value') WHERE key = 'recovered-once'"
+            }))).await;
+            assert_eq!(count.status(), StatusCode::OK);
+            assert_eq!(
+                response_json(count).await["rows"][0][0],
+                json!({"kind": "int", "value": 1})
+            );
+        }
+    }
 
-        storage.fail_next_commit();
-        let response = request_with_headers(
+    #[tokio::test]
+    async fn keyed_write_without_durable_receipt_proof_is_not_acknowledged() {
+        for batch in [false, true] {
+            let storage = PostCommitUnknownStorage::new();
+            let server = open_lix()
+                .with_storage(storage.clone())
+                .serve()
+                .with_embedded_lix_id()
+                .await
+                .expect("serve Lix");
+            let router = handler(server);
+            let (session_id, _) = new_session(&router).await;
+            let headers = [(IDEMPOTENCY_KEY_HEADER, "memory-has-no-durable-proof")];
+
+            storage.fail_next_commit();
+            let response = request_with_headers(
             &router,
             "POST",
-            "/lix/v1/execute",
+            if batch { "/lix/v1/execute-batch" } else { "/lix/v1/execute" },
             Some(&session_id),
             &headers,
-            Some(json!({
-                "sql": "INSERT INTO lix_key_value (key, value) VALUES ('unknown-commit', 'written')"
-            })),
+            Some(if batch {
+                json!({"statements": [{"sql": "INSERT INTO lix_key_value (key, value) VALUES ('unknown-commit', 'written')"}]})
+            } else {
+                json!({"sql": "INSERT INTO lix_key_value (key, value) VALUES ('unknown-commit', 'written')"})
+            }),
         )
         .await;
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-        let error = response_json(response).await;
-        assert_eq!(
-            error["error"]["code"],
-            LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
-        );
-        assert_eq!(error["error"]["details"]["retryable"], true);
-        assert_eq!(
-            error["error"]["details"]["retryScope"],
-            "same-idempotency-key"
-        );
-        assert_eq!(error["error"]["details"]["outcome"], "unknown");
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            let error = response_json(response).await;
+            assert_eq!(
+                error["error"]["code"],
+                LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+            );
+            assert_eq!(error["error"]["details"]["retryable"], true);
+            assert_eq!(
+                error["error"]["details"]["retryScope"],
+                "same-idempotency-key"
+            );
+            assert_eq!(error["error"]["details"]["outcome"], "unknown");
 
-        let persisted = request(
-            &router,
-            "POST",
-            "/lix/v1/execute",
-            Some(&session_id),
-            Some(json!({
-                "sql": "SELECT COUNT(*) FROM lix_key_value WHERE key = 'unknown-commit'"
-            })),
-        )
-        .await;
-        assert_eq!(persisted.status(), StatusCode::OK);
-        assert_eq!(
-            response_json(persisted).await["rows"][0][0],
-            json!({ "kind": "int", "value": 1 })
-        );
+            let persisted = request(
+                &router,
+                "POST",
+                "/lix/v1/execute",
+                Some(&session_id),
+                Some(json!({
+                    "sql": "SELECT COUNT(*) FROM lix_key_value WHERE key = 'unknown-commit'"
+                })),
+            )
+            .await;
+            assert_eq!(persisted.status(), StatusCode::OK);
+            assert_eq!(
+                response_json(persisted).await["rows"][0][0],
+                json!({ "kind": "int", "value": 1 })
+            );
+        }
     }
 
     async fn app_with_tracing_telemetry() -> TestApp {

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -1909,32 +1909,21 @@ where
         metadata: ExecuteStatementMetadata,
         idempotency: ExecuteIdempotency,
     ) -> Result<ExecuteResult, LixError> {
-        let mut expired_read_retries = ExpiredReadRetryState::default();
-        if let IdempotencyReceiptResolution::Replay(receipt) = self
-            .resolve_idempotency_receipt_with_expired_read_retry(
-                &idempotency,
-                &mut expired_read_retries,
-            )
-            .await?
-        {
-            return receipt.into_single_result();
-        }
-
-        let sql_for_error = sql.to_string();
-        let params = params.to_vec();
-        loop {
-            let write_access = self.begin_session_write_access().await?;
-            let sql_for_planning = sql_for_error.clone();
-            let statement = statement.clone();
-            let params = params.clone();
-            let options = options.clone();
-            let metadata = metadata.clone();
-            // Every retry retains the original identity. A transaction closure
-            // owns its copy because its future may outlive this call's immediate
-            // stack frame while the write lease is held.
-            let idempotency_for_commit = idempotency.clone();
-            let result = self
-                .with_write_transaction_reserved_lending(
+        self.execute_with_idempotency_recovery(
+            &idempotency,
+            ExecuteIdempotencyReceipt::into_single_result,
+            || async {
+                let write_access = self.begin_session_write_access().await?;
+                let sql_for_planning = sql.to_owned();
+                let statement = statement.clone();
+                let params = params.to_vec();
+                let options = options.clone();
+                let metadata = metadata.clone();
+                // Every retry retains the original identity. A transaction closure
+                // owns its copy because its future may outlive this call's immediate
+                // stack frame while the write lease is held.
+                let idempotency_for_commit = idempotency.clone();
+                self.with_write_transaction_reserved_lending(
                     write_access,
                     async move |transaction| {
                         let previous_origin_key =
@@ -1967,8 +1956,36 @@ where
                     |_| Ok(()),
                 )
                 .await
-                .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
+                .map_err(|error| normalize_sql_surface_error(error, sql))
+            },
+        )
+        .await
+    }
 
+    /// One retry budget covers receipt preflight, expired transaction reads,
+    /// and durable proof after an ambiguous commit for both SQL APIs.
+    async fn execute_with_idempotency_recovery<T, F, Fut>(
+        &self,
+        idempotency: &ExecuteIdempotency,
+        replay: fn(ExecuteIdempotencyReceipt) -> Result<T, LixError>,
+        mut execute: F,
+    ) -> Result<T, LixError>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, LixError>>,
+    {
+        let mut expired_read_retries = ExpiredReadRetryState::default();
+        if let IdempotencyReceiptResolution::Replay(receipt) = self
+            .resolve_idempotency_receipt_with_expired_read_retry(
+                idempotency,
+                &mut expired_read_retries,
+            )
+            .await?
+        {
+            return replay(receipt);
+        }
+        loop {
+            let result = execute().await;
             match result {
                 Ok(result) => return Ok(result),
                 Err(error)
@@ -1986,14 +2003,14 @@ where
                 {
                     return match self
                         .resolve_idempotency_receipt_with_expired_read_retry(
-                            &idempotency,
+                            idempotency,
                             &mut expired_read_retries,
                         )
                         .await
                     {
                         Ok(IdempotencyReceiptResolution::Replay(receipt)) => {
                             // `Transaction::commit` did not return normally, so
-                            // its usual invalidation path was skipped. A remote
+                            // its usual invalidation path was skipped. A durable
                             // receipt proves that this transaction did publish;
                             // wake local observers before acknowledging recovery.
                             self.observe_invalidation.bump();
@@ -2002,7 +2019,7 @@ where
                             // rather than let a stale acknowledgement poison the
                             // next plugin-backed edit.
                             self.file_views.clear();
-                            receipt.into_single_result()
+                            replay(receipt)
                         }
                         Ok(IdempotencyReceiptResolution::Absent) => Err(error),
                         Err(recovery_error) => Err(recovery_error),
@@ -2339,65 +2356,20 @@ where
                         )
                         .await;
                 };
-                let mut expired_read_retries = ExpiredReadRetryState::default();
-                if let IdempotencyReceiptResolution::Replay(receipt) = self
-                    .resolve_idempotency_receipt_with_expired_read_retry(
-                        &idempotency,
-                        &mut expired_read_retries,
-                    )
-                    .await?
-                {
-                    return receipt.into_results();
-                }
-                loop {
-                    let result = self
-                        .execute_transaction_batch(
+                self.execute_with_idempotency_recovery(
+                    &idempotency,
+                    ExecuteIdempotencyReceipt::into_results,
+                    || {
+                        self.execute_transaction_batch(
                             statements,
                             parsed.clone(),
                             options.clone(),
                             statement_metadata.clone(),
                             Some(idempotency.clone()),
                         )
-                        .await;
-                    match result {
-                        Ok(results) => return Ok(results),
-                        Err(error)
-                            if error.code == LixError::CODE_STORAGE_READ_EXPIRED
-                                && retry_expired_auto_commit(&mut expired_read_retries, &error)
-                                    .await =>
-                        {
-                            continue;
-                        }
-                        Err(error)
-                            if matches!(
-                                error.code.as_str(),
-                                LixError::CODE_TRANSACTION_CONFLICT
-                                    | LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
-                            ) =>
-                        {
-                            return match self
-                                .resolve_idempotency_receipt_with_expired_read_retry(
-                                    &idempotency,
-                                    &mut expired_read_retries,
-                                )
-                                .await
-                            {
-                                Ok(IdempotencyReceiptResolution::Replay(receipt)) => {
-                                    // See the single-statement recovery path:
-                                    // positive receipt proof means a commit
-                                    // happened after its normal invalidation
-                                    // callback was bypassed by an ambiguous error.
-                                    self.observe_invalidation.bump();
-                                    self.file_views.clear();
-                                    receipt.into_results()
-                                }
-                                Ok(IdempotencyReceiptResolution::Absent) => Err(error),
-                                Err(recovery_error) => Err(recovery_error),
-                            };
-                        }
-                        Err(error) => return Err(error),
-                    }
-                }
+                    },
+                )
+                .await
             }
         }
     }


### PR DESCRIPTION
Single SQL writes and mutation batches duplicated receipt preflight, expired-read retries, and ambiguous-commit recovery. Use one recovery driver with one retry budget and API-specific receipt decoding. Each transaction still stages its receipt atomically with its writes.

Durable receipt proof still invalidates observers and private plugin views; an absent receipt or unavailable durable tier cannot turn an unknown outcome into success. Non-idempotent conflict retries retain their existing policy.

Validation: local engine all-simulations with server-protocol enabled and doctests. Regression coverage exercises both APIs for ambiguous commits with and without durable proof, replay, and exactly-once history. Draft integration only; CI/CD intentionally skipped.
