### PR TITLE
refactor(plugin): share cold file transition protocol

### DIFF
--- a/.codex/plans/lix-plugin-transition-pipeline.md
+++ b/.codex/plans/lix-plugin-transition-pipeline.md
@@ -1,0 +1,43 @@
+# Shared plugin cold-file transition pipeline
+
+Fresh unowned-file imports and ownership reselection now use one guest open/drain routine, one host create-row/accounting preparation step, and one checkpoint/publication constructor. Fresh-file metadata is shared across its prepared and pending states.
+
+Preserved boundaries:
+
+- Fresh imports acquire batch reservations and store permits before spawning bounded chunks, join every worker, retain the first error, and finalize in input order.
+- Fresh imports append rows before checkpointing; reselection checkpoints before row staging and retains its explicit publication-discard path on append failure.
+- Keyless create validation/materialization precedes row-authority derivation and counters.
+- `PluginActorStore` owns the actor and permit across host preparation/checkpoint awaits, preserving actor-before-permit destruction on failure or cancellation.
+- The same-owner sparse transition, fresh permit-admission loop and join-all/first-error code are textually unchanged from integration fc0c0ecea.
+- No additional full-file bytes allocation, storage scan, worker, guest call or checkpoint is introduced.
+
+This removes duplicated protocol implementations; helper signatures and explicit intermediate state offset the removed lines, so it is not a net production line-count reduction.
+
+A real-plugin Memory regression covers a two-file fresh batch, markdown-to-JSON ownership reselection, transactional rows, rollback identity/byte restoration, retry, sibling preservation and a subsequent edit. Correctness and performance sub-agents reviewed the production diff; the performance reviewer independently reviewed the new test. No correctness findings remain.
+
+Validation: all 3,728 engine tests passed with `all-simulations,server-protocol` (69 skipped), all 10 doctests passed, and all five plugin-file-observation tests passed. Four additional existing regressions passed: the 17-file RocksDB import/lifecycle test, tracked/untracked ownership-loss reparse, markdown sparse successor/history/reopen, and JSON actor-eviction/sparse-successor behavior. The final code passed `git diff --check`. Performance results follow below.
+
+## Performance comparison
+
+Baseline: `fc0c0ecea`; candidate: shared cold plugin pipeline working tree. Same nightly toolchain and debug build profile. Three alternating process pairs, seven samples per lane per process (21 samples per variant/lane), run after compilation and tests were idle. Every workload passed its built-in correctness assertions. Ratios are candidate / baseline; values below 1 improve.
+
+| Workload | Time p50 | Allocations p50 | Allocated bytes p50 | Peak live bytes p50 |
+| --- | ---: | ---: | ---: | ---: |
+| csv-file-roundtrip | 0.969 | 0.996 | 1.011 | 0.992 |
+| csv-sparse-file-update | 0.992 | 1.015 | 1.041 | 1.050 |
+| json-file-roundtrip | 0.958 | 1.021 | 1.008 | 1.008 |
+| json-sparse-file-update | 0.957 | 0.980 | 1.055 | 1.019 |
+| markdown-file-roundtrip | 1.021 | 1.000 | 0.993 | 1.003 |
+| markdown-sparse-file-update | 1.011 | 0.999 | 1.051 | 1.020 |
+| text-file-roundtrip | 1.017 | 0.997 | 1.006 | 1.005 |
+| text-sparse-file-update | 1.004 | 0.999 | 1.000 | 1.003 |
+| excalidraw-file-roundtrip | 1.022 | 1.028 | 1.004 | 0.971 |
+| excalidraw-sparse-file-update | 0.987 | 0.993 | 1.003 | 1.032 |
+| markdown-same-row-text-merge | 0.955 | 0.986 | 0.997 | 1.000 |
+| csv-same-row-column-merge | 0.990 | 0.993 | 1.000 | 1.000 |
+
+These are bounded debug-profile regression measurements, not a production throughput guarantee. The five fresh-file and five warm sparse lanes use the public APIs; the two merge lanes provide adjacent-path controls. Parallel batching and reselection are additionally covered by source review and dedicated correctness tests. Raw sample logs are outside the repository at `/root/repos/lix-plugin-perf-{baseline,candidate}-run{2,3,4}.log`.
+
+Candidate `transaction/context.rs` SHA-256: `521fe273b6fccf1bbd97d49c7a76e197750f1c717601bf3c1002757536a8d657`. Toolchain: `nightly-2026-05-21`; E2E features: `plugin-tests,sdk-tests`.
+
+All observed ratios passed the benchmark's existing gates (10% for median elapsed/allocated bytes/peak live bytes and 15% for p95 elapsed). Maximum p95 elapsed ratio was 1.046. These results bound this comparison; they do not prove identical costs for every workload.

