### PR TITLE
perf: reduce SQL upload decoding and fingerprint overhead

### DIFF
--- a/.changenotes/faster-sql-uploads.md
+++ b/.changenotes/faster-sql-uploads.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+Large SQL uploads use less redundant decoding, copying and request fingerprinting work. The server protocol no longer imposes a default 64 MiB request-body limit; hosts can still configure an explicit byte budget.
+
+SQL requests keep the same public API. Retry keys recorded with the previous fingerprint format return `409 LIX_IDEMPOTENCY_KEY_REUSED` after upgrading, without re-executing the mutation. Reconcile uncertain pre-upgrade requests before issuing new keys. Existing repository content and storage formats are unchanged.

--- a/docs/server-protocol.md
+++ b/docs/server-protocol.md
@@ -85,6 +85,17 @@ SQL and file mutations accept an optional `Idempotency-Key` header. Replaying a
 key after a lost response applies the mutation once. Sync pushes are instead
 idempotent by immutable commit identity and compare-and-swap branch updates.
 
+SQL request fingerprints now hash typed parameters directly. Receipts created
+with the previous JSON-based fingerprint remain stored, but replaying those
+keys after upgrading returns `409 LIX_IDEMPOTENCY_KEY_REUSED` without executing
+the request again. Reconcile an uncertain pre-upgrade request before submitting
+it with a new key. Repository content and storage formats are unchanged.
+
+The protocol has no default request-body byte ceiling. Hosts can set
+`ServerProtocolOptions::max_request_body_bytes` to enforce a byte budget;
+explicit budgets still return `413` for oversized bodies. Proxy limits and the
+separate sync-chunk limits still apply.
+
 ## Sync
 
 Sync is Lix-scoped: the immutable ID in the path selects the Lix. Connected