--- a/packages/e2e/tests/plugin_file_observation.rs
+++ b/packages/e2e/tests/plugin_file_observation.rs
@@ -295,3 +295,223 @@ async fn mixed_read_batches_only_acknowledge_returned_file_bytes() {
         }
     }
 }
+
+#[tokio::test]
+async fn fresh_import_and_plugin_reselection_preserve_rows_across_rollback() {
+    let lix = open_lix().with_storage(Memory::new()).await.unwrap();
+    install_markdown(&lix).await;
+    let wasm = std::fs::read(env!("CARGO_CDYLIB_FILE_PLUGIN_JSON_plugin_json")).unwrap();
+    let mut archive = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (path, content) in [
+        (
+            "manifest.json",
+            include_str!("../../../plugins/json/manifest.json").as_bytes(),
+        ),
+        (
+            "schema/json_root.json",
+            include_str!("../../../plugins/json/schema/json_root.json").as_bytes(),
+        ),
+        (
+            "schema/json_object_member.json",
+            include_str!("../../../plugins/json/schema/json_object_member.json").as_bytes(),
+        ),
+        (
+            "schema/json_array_item.json",
+            include_str!("../../../plugins/json/schema/json_array_item.json").as_bytes(),
+        ),
+        ("plugin.wasm", wasm.as_slice()),
+    ] {
+        archive.start_file(path, options).unwrap();
+        archive.write_all(content).unwrap();
+    }
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/.lix/plugins/plugin_json.lixplugin',$1)",
+        &[Value::Blob(archive.finish().unwrap().into_inner().into())],
+    )
+    .await
+    .unwrap();
+
+    // Both ownerless files enter the fresh-import worker batch in one statement.
+    lix.execute(
+        "INSERT INTO lix_file(path,content) VALUES('/switch.md',$1),('/keep.md',$2)",
+        &[
+            Value::Blob(b"switch original\n".to_vec().into()),
+            Value::Blob(b"keep original\n".to_vec().into()),
+        ],
+    )
+    .await
+    .unwrap();
+    let file_id: String = lix
+        .execute("SELECT id FROM lix_file WHERE path='/switch.md'", &[])
+        .await
+        .unwrap()
+        .rows()[0]
+        .get("id")
+        .unwrap();
+    let original_rows = lix
+        .execute(
+            "SELECT id FROM markdown_node WHERE lixcol_file_id=$1 ORDER BY id",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap()
+        .rows()
+        .iter()
+        .map(|row| row.get::<String>("id").unwrap())
+        .collect::<Vec<_>>();
+    assert!(!original_rows.is_empty());
+
+    let json_bytes = br#"{"replacement":"accepted"}"#.to_vec();
+    let params = [
+        Value::Blob(json_bytes.clone().into()),
+        Value::Text(file_id.clone()),
+    ];
+    let mut transaction = lix.begin_transaction().await.unwrap();
+    transaction
+        .execute(
+            "UPDATE lix_file SET path='/switch.json',content=$1 WHERE id=$2",
+            &params,
+        )
+        .await
+        .expect("a different selected plugin must open a fresh actor");
+    assert!(
+        transaction
+            .execute(
+                "SELECT id FROM markdown_node WHERE lixcol_file_id=$1",
+                &[Value::Text(file_id.clone())],
+            )
+            .await
+            .unwrap()
+            .rows()
+            .is_empty()
+    );
+    assert_eq!(
+        transaction
+            .execute(
+                "SELECT key FROM json_object_member WHERE lixcol_file_id=$1",
+                &[Value::Text(file_id.clone())],
+            )
+            .await
+            .unwrap()
+            .rows()[0]
+            .get::<String>("key")
+            .unwrap(),
+        "replacement"
+    );
+    transaction.rollback().await.unwrap();
+
+    let after_rollback = lix
+        .execute(
+            "SELECT id FROM markdown_node WHERE lixcol_file_id=$1 ORDER BY id",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap()
+        .rows()
+        .iter()
+        .map(|row| row.get::<String>("id").unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        after_rollback, original_rows,
+        "rollback restores the original semantic identities"
+    );
+    assert!(
+        lix.execute(
+            "SELECT key FROM json_object_member WHERE lixcol_file_id=$1",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap()
+        .rows()
+        .is_empty()
+    );
+    let original = lix
+        .execute(
+            "SELECT path,content FROM lix_file WHERE id=$1",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        original.rows()[0].get::<String>("path").unwrap(),
+        "/switch.md"
+    );
+    assert_eq!(
+        original.rows()[0].get::<Vec<u8>>("content").unwrap(),
+        b"switch original\n"
+    );
+
+    lix.execute(
+        "UPDATE lix_file SET path='/switch.json',content=$1 WHERE id=$2",
+        &params,
+    )
+    .await
+    .expect("retry after rollback must publish the new plugin's actor");
+    assert!(
+        lix.execute(
+            "SELECT id FROM markdown_node WHERE lixcol_file_id=$1",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap()
+        .rows()
+        .is_empty()
+    );
+    let members = lix
+        .execute(
+            "SELECT key FROM json_object_member WHERE lixcol_file_id=$1",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(members.rows().len(), 1);
+    assert_eq!(
+        members.rows()[0].get::<String>("key").unwrap(),
+        "replacement"
+    );
+    let owner = lix
+        .execute(
+            "SELECT value FROM lix_key_value WHERE lixcol_file_id=$1 AND key='lix_plugin_owner_v2'",
+            &[Value::Text(file_id.clone())],
+        )
+        .await
+        .unwrap();
+    assert_eq!(owner.rows().len(), 1);
+    let Value::Jsonb(owner) = owner.rows()[0].get::<Value>("value").unwrap() else {
+        panic!("owner must be JSON");
+    };
+    assert_eq!(owner.to_value()["plugin_key"], "plugin_json");
+    let files = lix.execute("SELECT path,content FROM lix_file WHERE path IN ('/switch.json','/keep.md') ORDER BY path", &[]).await.unwrap();
+    assert_eq!(files.rows().len(), 2);
+    assert_eq!(
+        files.rows()[0].get::<Vec<u8>>("content").unwrap(),
+        b"keep original\n"
+    );
+    assert_eq!(
+        files.rows()[1].get::<Vec<u8>>("content").unwrap(),
+        json_bytes
+    );
+
+    // A subsequent ordinary edit exercises the newly published actor's authority.
+    lix.execute(
+        "UPDATE lix_file SET content=$1 WHERE id=$2",
+        &[
+            Value::Blob(br#"{"followup":"warm"}"#.to_vec().into()),
+            Value::Text(file_id.clone()),
+        ],
+    )
+    .await
+    .unwrap();
+    let members = lix
+        .execute(
+            "SELECT key FROM json_object_member WHERE lixcol_file_id=$1",
+            &[Value::Text(file_id)],
+        )
+        .await
+        .unwrap();
+    assert_eq!(members.rows().len(), 1);
+    assert_eq!(members.rows()[0].get::<String>("key").unwrap(), "followup");
+    lix.close().await.unwrap();
+}

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -4036,6 +4036,72 @@ where
         Ok(())
     }
 
+    /// Finish host admission after guest output validation. This must precede
+    /// row-authority derivation because keyless creates acquire their IDs here.
+    async fn prepare_plugin_file_changes(
+        &mut self,
+        validated: ValidatedFileTransition,
+        selected: &PluginRegistryEntry,
+        create_context: BoundCreateContext,
+        file_key: &PluginFileWriteKey,
+        existing_create_reservation: Option<&MaterializedHotStateRow>,
+        classified_bytes: u64,
+        create_rows_span: tracing::Span,
+    ) -> Result<PreparedPluginFileChanges, LixError> {
+        let mut changes = validated.changes;
+        let create_rows = self
+            .v2_create_rows(
+                selected,
+                &mut changes,
+                create_context,
+                file_key,
+                existing_create_reservation,
+                None,
+            )
+            .instrument(create_rows_span)
+            .await?;
+        let row_authorities =
+            plugin_row_authorities_from_transition(&changes, create_context.creates());
+        let mut counters = validated.counters;
+        counters.host_content_classification_bytes = classified_bytes;
+        counters.full_document_reparses = 1;
+        counters.durable_semantic_changes =
+            u64::try_from(changes.row_change_count()).unwrap_or(u64::MAX);
+        self.plugin_host.record_transition_counters(counters);
+        Ok(PreparedPluginFileChanges {
+            changes,
+            create_rows,
+            document: validated.document,
+            row_authorities,
+        })
+    }
+
+    /// Checkpoint at the caller's existing publication boundary: fresh imports
+    /// stage their rows first, while reselection checkpoints before row staging.
+    async fn checkpoint_new_plugin_file(
+        &mut self,
+        mut store: PluginActorStore,
+        document: WasmDocumentHandle,
+        actor_key: PluginActorKey,
+        submitted_bytes: crate::Blob,
+        materialization_version: Arc<str>,
+        row_authorities: PluginRowAuthorities,
+        view: PluginPublicationPolicy,
+    ) -> Result<PendingPluginActorPublication, LixError> {
+        let checkpoint = store.actor_mut().checkpoint_document(document).await?;
+        Ok(PendingPluginActorPublication::new(
+            actor_key,
+            self.plugin_host.actor_cache(),
+            store,
+            document,
+            checkpoint,
+            submitted_bytes,
+            materialization_version,
+            row_authorities,
+            view,
+        ))
+    }
+
     /// Reconciles plugin lifecycle, ownership, and state for one logical write
     /// batch against one storage snapshot.
     ///
@@ -5279,30 +5345,28 @@ where
                     .inline_payload()
                     .expect("selected plugin writes require inline content")
                     .shared_bytes();
-                let cold_limits = WasmTransitionLimits::for_cold_file_bytes(
-                    u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
-                );
                 prepared_opens.push(PreparedFreshPluginOpen {
-                    file_index,
-                    file_key,
-                    selected,
-                    owner_row,
-                    actor_key,
-                    view,
-                    materialization_version,
-                    submitted_bytes,
-                    create_context,
-                    existing_create_reservation: None,
+                    file: FreshPluginFile {
+                        file_index,
+                        file_key,
+                        selected,
+                        owner_row,
+                        actor_key,
+                        view,
+                        materialization_version,
+                        submitted_bytes,
+                        create_context,
+                        existing_create_reservation: None,
+                    },
                     factory,
                     descriptor,
                     schemas,
-                    cold_limits,
                 });
             }
 
             let preflight_requests = prepared_opens
                 .iter()
-                .map(|prepared| (prepared.create_context, prepared.file_key.clone()))
+                .map(|prepared| (prepared.file.create_context, prepared.file.file_key.clone()))
                 .collect::<Vec<_>>();
             let existing_rows = match self.preflight_creates(&preflight_requests).await {
                 Ok(existing_rows) => existing_rows,
@@ -5315,7 +5379,7 @@ where
                 }
             };
             for (prepared, existing) in prepared_opens.iter_mut().zip(existing_rows) {
-                prepared.existing_create_reservation = existing;
+                prepared.file.existing_create_reservation = existing;
             }
 
             let mut store_permits = Vec::with_capacity(prepared_opens.len());
@@ -5340,70 +5404,25 @@ where
                 .zip(store_permits)
                 .map(|(prepared, store_permit)| {
                     let PreparedFreshPluginOpen {
-                        file_index,
-                        file_key,
-                        selected,
-                        owner_row,
-                        actor_key,
-                        view,
-                        materialization_version,
-                        submitted_bytes,
-                        create_context,
-                        existing_create_reservation,
+                        file,
                         factory,
                         descriptor,
                         schemas,
-                        cold_limits,
                     } = prepared;
-                    let source_bytes = submitted_bytes.clone();
-                    let creates = create_context.creates();
+                    let source_bytes = file.submitted_bytes.clone();
+                    let creates = file.create_context.creates();
                     let task = tokio::spawn(async move {
-                        let mut actor = factory
-                            .instantiate_actor()
-                            .instrument(tracing::debug_span!(
-                                target: "lix_perf",
-                                "lix.perf.plugin_actor_instantiate"
-                            ))
-                            .await?;
-                        let transition = actor
-                            .open_file(
-                                cold_limits,
-                                WasmOpenFileInput {
-                                    descriptor,
-                                    file: Arc::new(ArcByteSource::new(source_bytes)),
-                                    creates,
-                                },
-                            )
-                            .instrument(tracing::debug_span!(
-                                target: "lix_perf",
-                                "lix.perf.plugin_open_file"
-                            ))
-                            .await?;
-                        let validated = drain_file_transition_changes(
-                            actor.as_mut(),
-                            transition,
+                        open_plugin_file(
+                            factory.as_ref(),
+                            descriptor,
+                            source_bytes,
                             creates,
                             &schemas,
-                            cold_limits,
                         )
-                        .instrument(tracing::debug_span!(
-                            target: "lix_perf",
-                            "lix.perf.plugin_open_file_drain"
-                        ))
-                        .await?;
-                        Ok((actor, validated))
+                        .await
                     });
                     PendingFreshPluginOpen {
-                        file_index,
-                        file_key,
-                        selected,
-                        owner_row,
-                        actor_key,
-                        view,
-                        materialization_version,
-                        submitted_bytes,
-                        create_context,
-                        existing_create_reservation,
+                        file,
                         store_permit,
                         task: Some(task),
                     }
@@ -5443,31 +5462,30 @@ where
                 return Err(error);
             }
 
-            for (pending, mut actor, validated) in completed_opens {
-                let mut changes = validated.changes;
-                let create_rows = self
-                    .v2_create_rows(
+            for (pending, actor, validated) in completed_opens {
+                // Keep Store destruction ahead of permit release on every
+                // host validation/checkpoint failure and cancellation path.
+                let store = PluginActorStore::new(actor, pending.store_permit);
+                let pending = pending.file;
+                let PreparedPluginFileChanges {
+                    changes,
+                    create_rows,
+                    document,
+                    row_authorities,
+                } = self
+                    .prepare_plugin_file_changes(
+                        validated,
                         &pending.selected,
-                        &mut changes,
                         pending.create_context,
                         &pending.file_key,
                         pending.existing_create_reservation.as_ref(),
-                        None,
+                        content_classification_bytes
+                            .get(&pending.file_key)
+                            .copied()
+                            .unwrap_or(0),
+                        tracing::Span::none(),
                     )
                     .await?;
-                let row_authorities = plugin_row_authorities_from_transition(
-                    &changes,
-                    pending.create_context.creates(),
-                );
-                let mut counters = validated.counters;
-                counters.host_content_classification_bytes = content_classification_bytes
-                    .get(&pending.file_key)
-                    .copied()
-                    .unwrap_or(0);
-                counters.full_document_reparses = 1;
-                counters.durable_semantic_changes =
-                    u64::try_from(changes.row_change_count()).unwrap_or(u64::MAX);
-                self.plugin_host.record_transition_counters(counters);
 
                 rows.push(pending.owner_row);
                 rows.append(create_rows);
@@ -5493,20 +5511,18 @@ where
                     pending.file_key.clone(),
                     pending.materialization_version.clone(),
                 );
-                let checkpoint = actor.checkpoint_document(validated.document).await?;
-                reconciliation
-                    .actor_publications
-                    .push(PendingPluginActorPublication::new(
+                reconciliation.actor_publications.push(
+                    self.checkpoint_new_plugin_file(
+                        store,
+                        document,
                         pending.actor_key,
-                        self.plugin_host.actor_cache(),
-                        PluginActorStore::new(actor, pending.store_permit),
-                        validated.document,
-                        checkpoint,
                         pending.submitted_bytes,
                         Arc::from(pending.materialization_version),
                         row_authorities,
                         pending.view,
-                    ));
+                    )
+                    .await?,
+                );
                 reconciled_file_keys.insert(pending.file_key);
             }
         }
@@ -6401,86 +6417,46 @@ where
                 let store_permit = self
                     .admit_fresh_plugin_store(&mut reconciliation.actor_publications)
                     .await?;
-                let mut actor = factory
-                    .instantiate_actor()
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.plugin_actor_instantiate"
-                    ))
-                    .await?;
-                let source = ArcByteSource::new(submitted_bytes.clone());
-                let cold_limits = WasmTransitionLimits::for_cold_file_bytes(
-                    u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
-                );
-                let transition = actor
-                    .open_file(
-                        cold_limits,
-                        WasmOpenFileInput {
-                            descriptor,
-                            file: Arc::new(source),
-                            creates,
-                        },
-                    )
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.plugin_open_file"
-                    ))
-                    .await?;
-                let validated = drain_file_transition_changes(
-                    actor.as_mut(),
-                    transition,
+                let (actor, validated) = open_plugin_file(
+                    factory.as_ref(),
+                    descriptor,
+                    submitted_bytes.clone(),
                     creates,
                     &schemas,
-                    cold_limits,
                 )
-                .instrument(tracing::debug_span!(
-                    target: "lix_perf",
-                    "lix.perf.plugin_open_file_drain"
-                ))
                 .await?;
-                let mut changes = validated.changes;
-                let create_rows = self
-                    .v2_create_rows(
+                let store = PluginActorStore::new(actor, store_permit);
+                let PreparedPluginFileChanges {
+                    changes,
+                    create_rows,
+                    document,
+                    row_authorities,
+                } = self
+                    .prepare_plugin_file_changes(
+                        validated,
                         selected,
-                        &mut changes,
                         create_context,
                         &file_key,
                         existing_create_reservation.as_ref(),
-                        None,
+                        content_classification_bytes
+                            .get(&file_key)
+                            .copied()
+                            .unwrap_or(0),
+                        tracing::debug_span!(target: "lix_perf", "lix.perf.plugin_create_rows"),
                     )
-                    .instrument(tracing::debug_span!(
-                        target: "lix_perf",
-                        "lix.perf.plugin_create_rows"
-                    ))
                     .await?;
-                let row_authorities =
-                    plugin_row_authorities_from_transition(&changes, create_context.creates());
-                let mut counters = validated.counters;
-                counters.host_content_classification_bytes = content_classification_bytes
-                    .get(&file_key)
-                    .copied()
-                    .unwrap_or(0);
-                counters.full_document_reparses = 1;
-                counters.durable_semantic_changes =
-                    u64::try_from(changes.row_change_count()).unwrap_or(u64::MAX);
-                self.plugin_host.record_transition_counters(counters);
-                let checkpoint = actor.checkpoint_document(validated.document).await?;
-                (
-                    changes,
-                    PendingPluginActorPublication::new(
+                let publication = self
+                    .checkpoint_new_plugin_file(
+                        store,
+                        document,
                         actor_key,
-                        self.plugin_host.actor_cache(),
-                        PluginActorStore::new(actor, store_permit),
-                        validated.document,
-                        checkpoint,
                         submitted_bytes.clone(),
                         Arc::from(materialization_version.clone()),
                         row_authorities,
                         view,
-                    ),
-                    submitted_bytes.clone(),
-                    create_rows,
-                )
+                    )
+                    .await?;
+                (changes, publication, submitted_bytes.clone(), create_rows)
             };
             rows.append(create_rows);
             let change_rows = tracing::debug_span!(
@@ -13531,7 +13507,58 @@ struct PluginWriteReconciliation {
     reconciled_rows: Option<ReconciledRowBatch>,
 }
 
-struct PreparedFreshPluginOpen {
+/// The guest protocol is identical for a fresh file and a newly selected
+/// owner. Scheduling, reservation admission and owner cleanup stay with the
+/// caller; in particular, fresh files still open in bounded parallel chunks.
+async fn open_plugin_file(
+    factory: &dyn WasmComponentFactory,
+    descriptor: WasmFileDescriptor,
+    submitted_bytes: crate::Blob,
+    creates: WasmCreateContext,
+    schemas: &SchemaAllowlist,
+) -> Result<(Box<dyn WasmComponentActor>, ValidatedFileTransition), LixError> {
+    let mut actor = factory
+        .instantiate_actor()
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.plugin_actor_instantiate"
+        ))
+        .await?;
+    let cold_limits = WasmTransitionLimits::for_cold_file_bytes(
+        u64::try_from(submitted_bytes.len()).unwrap_or(u64::MAX),
+    );
+    let transition = actor
+        .open_file(
+            cold_limits,
+            WasmOpenFileInput {
+                descriptor,
+                file: Arc::new(ArcByteSource::new(submitted_bytes)),
+                creates,
+            },
+        )
+        .instrument(tracing::debug_span!(
+            target: "lix_perf",
+            "lix.perf.plugin_open_file"
+        ))
+        .await?;
+    let validated =
+        drain_file_transition_changes(actor.as_mut(), transition, creates, schemas, cold_limits)
+            .instrument(tracing::debug_span!(
+                target: "lix_perf",
+                "lix.perf.plugin_open_file_drain"
+            ))
+            .await?;
+    Ok((actor, validated))
+}
+
+struct PreparedPluginFileChanges {
+    changes: WasmHostRowChanges,
+    create_rows: RawWriteBatch,
+    document: WasmDocumentHandle,
+    row_authorities: PluginRowAuthorities,
+}
+
+struct FreshPluginFile {
     file_index: usize,
     file_key: PluginFileWriteKey,
     selected: PluginRegistryEntry,
@@ -13542,23 +13569,17 @@ struct PreparedFreshPluginOpen {
     submitted_bytes: crate::Blob,
     create_context: BoundCreateContext,
     existing_create_reservation: Option<MaterializedHotStateRow>,
+}
+
+struct PreparedFreshPluginOpen {
+    file: FreshPluginFile,
     factory: Arc<dyn WasmComponentFactory>,
     descriptor: WasmFileDescriptor,
     schemas: SchemaAllowlist,
-    cold_limits: WasmTransitionLimits,
 }
 
 struct PendingFreshPluginOpen {
-    file_index: usize,
-    file_key: PluginFileWriteKey,
-    selected: PluginRegistryEntry,
-    owner_row: TransactionWriteRow,
-    actor_key: PluginActorKey,
-    view: PluginPublicationPolicy,
-    materialization_version: String,
-    submitted_bytes: crate::Blob,
-    create_context: BoundCreateContext,
-    existing_create_reservation: Option<MaterializedHotStateRow>,
+    file: FreshPluginFile,
     store_permit: PluginActorStorePermit,
     task: Option<
         tokio::task::JoinHandle<


### PR DESCRIPTION
Fresh plugin imports and ownership reselection separately implemented the cold actor-open, output validation, create-row admission, accounting, checkpoint and publication sequence. A change to that protocol required updating both paths.

Share guest open/drain, host create-row/accounting preparation, and checkpoint/publication construction. Group fresh-file metadata once across prepared and pending work. Keep fresh batch admission, bounded parallel scheduling, join-all/first-error handling and the same-owner sparse transition unchanged. Preserve fresh row-staging-before-checkpoint and reselection checkpoint-before-row-staging ordering. `PluginActorStore` owns the actor and permit throughout host validation/checkpointing so failures and cancellation retain Store-before-permit destruction.

Add a canonical-Memory real-plugin regression covering a two-file fresh batch, markdown-to-JSON ownership reselection, transactional row visibility, rollback identity/byte restoration, successful retry, unaffected sibling bytes and a subsequent edit through the published actor.

Validation:

- All 3,728 engine tests passed with `all-simulations,server-protocol` (69 skipped); all 10 doctests passed.
- All five `plugin_file_observation` tests passed, including the new regression.
- Four existing regressions passed: 17-file RocksDB import/lifecycle, tracked/untracked ownership-loss reparse, markdown sparse successor/history/reopen, and JSON actor eviction/sparse successor.
- Two sub-agents reviewed correctness and performance with no remaining findings; the performance reviewer independently reviewed the new test.
- Three alternating benchmark pairs, seven samples per workload per process (21 per variant), across 12 public API workloads. All correctness assertions and existing performance gates passed. Median elapsed ratios were 0.955–1.022; maximum p95 elapsed was 1.046. Maximum allocated bytes ratio was 1.055 and peak live bytes ratio 1.050. Same nightly and debug profile; these are bounded regression measurements, not production throughput guarantees.

The comparison table and preserved invariants are recorded in `.codex/plans/lix-plugin-transition-pipeline.md`. This removes duplicated protocol implementations; helper signatures and explicit intermediate state offset the deleted lines, so it is not a net production LOC reduction.

This PR targets `codex/lix-simplification-dev` and stays draft through its local merge. CI/CD is intentionally skipped via commit markers. Keep integration #1729 draft; do not merge it into main.