--- a/packages/lix/src/server_protocol/fingerprint.rs
+++ b/packages/lix/src/server_protocol/fingerprint.rs
@@ -1,0 +1,223 @@
+//! Versioned SQL request identity. Hash typed, length-delimited bytes rather
+//! than serializing file contents into a second representation.
+use crate::{ExecuteBatchStatement, Value};
+
+pub(super) fn execute(sql: &str, params: &[Value], origin_key: Option<&str>) -> [u8; 32] {
+    let mut hash = Fingerprint::new(0, origin_key, 1);
+    hash.statement(sql, params, None);
+    hash.finish()
+}
+
+pub(super) fn batch(statements: &[ExecuteBatchStatement], origin_key: Option<&str>) -> [u8; 32] {
+    let mut hash = Fingerprint::new(1, origin_key, statements.len());
+    for statement in statements {
+        hash.statement(
+            &statement.sql,
+            &statement.params,
+            statement.label.as_deref(),
+        );
+    }
+    hash.finish()
+}
+
+struct Fingerprint(blake3::Hasher);
+
+impl Fingerprint {
+    fn new(operation: u8, origin_key: Option<&str>, statements: usize) -> Self {
+        // A new domain intentionally invalidates pre-upgrade retry hashes. Old
+        // receipts remain present, so reusing those keys fails closed instead
+        // of executing the mutation again. Repository content is unaffected.
+        let mut hash = Self(blake3::Hasher::new_derive_key(
+            "lix sql request fingerprint v2",
+        ));
+        hash.tag(operation);
+        hash.optional_text(origin_key);
+        hash.length(statements);
+        hash
+    }
+
+    fn tag(&mut self, tag: u8) {
+        self.0.update(&[tag]);
+    }
+    fn length(&mut self, length: usize) {
+        self.0.update(&(length as u64).to_le_bytes());
+    }
+    fn bytes(&mut self, bytes: &[u8]) {
+        self.length(bytes.len());
+        self.0.update(bytes);
+    }
+    fn optional_text(&mut self, text: Option<&str>) {
+        match text {
+            None => self.tag(0),
+            Some(text) => {
+                self.tag(1);
+                self.bytes(text.as_bytes());
+            }
+        }
+    }
+    fn statement(&mut self, sql: &str, params: &[Value], label: Option<&str>) {
+        self.bytes(sql.as_bytes());
+        self.optional_text(label);
+        self.length(params.len());
+        for param in params {
+            self.value(param);
+        }
+    }
+    fn value(&mut self, value: &Value) {
+        // Explicit tags are format identifiers, not Rust enum discriminants.
+        // Exhaustiveness requires every new SQL value type to choose a tag.
+        match value {
+            Value::Null => self.tag(0),
+            Value::Boolean(value) => {
+                self.tag(1);
+                self.tag(u8::from(*value));
+            }
+            Value::Integer(value) => {
+                self.tag(2);
+                self.0.update(&value.to_le_bytes());
+            }
+            Value::Real(value) => {
+                self.tag(3);
+                self.0.update(&value.to_bits().to_le_bytes());
+            }
+            Value::Text(value) => {
+                self.tag(4);
+                self.bytes(value.as_bytes());
+            }
+            Value::Jsonb(value) => {
+                self.tag(5);
+                self.bytes(value.as_bytes());
+            }
+            Value::RowRef(value) => {
+                self.tag(6);
+                self.bytes(value.as_str().as_bytes());
+            }
+            Value::Timestamptz(value) => {
+                self.tag(7);
+                self.0.update(&value.to_le_bytes());
+            }
+            Value::Blob(value) => {
+                self.tag(8);
+                self.bytes(value.as_ref());
+            }
+        }
+    }
+    fn finish(self) -> [u8; 32] {
+        *self.0.finalize().as_bytes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Blob, Json};
+    use std::collections::HashSet;
+
+    #[test]
+    fn idempotency_typed_fingerprint_v2_stays_stable() {
+        // These vectors pin the persisted receipt format across refactors.
+        // Intentional encoding changes must use a new fingerprint domain.
+        assert_eq!(
+            blake3::Hash::from(execute(
+                "SELECT $1",
+                &[Value::Text("hello λ".into())],
+                Some("origin"),
+            ))
+            .to_hex()
+            .as_str(),
+            "92e6b86f1472722022fc4b25f02c28cf2b1fc68f178a77171572894622ae5746"
+        );
+        assert_eq!(
+            blake3::Hash::from(batch(&[], None)).to_hex().as_str(),
+            "a8a424c84d07dda5c556c70d7d21ccc959164c9004b29bb3dc363d955dc832f7"
+        );
+    }
+
+    #[test]
+    fn idempotency_typed_fingerprint_distinguishes_types_and_boundaries() {
+        let params = vec![
+            vec![],
+            vec![Value::Null],
+            vec![Value::Boolean(false)],
+            vec![Value::Integer(0)],
+            vec![Value::Real(0.0)],
+            vec![Value::Real(-0.0)],
+            vec![Value::Text(String::new())],
+            vec![Value::Blob(Blob::from(Vec::new()))],
+            vec![Value::Jsonb(Json::parse("null").unwrap())],
+            vec![Value::Timestamptz(0)],
+            vec![Value::RowRef(crate::RowRef("0".into()))],
+            vec![Value::Text("a".into()), Value::Text("bc".into())],
+            vec![Value::Text("ab".into()), Value::Text("c".into())],
+            vec![Value::Text("\0\"λ😀\r\n".into())],
+            vec![Value::Blob(Blob::from("\0\"λ😀\r\n".as_bytes().to_vec()))],
+        ];
+        let hashes = params
+            .iter()
+            .map(|p| execute("SELECT $1", p, None))
+            .collect::<HashSet<_>>();
+        assert_eq!(hashes.len(), params.len());
+        assert_ne!(
+            execute("ab", &[Value::Text("c".into())], None),
+            execute("a", &[Value::Text("bc".into())], None)
+        );
+        assert_ne!(
+            execute("SELECT 1", &[], None),
+            execute("SELECT 1", &[], Some(""))
+        );
+        assert_ne!(
+            execute("SELECT 1", &[], Some("a")),
+            execute("SELECT 1", &[], Some("b"))
+        );
+    }
+
+    #[test]
+    fn idempotency_typed_fingerprint_covers_batch_order_labels_and_operation() {
+        let first = ExecuteBatchStatement {
+            sql: "SELECT $1".into(),
+            params: vec![Value::Integer(1)],
+            label: None,
+        };
+        let second = ExecuteBatchStatement {
+            sql: "SELECT $1".into(),
+            params: vec![Value::Integer(2)],
+            label: None,
+        };
+        assert_ne!(
+            batch(&[first.clone(), second.clone()], None),
+            batch(&[second, first.clone()], None)
+        );
+        assert_ne!(
+            batch(std::slice::from_ref(&first), None),
+            execute(&first.sql, &first.params, None)
+        );
+        let mut labeled = first.clone();
+        labeled.label = Some(String::new());
+        assert_ne!(batch(&[first.clone()], None), batch(&[labeled], None));
+        assert_ne!(
+            batch(std::slice::from_ref(&first), None),
+            batch(&[first], Some("origin"))
+        );
+    }
+
+    #[test]
+    fn idempotency_typed_fingerprint_hashes_canonical_json_and_exact_content() {
+        let left = Value::Jsonb(Json::parse("{\"b\":2,\"a\":1}").unwrap());
+        let right = Value::Jsonb(Json::parse("{ \"a\":1, \"b\":2 }").unwrap());
+        assert_eq!(
+            execute("SELECT $1", &[left], None),
+            execute("SELECT $1", &[right], None)
+        );
+        let original = "\u{feff}\r\n\"quoted\"\\\0λ😀".repeat(16384);
+        let mut changed = original.clone();
+        changed.push('x');
+        assert_eq!(
+            execute("SELECT $1", &[Value::Text(original.clone())], None),
+            execute("SELECT $1", &[Value::Text(original.clone())], None)
+        );
+        assert_ne!(
+            execute("SELECT $1", &[Value::Text(original)], None),
+            execute("SELECT $1", &[Value::Text(changed)], None)
+        );
+    }
+}

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(test, allow(clippy::large_futures))]
 
 use super::PROTOCOL_VERSION;
+use super::request_value::RequestWireValue;
 use crate::engine::Engine;
 use crate::session::ExecuteOptions;
 #[cfg(test)]
@@ -105,6 +106,14 @@ impl ServerProtocolBody {
     }
 
     pub(super) async fn into_bytes(mut self, limit: usize) -> Result<Bytes, ApiError> {
+        if let ServerProtocolBodyInner::Full(bytes) = &mut self.inner {
+            let bytes = bytes.take().unwrap_or_default();
+            return if bytes.len() > limit {
+                Err(ApiError::payload_too_large(limit))
+            } else {
+                Ok(bytes)
+            };
+        }
         let mut collected = Vec::new();
         while let Some(frame) =
             std::future::poll_fn(|context| Pin::new(&mut self).poll_frame(context)).await
@@ -321,10 +330,9 @@ pub const FILE_UPLOAD_ID_HEADER: &str = "lix-upload-id";
 pub const DEFAULT_MAX_SESSIONS: usize = 64;
 /// Default idle lifetime for a remote session.
 pub const DEFAULT_SESSION_IDLE_TIMEOUT: Duration = Duration::from_mins(30);
-/// Default JSON request ceiling. Base64 expands blobs by roughly one third,
-/// so 64 MiB carries the engine's 32 MiB maximum plugin archive with room for
-/// the SQL envelope and also covers ordinary larger document blobs.
-pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
+/// No application-level request-body ceiling by default. Hosts that require a
+/// byte budget can set [`ServerProtocolOptions::max_request_body_bytes`].
+pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = usize::MAX;
 /// Largest number of file entries accepted by one native batch request.
 ///
 /// Keeping this bounded makes the fast path predictable for the normal bulk
@@ -1915,15 +1923,19 @@ where
         };
 
         macro_rules! json_request {
-            ($ty:ty) => {
-                match serde_json::from_slice::<$ty>(&body) {
+            ($ty:ty) => {{
+                let parsed = serde_json::from_slice::<$ty>(&body);
+                // Request types own their decoded fields. Release the raw
+                // body before hashing or executing a large SQL upload.
+                drop(body);
+                match parsed {
                     Ok(value) => Json(value),
                     Err(error) => {
                         return ApiError::bad_request(format!("invalid JSON request: {error}"))
                             .into_response();
                     }
                 }
-            };
+            }};
         }
 
         match (&method, path.as_str()) {
@@ -4683,20 +4695,6 @@ struct ExecuteBatchStatementRequest {
     label: Option<String>,
 }
 
-#[derive(Serialize)]
-struct ExecuteFingerprint<'a> {
-    sql: &'a str,
-    params: &'a [Value],
-    origin_key: Option<&'a str>,
-    label: Option<&'a str>,
-}
-
-#[derive(Serialize)]
-struct ExecuteBatchFingerprint<'a> {
-    statements: Vec<ExecuteFingerprint<'a>>,
-    origin_key: Option<&'a str>,
-}
-
 fn execute_idempotency(
     headers: &HeaderMap,
     scope: Option<String>,
@@ -4707,15 +4705,7 @@ fn execute_idempotency(
     let Some(key) = optional_idempotency_key(headers)? else {
         return Ok(None);
     };
-    let fingerprint = idempotency_fingerprint(
-        "execute",
-        &ExecuteFingerprint {
-            sql,
-            params,
-            origin_key,
-            label: None,
-        },
-    )?;
+    let fingerprint = super::fingerprint::execute(sql, params, origin_key);
     Ok(Some(ExecuteIdempotency::new(scope, key, fingerprint)))
 }
 
@@ -4728,21 +4718,7 @@ fn execute_batch_idempotency(
     let Some(key) = optional_idempotency_key(headers)? else {
         return Ok(None);
     };
-    let fingerprint = idempotency_fingerprint(
-        "execute-batch",
-        &ExecuteBatchFingerprint {
-            statements: statements
-                .iter()
-                .map(|statement| ExecuteFingerprint {
-                    sql: &statement.sql,
-                    params: &statement.params,
-                    origin_key: None,
-                    label: statement.label.as_deref(),
-                })
-                .collect(),
-            origin_key,
-        },
-    )?;
+    let fingerprint = super::fingerprint::batch(statements, origin_key);
     Ok(Some(ExecuteIdempotency::new(scope, key, fingerprint)))
 }
 
@@ -4806,56 +4782,6 @@ fn require_octet_stream_content_type(headers: &HeaderMap) -> Result<(), ApiError
             "raw sync chunk requests require Content-Type application/octet-stream",
         ))
     }
-}
-
-fn idempotency_fingerprint(
-    operation: &'static str,
-    payload: &impl Serialize,
-) -> Result<[u8; 32], ApiError> {
-    #[derive(Serialize)]
-    struct Envelope<'a, T: ?Sized> {
-        version: u8,
-        operation: &'static str,
-        payload: &'a T,
-    }
-
-    let bytes = serde_json::to_vec(&Envelope {
-        version: 1,
-        operation,
-        payload,
-    })
-    .map_err(|error| {
-        ApiError::from(LixError::new(
-            LixError::CODE_INTERNAL_ERROR,
-            format!("serialize idempotency request fingerprint: {error}"),
-        ))
-    })?;
-    Ok(Sha256::digest(bytes).into())
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum RequestWireValue {
-    BlobSplice(RequestBlobSplice),
-    Value(WireValue),
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RequestBlobSplice {
-    #[serde(rename = "kind")]
-    _kind: RequestBlobSpliceKind,
-    base_sha256: String,
-    result_sha256: String,
-    prefix_bytes: u64,
-    suffix_bytes: u64,
-    insert_base64: String,
-}
-
-#[derive(Debug, Deserialize)]
-enum RequestBlobSpliceKind {
-    #[serde(rename = "blob-splice")]
-    BlobSplice,
 }
 
 #[derive(Debug, Serialize)]
@@ -11679,6 +11605,35 @@ mod tests {
         .await;
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn full_body_limit_preserves_shared_bytes_without_copying() {
+        let bytes = Bytes::from(vec![b'x'; 1024 * 1024]);
+        let body = ServerProtocolBody::full(bytes.clone())
+            .into_bytes(bytes.len())
+            .await
+            .expect("body at the exact limit");
+        assert_eq!(body.as_ptr(), bytes.as_ptr());
+        assert_eq!(body, bytes);
+        assert!(
+            ServerProtocolBody::full(bytes.clone())
+                .into_bytes(bytes.len() - 1)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn default_body_limit_accepts_stream_larger_than_64_mib() {
+        let chunk = Bytes::from(vec![b'x'; 1024 * 1024]);
+        let stream =
+            futures_util::stream::iter((0..65).map(move |_| Ok::<_, io::Error>(chunk.clone())));
+        let body = ServerProtocolBody::stream(stream)
+            .into_bytes(ServerProtocolOptions::default().max_request_body_bytes)
+            .await
+            .expect("default protocol budget must accept bulk imports over 64 MiB");
+        assert_eq!(body.len(), 65 * 1024 * 1024);
     }
 
     #[tokio::test]

--- a/packages/lix/src/server_protocol/mod.rs
+++ b/packages/lix/src/server_protocol/mod.rs
@@ -6,7 +6,11 @@
 pub const PROTOCOL_VERSION: u32 = crate::SERVER_PROTOCOL_VERSION;
 
 #[cfg(feature = "server-protocol")]
+mod fingerprint;
+#[cfg(feature = "server-protocol")]
 mod handler;
+#[cfg(feature = "server-protocol")]
+mod request_value;
 #[cfg(feature = "server-protocol")]
 pub use handler::*;
 

--- a/packages/lix/src/server_protocol/request_value.rs
+++ b/packages/lix/src/server_protocol/request_value.rs
@@ -1,0 +1,136 @@
+//! Dispatch request parameters by their wire tag once. Nesting an untagged
+//! enum around WireValue made serde buffer and clone large text parameters.
+use crate::{Json, WireValue};
+use serde::{Deserialize, Deserializer};
+
+#[derive(Debug)]
+pub(super) enum RequestWireValue {
+    BlobSplice(RequestBlobSplice),
+    Value(WireValue),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RequestBlobSplice {
+    pub(super) base_sha256: String,
+    pub(super) result_sha256: String,
+    pub(super) prefix_bytes: u64,
+    pub(super) suffix_bytes: u64,
+    pub(super) insert_base64: String,
+}
+
+impl<'de> Deserialize<'de> for RequestWireValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(tag = "kind", rename_all = "lowercase")]
+        enum Tagged {
+            Null {
+                value: (),
+            },
+            Bool {
+                value: bool,
+            },
+            Int {
+                value: i64,
+            },
+            Float {
+                value: f64,
+            },
+            Text {
+                value: String,
+            },
+            Jsonb {
+                value: Json,
+            },
+            #[serde(rename = "row_ref")]
+            RowRef {
+                value: String,
+            },
+            Timestamptz {
+                value: String,
+            },
+            Blob {
+                base64: String,
+            },
+            #[serde(rename = "blob-splice")]
+            BlobSplice(RequestBlobSplice),
+        }
+        Ok(match Tagged::deserialize(deserializer)? {
+            Tagged::Null { value } => Self::Value(WireValue::Null { value }),
+            Tagged::Bool { value } => Self::Value(WireValue::Bool { value }),
+            Tagged::Int { value } => Self::Value(WireValue::Int { value }),
+            Tagged::Float { value } => Self::Value(WireValue::Float { value }),
+            Tagged::Text { value } => Self::Value(WireValue::Text { value }),
+            Tagged::Jsonb { value } => Self::Value(WireValue::Jsonb { value }),
+            Tagged::RowRef { value } => Self::Value(WireValue::RowRef { value }),
+            Tagged::Timestamptz { value } => Self::Value(WireValue::Timestamptz { value }),
+            Tagged::Blob { base64 } => Self::Value(WireValue::Blob { base64 }),
+            Tagged::BlobSplice(splice) => Self::BlobSplice(splice),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn sql_request_value_preserves_all_wire_types() {
+        let values = [
+            json!({"kind":"null","value":null}),
+            json!({"kind":"bool","value":true}),
+            json!({"kind":"int","value":i64::MIN}),
+            json!({"kind":"float","value":-0.0}),
+            json!({"kind":"text","value":"\u{feff}\r\n\"λ😀\\\0".repeat(16_384)}),
+            json!({"kind":"jsonb","value":{"b":[null,42],"a":"text"}}),
+            json!({"kind":"row_ref","value":"validated by the engine"}),
+            json!({"kind":"timestamptz","value":"2026-09-10T00:00:00Z"}),
+            json!({"kind":"blob","base64":"AAH/"}),
+        ];
+        for value in values {
+            let encoded = serde_json::to_vec(&value).unwrap();
+            let expected: WireValue = serde_json::from_slice(&encoded).unwrap();
+            let RequestWireValue::Value(actual) = serde_json::from_slice(&encoded).unwrap() else {
+                panic!("ordinary value became a splice")
+            };
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn sql_request_value_accepts_late_kind_and_blob_splices() {
+        let RequestWireValue::Value(WireValue::Text { value }) =
+            serde_json::from_str(r#"{"value":"before tag","kind":"text"}"#).unwrap()
+        else {
+            panic!("late tag rejected")
+        };
+        assert_eq!(value, "before tag");
+        let value = json!({"kind":"blob-splice","baseSha256":"a".repeat(64),"resultSha256":"b".repeat(64),"prefixBytes":3,"suffixBytes":2,"insertBase64":"AAH/"});
+        let RequestWireValue::BlobSplice(splice) = serde_json::from_value(value).unwrap() else {
+            panic!("splice rejected")
+        };
+        assert_eq!(splice.prefix_bytes, 3);
+        assert_eq!(splice.suffix_bytes, 2);
+        assert_eq!(splice.base_sha256, "a".repeat(64));
+        assert_eq!(splice.result_sha256, "b".repeat(64));
+        assert_eq!(splice.insert_base64, "AAH/");
+    }
+
+    #[test]
+    fn sql_request_value_rejects_malformed_parameters() {
+        for encoded in [
+            r#"{"kind":"unknown","value":0}"#,
+            r#"{"value":"no tag"}"#,
+            r#"{"kind":"text","value":123}"#,
+            r#"{"kind":"int","value":1.5}"#,
+            r#"{"kind":"text","kind":"blob","value":"ambiguous"}"#,
+            r#"{"kind":"blob-splice","baseSha256":"missing fields"}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<RequestWireValue>(encoded).is_err(),
+                "accepted {encoded}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Large SQL uploads currently copy and decode request contents redundantly, then serialize all typed parameters back to JSON to compute a retry fingerprint. This change hashes the typed parameters directly with domain-separated BLAKE3, removes nested untagged value decoding, reuses complete request bodies, and releases raw JSON before executing SQL. It also removes the default 64 MiB request-body ceiling while retaining explicitly configured host budgets.

The SQL and MCP request shapes are unchanged. Atomic execution and current-format retry semantics are preserved. Existing repository content and storage formats are unchanged. **Upgrade behavior:** persisted retry keys using the old fingerprint return `409 LIX_IDEMPOTENCY_KEY_REUSED` without re-executing the mutation; clients must reconcile uncertain old requests before issuing new keys. This is documented in the protocol guide and changenote.

### Performance

Five local runs per route and implementation, using 183 synthetic drawings (289,429,120 raw bytes) in one request with 549 SQL statements. The original user ZIP was unavailable. The baseline already used buffered JSON/SHA-256 hashing; results therefore compare against that intermediate optimization, not an untouched main build.

| Median | Before | After |
| --- | ---: | ---: |
| Server fingerprint | 162 ms | 33 ms |
| Native SQL request | 0.928 s | 0.800 s |
| Native import including preparation | 1.125 s | 0.953 s |
| Complete MCP import including setup | 2.346 s | 2.227 s |

Native runs used fresh repositories; MCP runs used fresh branches in an existing repository. Engine execution was essentially unchanged, and the full MCP path remains above one second. Whole-process peak RSS fell only about 1%; these measurements do not establish a large total-memory improvement.

### Validation

- Two independent sub-agent reviews found no correctness blockers. Added fixed fingerprint vectors following review feedback.
- Protocol tests cover all current wire types, malformed values, blob splices, fingerprint boundaries/order/labels, exact content, shared body ownership, requests over 64 MiB, and explicit byte limits.
- Live HTTP probes verified current-key replay, changed-payload rejection, atomic rollback, reuse of failed request keys, and rejection of pre-upgrade keys.
- `cargo nextest run -p lix --features all-simulations --no-fail-fast`: 3,568 passed, 67 skipped. The first run hit an unchanged GC fixture precondition race; the exact failed test passed 20/20 isolated repeats, then the full suite passed.
- `cargo test -p lix --doc`: 10 passed.
- Updated server-protocol suite: 151 passed, 2 manual diagnostics ignored. Formatting, change-fragment validation and protocol-doc validation passed.

Partial-replica sync, local Compose changes, benchmark repositories and diagnostic instrumentation are outside this PR.
