### PR TITLE
Write results carry the commit span they published

### DIFF
--- a/.changenotes/execute-commit-span.md
+++ b/.changenotes/execute-commit-span.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Write results now report the commits they moved the active branch between.
+
+`execute` and `executeBatch` results carry `commit: { before, after }` for every statement that committed a write: `before` is the active branch's head before the write and `after` the head it published. `lix_diff('lix_file', before, after)` is then exactly what the write changed, with no readback. Every statement of a written batch carries the batch's one span, and a write that published no commit on the active branch reports both ids equal. Read statements outside a written batch, read-only batches, and statements inside an explicit transaction carry no span. The server protocol, the remote client, and the CLI's JSON output pass it through, and results from servers that predate it simply omit it.

--- a/docs/diff-commands.md
+++ b/docs/diff-commands.md
@@ -6,7 +6,9 @@ description: Compare typed Lix relations across commits and select rows atomical
 
 `lix_diff(relation, from_commit_id, to_commit_id)` compares one relation across
 two explicitly selected commits. With only the relation argument it defaults
-to latest checkpoint → active head. A file is one row of `lix_file`; a
+to latest checkpoint → active head. A write's own span is on its result:
+`execute` returns `commit: { before, after }`, and `lix_diff('lix_file',
+before, after)` is exactly what that write changed. A file is one row of `lix_file`; a
 registered schema row is one row of its schema relation. Commands consume the
 diff's `row_ref` identity, so selecting a file also selects its underlying
 tracked content.

--- a/docs/js-api-reference.md
+++ b/docs/js-api-reference.md
@@ -187,6 +187,7 @@ type ExecuteResult<TRow = Record<string, unknown>> = {
   rows: TRow[];
   rowsAffected: number;
   notices: { code: string; message: string; hint?: string }[];
+  commit?: { before: string; after: string };
 };
 ```
 
@@ -196,6 +197,7 @@ type ExecuteResult<TRow = Record<string, unknown>> = {
 | `rows`         | Enumerable plain objects by default. Property access, destructuring, spread, and JSON serialization work directly. |
 | `rowsAffected` | Number of rows affected by write statements.                                |
 | `notices`      | Non-fatal engine notices with `{ code, message, hint? }`.                   |
+| `commit`       | The active-branch commits a write moved between: `before` is the branch head before the write, `after` the head it published, so `lix_diff('lix_file', before, after)` is exactly what it changed. Present for every auto-committed write statement, including `RETURNING` writes and restores, and for every statement of a written batch (all share the batch's span, read statements included); a write that published no commit on the active branch reports both ids equal. Absent for read statements outside a written batch, read-only batches, statements inside an explicit transaction, and the first commit on a branch that had no head yet. |
 
 Example:
 

--- a/packages/cli/src/output/mod.rs
+++ b/packages/cli/src/output/mod.rs
@@ -37,6 +37,10 @@ pub fn print_execute_result_table(result: &ExecuteResult) {
 
     println!("{table}");
     println!("({} rows)", result.rows().len());
+    // A RETURNING write has rows and a span; show both.
+    if let Some(span) = result.commit() {
+        println!("(commit {} -> {})", span.before(), span.after());
+    }
 }
 
 pub fn print_execute_result_json(result: &ExecuteResult) {

--- a/packages/cli/src/output/mod.rs
+++ b/packages/cli/src/output/mod.rs
@@ -9,6 +9,9 @@ pub fn print_execute_result_table(result: &ExecuteResult) {
         if result.rows_affected() > 0 {
             println!("({} rows affected)", result.rows_affected());
         }
+        if let Some(span) = result.commit() {
+            println!("(commit {} -> {})", span.before(), span.after());
+        }
         return;
     }
 
@@ -45,12 +48,20 @@ pub fn print_execute_result_json(result: &ExecuteResult) {
 }
 
 fn execute_result_to_json(result: &ExecuteResult) -> JsonValue {
-    serde_json::json!({
+    let mut payload = serde_json::json!({
         "columns": result.columns(),
         "rows": result.rows().iter().map(|row| row_to_json(result.columns(), row)).collect::<Vec<_>>(),
         "rowsAffected": result.rows_affected(),
         "notices": result.notices(),
-    })
+    });
+    // Same shape as the server: present for writes, absent for reads.
+    if let Some(span) = result.commit() {
+        payload["commit"] = serde_json::json!({
+            "before": span.before(),
+            "after": span.after(),
+        });
+    }
+    payload
 }
 
 fn row_to_json(columns: &[String], row: &lix::Row) -> JsonValue {

--- a/packages/e2e/tests/rust_sdk_api.rs
+++ b/packages/e2e/tests/rust_sdk_api.rs
@@ -1705,3 +1705,27 @@ async fn task_done(lix: &Lix, task_id: &str) -> bool {
 fn assert_closed(error: LixError) {
     assert_eq!(error.code, LixError::CODE_CLOSED);
 }
+
+#[tokio::test]
+async fn rs_sdk_writes_return_the_commit_span_they_published() {
+    let lix = open_lix().await.unwrap();
+    let before = active_head_commit_id(&lix).await;
+    let written = lix
+        .execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('span-rs', 'one')",
+            &[],
+        )
+        .await
+        .unwrap();
+    let span = written.commit().expect("a write carries its commit span");
+    assert_eq!(span.before(), before);
+    assert_eq!(span.after(), active_head_commit_id(&lix).await);
+    assert_ne!(span.before(), span.after());
+
+    let read = lix
+        .execute("SELECT value FROM lix_key_value WHERE key = 'span-rs'", &[])
+        .await
+        .unwrap();
+    assert_eq!(read.commit(), None);
+    lix.close().await.unwrap();
+}

--- a/packages/js-sdk/native/napi.rs
+++ b/packages/js-sdk/native/napi.rs
@@ -3181,6 +3181,14 @@ pub struct ExecuteResult {
     pub rows: Vec<Vec<LixValue>>,
     pub rows_affected: u32,
     pub notices: Vec<LixNotice>,
+    /// The active-branch commits a write moved between; absent for reads.
+    pub commit: Option<CommitSpan>,
+}
+
+#[napi(object)]
+pub struct CommitSpan {
+    pub before: String,
+    pub after: String,
 }
 
 #[napi(object)]
@@ -3241,6 +3249,10 @@ impl TryFrom<RsExecuteResult> for ExecuteResult {
                     hint: notice.hint.clone(),
                 })
                 .collect(),
+            commit: result.commit().map(|span| CommitSpan {
+                before: span.before().to_owned(),
+                after: span.after().to_owned(),
+            }),
         })
     }
 }

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -1433,6 +1433,15 @@ pub(super) struct ExecuteResultDto {
     rows: Vec<Vec<LixValueDto>>,
     rows_affected: f64,
     notices: Vec<LixNoticeDto>,
+    /// The active-branch commits a write moved between; absent for reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit: Option<CommitSpanDto>,
+}
+
+#[derive(Serialize)]
+struct CommitSpanDto {
+    before: String,
+    after: String,
 }
 
 #[derive(Serialize)]
@@ -1477,6 +1486,10 @@ impl TryFrom<RsExecuteResult> for ExecuteResultDto {
                     hint: notice.hint.clone(),
                 })
                 .collect(),
+            commit: result.commit().map(|span| CommitSpanDto {
+                before: span.before().to_owned(),
+                after: span.after().to_owned(),
+            }),
         })
     }
 }

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -1,4 +1,5 @@
 import type {
+	CommitSpan,
 	CreateBranchOptions,
 	CreateBranchReceipt,
 	UndoReceipt,
@@ -41,6 +42,7 @@ export type BindingExecuteResult = {
 		message: string;
 		hint?: string;
 	}>;
+	commit?: CommitSpan;
 };
 
 export type BindingObserveEvent = {

--- a/packages/js-sdk/src/commit-span.test.ts
+++ b/packages/js-sdk/src/commit-span.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { openLix } from "./index.js";
+test("writes return the commit span they published", async () => {
+	const lix = await openLix();
+	const head = async () =>
+		String(
+			(
+				await lix.execute<{ commit_id: string }>(
+					"SELECT lix_active_branch_commit_id() AS commit_id",
+				)
+			).rows[0]?.commit_id,
+		);
+	const before = await head();
+	const written = await lix.execute(
+		"INSERT INTO lix_key_value (key, value) VALUES ('span-js', 'one')",
+	);
+	expect(written.commit).toEqual({ before, after: await head() });
+	expect(written.commit?.after).not.toBe(before);
+
+	const read = await lix.execute("SELECT 1 AS value");
+	expect(read.commit).toBeUndefined();
+
+	const batchBefore = await head();
+	const batch = await lix.executeBatch([
+		{ sql: "INSERT INTO lix_key_value (key, value) VALUES ('span-js-b', 'one')" },
+		{ sql: "UPDATE lix_key_value SET value = 'two' WHERE key = 'span-js-b' RETURNING key" },
+	]);
+	expect(batch[0]?.commit).toEqual({ before: batchBefore, after: await head() });
+	expect(batch[1]?.commit).toEqual(batch[0]?.commit);
+
+	// Inside an explicit transaction the commit is the write.
+	const transaction = await lix.beginTransaction();
+	const staged = await transaction.execute(
+		"INSERT INTO lix_key_value (key, value) VALUES ('span-js-tx', 'one')",
+	);
+	expect(staged.rowsAffected).toBe(1);
+	expect(staged.commit).toBeUndefined();
+	await transaction.commit();
+	await lix.close();
+});

--- a/packages/js-sdk/src/index.ts
+++ b/packages/js-sdk/src/index.ts
@@ -32,6 +32,7 @@ export type {
 	CreateBranchOptions,
 	CreateBranchReceipt,
 	RedoReceipt,
+	CommitSpan,
 	ExecuteOptions,
 	ExecuteResult,
 	ExecuteBatchResult,

--- a/packages/js-sdk/src/remote/server-protocol.test.ts
+++ b/packages/js-sdk/src/remote/server-protocol.test.ts
@@ -374,3 +374,17 @@ test("observe row deltas reject invalid bases ranges and row shapes", () => {
 		),
 	).toThrow("observe row delta insert row 0 has 0 values for 1 columns");
 });
+
+test("remote execute results carry a commit span when the server sends one", () => {
+	const base = { columns: [], rows: [], rowsAffected: 1, notices: [] };
+	expect(decodeExecuteResult(base).commit).toBeUndefined();
+	expect(
+		decodeExecuteResult({
+			...base,
+			commit: { before: "commit-a", after: "commit-b" },
+		}).commit,
+	).toEqual({ before: "commit-a", after: "commit-b" });
+	expect(() =>
+		decodeExecuteResult({ ...base, commit: { before: "commit-a" } }),
+	).toThrow("execute result commit requires before and after commit ids");
+});

--- a/packages/js-sdk/src/remote/server-protocol.ts
+++ b/packages/js-sdk/src/remote/server-protocol.ts
@@ -2,6 +2,7 @@ import type {
 	BindingExecuteResult,
 	BindingObserveEvent,
 } from "../binding-types.js";
+import type { CommitSpan } from "../types.js";
 import type { NativeLixValue } from "../value.js";
 
 export const SERVER_PROTOCOL_VERSION = 7;
@@ -61,6 +62,7 @@ export type ServerProtocolExecuteResponse = {
 	rows: WireValue[][];
 	rowsAffected: number;
 	notices: Array<{ code: string; message: string; hint?: string }>;
+	commit?: CommitSpan;
 };
 
 export type ServerProtocolExecuteBatchResponse =
@@ -253,7 +255,25 @@ export function decodeExecuteResult(value: unknown): BindingExecuteResult {
 			...(item.hint === undefined ? {} : { hint: item.hint }),
 		};
 	});
-	return { columns, rows, rowsAffected: result.rowsAffected, notices };
+	// Servers that predate commit spans send none; a present span must be
+	// two commit ids.
+	let commit: CommitSpan | undefined;
+	if (result.commit !== undefined) {
+		const span = record(result.commit, "execute result commit");
+		if (typeof span.before !== "string" || typeof span.after !== "string") {
+			throw protocolError(
+				"execute result commit requires before and after commit ids",
+			);
+		}
+		commit = { before: span.before, after: span.after };
+	}
+	return {
+		columns,
+		rows,
+		rowsAffected: result.rowsAffected,
+		notices,
+		...(commit === undefined ? {} : { commit }),
+	};
 }
 
 function isResultColumnType(

--- a/packages/js-sdk/src/types.ts
+++ b/packages/js-sdk/src/types.ts
@@ -243,6 +243,19 @@ export type ResultObjectRow = Record<string, unknown>;
 export type ResultArrayRow = unknown[];
 export type ResultRow = ResultObjectRow | ResultArrayRow;
 
+/**
+ * The active-branch commits a write moved between.
+ *
+ * `before` is the active branch's head before the write and `after` the head
+ * it published, so `lix_diff('lix_file', before, after)` is exactly what the
+ * write changed. A write that published no commit on the active branch
+ * reports both ids equal; a restore reports the commit it moved the head to.
+ */
+export type CommitSpan = {
+	before: string;
+	after: string;
+};
+
 export type ExecuteResult<TRow extends object = ResultObjectRow> = {
 	statementIndex?: number;
 	label?: string;
@@ -254,6 +267,15 @@ export type ExecuteResult<TRow extends object = ResultObjectRow> = {
 		message: string;
 		hint?: string;
 	}>;
+	/**
+	 * Present on every auto-committed write statement, including `RETURNING`
+	 * writes, and on every statement of a written batch (all carry the
+	 * batch's one span, read statements included). Absent for read
+	 * statements outside a written batch, read-only batches, statements
+	 * inside an explicit transaction (whose commit is the write), and the
+	 * first commit on a branch that had no head yet.
+	 */
+	commit?: CommitSpan;
 };
 
 export type ExecuteBatchResult<TRow extends object = ResultObjectRow> =

--- a/packages/lix/src/authority_client/observe.rs
+++ b/packages/lix/src/authority_client/observe.rs
@@ -1010,6 +1010,7 @@ fn apply_observe_delta(
                 vec![vec![Value::Blob(next.into())]],
                 0,
                 Vec::new(),
+                None,
             ))
         }
         ObserveDelta::RowSplice {
@@ -1061,6 +1062,7 @@ fn apply_observe_delta(
                 rows,
                 base.rows.rows_affected(),
                 base.rows.notices().to_vec(),
+                base.rows.commit().cloned(),
             ))
         }
     }

--- a/packages/lix/src/authority_client/wire.rs
+++ b/packages/lix/src/authority_client/wire.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{ExecuteResult, LixError, LixNotice, ResultColumnType, Value, WireValue};
+use crate::{CommitSpan, ExecuteResult, LixError, LixNotice, ResultColumnType, Value, WireValue};
 use crate::{
     MergeBranchOptions, MergeBranchOutcome, MergeBranchPreview, MergeBranchPreviewOptions,
     MergeBranchReceipt, MergeChangeStats, MergeConflict, MergeConflictChangeKind,
@@ -95,6 +95,15 @@ pub struct ExecuteResponseBody {
     pub rows_affected: u64,
     #[serde(default)]
     pub notices: Vec<LixNotice>,
+    /// Absent from servers that predate commit spans.
+    #[serde(default)]
+    pub commit: Option<CommitSpanBody>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CommitSpanBody {
+    pub before: String,
+    pub after: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -149,6 +158,8 @@ impl ExecuteResponseBody {
             rows,
             self.rows_affected,
             self.notices,
+            self.commit
+                .map(|span| CommitSpan::new(span.before, span.after)),
         ))
     }
 }
@@ -625,4 +636,40 @@ pub fn unsupported_remote_operation(operation: &str) -> LixError {
         format!("{operation} is not supported in remote mode"),
     )
     .with_details(serde_json::json!({ "operation": operation }))
+}
+
+#[cfg(test)]
+mod commit_span_tests {
+    use super::*;
+
+    fn body(commit: serde_json::Value) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "columns": [],
+            "rows": [],
+            "rowsAffected": 1,
+            "notices": []
+        });
+        if !commit.is_null() {
+            body["commit"] = commit;
+        }
+        body
+    }
+
+    #[test]
+    fn execute_responses_decode_with_and_without_a_commit_span() {
+        let without = serde_json::from_value::<ExecuteResponseBody>(body(serde_json::Value::Null))
+            .expect("older servers omit the span")
+            .into_execute_result()
+            .expect("result should decode");
+        assert_eq!(without.commit(), None);
+
+        let with = serde_json::from_value::<ExecuteResponseBody>(body(
+            serde_json::json!({ "before": "commit-a", "after": "commit-b" }),
+        ))
+        .expect("span should decode")
+        .into_execute_result()
+        .expect("result should decode");
+        let span = with.commit().expect("span is kept");
+        assert_eq!((span.before(), span.after()), ("commit-a", "commit-b"));
+    }
 }

--- a/packages/lix/src/lib.rs
+++ b/packages/lix/src/lib.rs
@@ -193,7 +193,8 @@ pub use session::{
     RedoReceipt, SessionTransaction, SwitchBranchOptions, SwitchBranchReceipt, UndoReceipt,
 };
 pub use session::{
-    ExecuteBatchStatement, ExecuteResult, ObserveEvent, ResultRowRef, Row, TryFromValue,
+    CommitSpan, ExecuteBatchStatement, ExecuteResult, ObserveEvent, ResultRowRef, Row,
+    TryFromValue,
 };
 #[doc(hidden)]
 pub use session::CoherentReadBatch;

--- a/packages/lix/src/server_protocol/handler.rs
+++ b/packages/lix/src/server_protocol/handler.rs
@@ -4869,6 +4869,15 @@ struct ExecuteResponse {
     rows: Vec<Vec<WireValue>>,
     rows_affected: u64,
     notices: Vec<lix::LixNotice>,
+    /// The active-branch commits a write moved between; absent for reads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit: Option<CommitSpanResponse>,
+}
+
+#[derive(Debug, Serialize)]
+struct CommitSpanResponse {
+    before: String,
+    after: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -4905,6 +4914,10 @@ impl TryFrom<ExecuteResult> for ExecuteResponse {
             rows,
             rows_affected: result.rows_affected(),
             notices: result.notices().to_vec(),
+            commit: result.commit().map(|span| CommitSpanResponse {
+                before: span.before().to_owned(),
+                after: span.after().to_owned(),
+            }),
         })
     }
 }
@@ -10717,6 +10730,58 @@ mod tests {
         assert_eq!(body.as_array().map(Vec::len), Some(2));
         assert_eq!(body[0]["rows"][0][0], json!({ "kind": "int", "value": 1 }));
         assert_eq!(body[1]["rows"][0][0], json!({ "kind": "int", "value": 2 }));
+    }
+
+    #[tokio::test]
+    async fn execute_responses_carry_the_commit_span_of_writes() {
+        let app = app().await;
+        let (session_id, _) = new_session(&app.router).await;
+        let head = |sql: &'static str| {
+            let router = app.router.clone();
+            let session_id = session_id.clone();
+            async move {
+                let response = request(
+                    &router,
+                    "POST",
+                    "/lix/v1/execute",
+                    Some(&session_id),
+                    Some(json!({ "sql": sql, "params": [] })),
+                )
+                .await;
+                assert_eq!(response.status(), StatusCode::OK);
+                response_json(response).await
+            }
+        };
+        let read = head("SELECT lix_active_branch_commit_id() AS commit_id").await;
+        assert!(read.get("commit").is_none(), "reads carry no span: {read}");
+        let before = read["rows"][0][0]["value"].as_str().unwrap().to_owned();
+
+        let written =
+            head("INSERT INTO lix_key_value (key, value) VALUES ('span-http', 'one')").await;
+        assert_eq!(written["commit"]["before"], json!(before));
+        let after = written["commit"]["after"].as_str().unwrap().to_owned();
+        assert_ne!(after, before);
+
+        let now = head("SELECT lix_active_branch_commit_id() AS commit_id").await;
+        assert_eq!(now["rows"][0][0]["value"], json!(after));
+
+        let batch = request(
+            &app.router,
+            "POST",
+            "/lix/v1/execute-batch",
+            Some(&session_id),
+            Some(json!({
+                "statements": [
+                    { "sql": "INSERT INTO lix_key_value (key, value) VALUES ('span-http-b', 'one')", "params": [] },
+                    { "sql": "SELECT 1 AS value", "params": [] }
+                ]
+            })),
+        )
+        .await;
+        assert_eq!(batch.status(), StatusCode::OK);
+        let batch = response_json(batch).await;
+        assert_eq!(batch[0]["commit"]["before"], json!(after));
+        assert_eq!(batch[1]["commit"], batch[0]["commit"], "one span per batch");
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -16,6 +16,7 @@ use crate::branch::{
 };
 use crate::catalog::{CatalogContext, CatalogFingerprint, CatalogSnapshot, load_catalog_revision};
 use crate::changelog::CommitId;
+use crate::session::execute::CommitSpan;
 use crate::commit_graph::{CommitGraphContext, CommitGraphReader};
 use crate::domain::Domain;
 use crate::filesystem::FilesystemPathIndexReader;
@@ -471,9 +472,23 @@ where
     where
         F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
     {
+        self.with_write_transaction_lending_spanned(f)
+            .await
+            .map(|(value, _)| value)
+    }
+
+    /// Like [`Self::with_write_transaction_lending`], also returning the
+    /// active-branch commit span the transaction published.
+    pub(crate) async fn with_write_transaction_lending_spanned<T, F>(
+        &self,
+        f: F,
+    ) -> Result<(T, Option<CommitSpan>), LixError>
+    where
+        F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
+    {
         self.ensure_open()?;
         let write_access = self.begin_session_write_access().await?;
-        self.with_write_transaction_reserved_lending(write_access, f, |_| Ok(()))
+        self.with_write_transaction_reserved_lending_spanned(write_access, f, |_| Ok(()))
             .await
     }
 
@@ -483,6 +498,23 @@ where
         f: F,
         after_commit: A,
     ) -> Result<T, LixError>
+    where
+        F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
+        A: FnOnce(&T) -> Result<(), LixError>,
+    {
+        self.with_write_transaction_reserved_lending_spanned(write_access, f, after_commit)
+            .await
+            .map(|(value, _)| value)
+    }
+
+    /// Runs `f` in a write transaction and commits it, returning its value
+    /// together with the commit span the active branch moved through.
+    pub(super) async fn with_write_transaction_reserved_lending_spanned<T, F, A>(
+        &self,
+        write_access: SessionWriteAccess,
+        f: F,
+        after_commit: A,
+    ) -> Result<(T, Option<CommitSpan>), LixError>
     where
         F: for<'tx> AsyncFnOnce(&'tx mut Transaction<StorageImpl>) -> Result<T, LixError>,
         A: FnOnce(&T) -> Result<(), LixError>,
@@ -555,7 +587,12 @@ where
                     );
                 }
                 after_commit_result?;
-                Ok(value)
+                Ok((
+                    value,
+                    outcome
+                        .active_branch_commit_span
+                        .map(CommitSpan::from_commit_ids),
+                ))
             }
             Err(error) => Err(error),
         }

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -75,6 +75,40 @@ impl LiteralParameterBuilder {
     }
 }
 
+/// The active-branch commits a write moved between.
+///
+/// `before` is the active branch's head before the write and `after` the head
+/// it published, so `lix_diff('lix_file', before, after)` is exactly what the
+/// write changed. A write that published no commit on the active branch
+/// reports both ids equal; a restore reports the commit it moved the head to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitSpan {
+    before: String,
+    after: String,
+}
+
+impl CommitSpan {
+    pub(crate) fn new(before: String, after: String) -> Self {
+        Self { before, after }
+    }
+
+    pub(crate) fn from_commit_ids(
+        (before, after): (crate::changelog::CommitId, crate::changelog::CommitId),
+    ) -> Self {
+        Self::new(before.to_string(), after.to_string())
+    }
+
+    /// The head the write committed on top of.
+    pub fn before(&self) -> &str {
+        &self.before
+    }
+
+    /// The head the write published.
+    pub fn after(&self) -> &str {
+        &self.after
+    }
+}
+
 /// Result of executing one SQL statement through engine.
 ///
 /// Column names live once at the result-set level. Individual rows only own
@@ -89,6 +123,8 @@ pub struct ExecuteResult {
     /// empty case inline avoids one Arc clone/drop pair for every scalar write.
     backing: Option<Arc<ExecuteResultBacking>>,
     rows_affected: u64,
+    /// Present on results of statements that committed a write.
+    commit: Option<CommitSpan>,
     checkpoint_telemetry: Option<(String, String)>,
     #[cfg(feature = "storage-benches")]
     profile_provider_rows_examined: u64,
@@ -118,6 +154,7 @@ impl PartialEq for ExecuteResult {
         self.statement_index == other.statement_index
             && self.statement_label == other.statement_label
             && self.rows_affected == other.rows_affected
+            && self.commit == other.commit
             && (matches!(
                 (&self.backing, &other.backing),
                 (Some(left), Some(right)) if Arc::ptr_eq(left, right)
@@ -179,6 +216,29 @@ impl ExecuteResult {
 
     pub fn label(&self) -> Option<&str> {
         self.statement_label.as_deref()
+    }
+
+    /// The commits a write moved the active branch between.
+    ///
+    /// `Some` for every auto-committed write statement, including `RETURNING`
+    /// writes, and for every statement of a written batch (all carry the
+    /// batch's one span, read statements included). A write that published
+    /// no commit on the active branch reports both ids equal. `None` for read
+    /// statements outside a written batch, read-only batches, statements
+    /// inside an explicit transaction (whose commit is the write), and the
+    /// first commit on a branch that had no head yet.
+    pub fn commit(&self) -> Option<&CommitSpan> {
+        self.commit.as_ref()
+    }
+
+    /// Sets the span when one is known. `None` leaves an earlier span in
+    /// place, so the post-commit stamp never erases the staging-time span a
+    /// receipt already carries.
+    pub(crate) fn with_commit(mut self, commit: Option<CommitSpan>) -> Self {
+        if commit.is_some() {
+            self.commit = commit;
+        }
+        self
     }
 
     fn with_batch_metadata(mut self, statement_index: usize, label: Option<String>) -> Self {
@@ -244,6 +304,7 @@ impl ExecuteResult {
             statement_label: None,
             backing: None,
             rows_affected,
+            commit: None,
             checkpoint_telemetry: None,
             #[cfg(feature = "storage-benches")]
             profile_provider_rows_examined: 0,
@@ -260,8 +321,10 @@ impl ExecuteResult {
         rows: Vec<Vec<Value>>,
         rows_affected: u64,
         notices: Vec<LixNotice>,
+        commit: Option<CommitSpan>,
     ) -> Self {
         Self::from_query_parts(columns, column_types, rows, rows_affected, notices)
+            .with_commit(commit)
     }
 
     pub(crate) fn from_protocol_response(
@@ -272,12 +335,13 @@ impl ExecuteResult {
         rows: Vec<Vec<Value>>,
         rows_affected: u64,
         notices: Vec<LixNotice>,
+        commit: Option<CommitSpan>,
     ) -> Self {
         let mut result =
             Self::from_query_parts(columns, column_types, rows, rows_affected, notices);
         result.statement_index = statement_index;
         result.statement_label = label;
-        result
+        result.with_commit(commit)
     }
 
     fn from_query_parts(
@@ -305,6 +369,7 @@ impl ExecuteResult {
                 file_view_mutations: Vec::new(),
             })),
             rows_affected,
+            commit: None,
             checkpoint_telemetry: None,
             #[cfg(feature = "storage-benches")]
             profile_provider_rows_examined: 0,
@@ -339,6 +404,7 @@ impl ExecuteResult {
                 file_view_mutations: Vec::new(),
             })),
             rows_affected: 0,
+            commit: None,
             checkpoint_telemetry: None,
             #[cfg(feature = "storage-benches")]
             profile_provider_rows_examined: 0,
@@ -779,6 +845,33 @@ pub struct ExecuteBatchStatement {
     /// Opaque caller metadata echoed by the corresponding batch result.
     /// Labels need not be unique; `statement_index` is the unique identity.
     pub label: Option<String>,
+}
+
+/// The span a transaction knows before it commits; see
+/// `Transaction::staged_active_branch_commit_span`.
+fn staged_commit_span<StorageImpl>(
+    transaction: &crate::transaction::Transaction<StorageImpl>,
+) -> Result<Option<CommitSpan>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    Ok(transaction
+        .staged_active_branch_commit_span()?
+        .map(CommitSpan::from_commit_ids))
+}
+
+fn with_staged_commit_span<StorageImpl>(
+    transaction: &crate::transaction::Transaction<StorageImpl>,
+    results: Vec<ExecuteResult>,
+) -> Result<Vec<ExecuteResult>, LixError>
+where
+    StorageImpl: Storage + Clone + Send + Sync + 'static,
+{
+    let commit = staged_commit_span(transaction)?;
+    Ok(results
+        .into_iter()
+        .map(|result| result.with_commit(commit.clone()))
+        .collect())
 }
 
 fn annotate_batch_results(
@@ -1601,7 +1694,7 @@ where
                 let options = options.clone();
                 let metadata = metadata.clone();
                 let result = self
-                    .with_write_transaction_reserved_lending(
+                    .with_write_transaction_reserved_lending_spanned(
                         write_access,
                         async move |transaction| {
                             let previous_origin_key =
@@ -1629,7 +1722,7 @@ where
                     .await
                     .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
                 match result {
-                    Ok(result) => return Ok(result),
+                    Ok((result, commit)) => return Ok(result.with_commit(commit)),
                     Err(error) => {
                         if retry_auto_commit(
                             &mut transaction_conflict_retries,
@@ -1958,7 +2051,7 @@ where
             // stack frame while the write lease is held.
             let idempotency_for_commit = idempotency.clone();
             let result = self
-                .with_write_transaction_reserved_lending(
+                .with_write_transaction_reserved_lending_spanned(
                     write_access,
                     async move |transaction| {
                         let previous_origin_key =
@@ -1973,7 +2066,11 @@ where
                                 &metadata,
                             )
                             .await?;
-                            let result = ExecuteResult::from_sql_write_result(result);
+                            // The receipt is part of this write set, so it can
+                            // only carry the span known at staging time; a
+                            // replay reports that span.
+                            let result = ExecuteResult::from_sql_write_result(result)
+                                .with_commit(staged_commit_span(transaction)?);
                             let receipt = ExecuteIdempotencyReceipt::single(
                                 &idempotency_for_commit,
                                 &result,
@@ -1994,7 +2091,7 @@ where
                 .map_err(|error| normalize_sql_surface_error(error, &sql_for_error));
 
             match result {
-                Ok(result) => return Ok(result),
+                Ok((result, commit)) => return Ok(result.with_commit(commit)),
                 Err(error)
                     if error.code == LixError::CODE_STORAGE_READ_EXPIRED
                         && retry_expired_auto_commit(&mut expired_read_retries, &error).await =>
@@ -2175,7 +2272,7 @@ where
 
         let sql_for_error = Arc::clone(&sql);
         let result = self
-            .with_write_transaction_lending(async move |transaction| {
+            .with_write_transaction_lending_spanned(async move |transaction| {
                 let plan = transaction.prepare_sql_write_logical_plan(&sql, &statement)?;
                 let results = sql2::execute_write_logical_plan_prepared_dml_batch(
                     transaction,
@@ -2194,10 +2291,16 @@ where
                         results
                             .into_iter()
                             .map(ExecuteResult::from_sql_write_result)
-                            .collect()
+                            .collect::<Vec<_>>()
                     })
             })
-            .await;
+            .await
+            .map(|(results, commit)| {
+                results
+                    .into_iter()
+                    .map(|result| result.with_commit(commit.clone()))
+                    .collect()
+            });
         result.map_err(|error| normalize_sql_surface_error(error, &sql_for_error))
     }
 
@@ -2475,8 +2578,12 @@ where
         let parameter_route = Arc::new(AtomicBool::new(false));
         let transaction_parameter_route = Arc::clone(&parameter_route);
         let transaction_telemetry_sink = telemetry_sink.clone();
+        // Only a batch that writes reports a span. Read-only batches also run
+        // on this lane when a statement is nondeterministic; they commit
+        // nothing worth naming.
+        let carries_span = parsed.contains_write()?;
         let result = self
-            .with_write_transaction_lending(async move |transaction| {
+            .with_write_transaction_lending_spanned(async move |transaction| {
                 if let Some(results) = try_execute_transaction_parameter_batch(
                     transaction,
                     statements,
@@ -2487,6 +2594,11 @@ where
                 )
                 .await?
                 {
+                    let results = if carries_span {
+                        with_staged_commit_span(transaction, results)?
+                    } else {
+                        results
+                    };
                     if let Some(idempotency) = &idempotency {
                         let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
                         transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
@@ -2581,13 +2693,29 @@ where
                         }
                     }
                 }
+                let results = if carries_span {
+                    with_staged_commit_span(transaction, results)?
+                } else {
+                    results
+                };
                 if let Some(idempotency) = &idempotency {
                     let receipt = ExecuteIdempotencyReceipt::batch(idempotency, &results)?;
                     transaction.stage_execute_idempotency_receipt(idempotency, &receipt)?;
                 }
                 Ok(results)
             })
-            .await;
+            .await
+            .map(|(results, commit)| {
+                if !carries_span {
+                    return results;
+                }
+                // Every statement of the batch sits between the same two
+                // commits: the span the batch published.
+                results
+                    .into_iter()
+                    .map(|result| result.with_commit(commit.clone()))
+                    .collect::<Vec<_>>()
+            });
         if parameter_route.load(Ordering::Relaxed) {
             finish_parameter_batch_statement_telemetry(
                 telemetry_sink.as_ref(),
@@ -5886,6 +6014,162 @@ mod tests {
             .await
             .expect("initialized storage should create engine");
         engine.open_session().await.expect("session should open")
+    }
+
+    async fn active_head(session: &SessionContext<Memory>) -> String {
+        session
+            .execute("SELECT lix_active_branch_commit_id() AS commit_id", &[])
+            .await
+            .expect("head should read")
+            .rows()[0]
+            .get::<String>("commit_id")
+            .expect("head should be text")
+    }
+
+    #[tokio::test]
+    async fn write_results_carry_the_commit_span_they_published() {
+        let session = open_session().await;
+        let read = session
+            .execute("SELECT 1 AS value", &[])
+            .await
+            .expect("read should run");
+        assert_eq!(read.commit(), None, "reads commit nothing");
+
+        let head_before_first = active_head(&session).await;
+        let first = session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('span-a', 'one')",
+                &[],
+            )
+            .await
+            .expect("write should commit");
+        let first_span = first.commit().expect("a write carries its span");
+        assert_eq!(first_span.before(), head_before_first);
+        assert_eq!(first_span.after(), active_head(&session).await);
+        assert_ne!(first_span.before(), first_span.after());
+
+        // The next write parents the head the previous one published.
+        let second = session
+            .execute(
+                "UPDATE lix_key_value SET value = 'two' WHERE key = 'span-a' RETURNING key",
+                &[],
+            )
+            .await
+            .expect("returning write should commit");
+        assert_eq!(second.rows().len(), 1, "RETURNING rows still come back");
+        let second_span = second.commit().expect("a RETURNING write carries its span");
+        assert_eq!(second_span.before(), first_span.after());
+        assert_eq!(second_span.after(), active_head(&session).await);
+
+        // Every statement of a batch sits between the same two commits.
+        let head_before_batch = active_head(&session).await;
+        let batch = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    label: None,
+                    sql: "INSERT INTO lix_key_value (key, value) VALUES ('span-b', 'one')"
+                        .to_string(),
+                    params: Vec::new(),
+                },
+                ExecuteBatchStatement {
+                    label: None,
+                    sql: "INSERT INTO lix_key_value (key, value) VALUES ('span-c', 'one')"
+                        .to_string(),
+                    params: Vec::new(),
+                },
+            ])
+            .await
+            .expect("batch should commit");
+        let spans = batch
+            .iter()
+            .map(|result| result.commit().expect("batch statements carry the span"))
+            .collect::<Vec<_>>();
+        assert_eq!(spans[0], spans[1]);
+        assert_eq!(spans[0].before(), head_before_batch);
+        assert_eq!(spans[0].after(), active_head(&session).await);
+        assert_ne!(spans[0].before(), spans[0].after());
+    }
+
+    #[tokio::test]
+    async fn spans_are_absent_where_nothing_auto_committed() {
+        let session = open_session().await;
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('span-d', 'one')",
+                &[],
+            )
+            .await
+            .expect("seed should commit");
+        let head = active_head(&session).await;
+
+        // A write that matched nothing still reports where it stands.
+        let noop = session
+            .execute(
+                "UPDATE lix_key_value SET value = 'x' WHERE key = 'span-missing'",
+                &[],
+            )
+            .await
+            .expect("no-op write should run");
+        assert_eq!(noop.rows_affected(), 0);
+        let span = noop.commit().expect("a no-op write still carries its span");
+        assert_eq!(span.before(), head);
+        assert_eq!(span.after(), active_head(&session).await);
+
+        // A restore moves the head to a commit it did not author.
+        let target = span.before().to_owned();
+        let restored = session
+            .execute(
+                "INSERT INTO lix_restore (commit_id) VALUES ($1) RETURNING commit_id",
+                &[Value::Text(target.clone())],
+            )
+            .await
+            .expect("restore should run");
+        let restore_span = restored.commit().expect("a restore carries its span");
+        assert_eq!(restore_span.before(), head);
+        assert_eq!(restore_span.after(), target);
+        assert_eq!(active_head(&session).await, target);
+
+        // Read-only batches commit nothing, even on the transaction lane
+        // that nondeterministic reads take.
+        let nondeterministic = session
+            .execute_batch(&[ExecuteBatchStatement {
+                label: None,
+                sql: "SELECT uuidv7() AS id".to_string(),
+                params: Vec::new(),
+            }])
+            .await
+            .expect("nondeterministic read batch should run");
+        assert!(nondeterministic.iter().all(|result| result.commit().is_none()));
+        let reads = session
+            .execute_batch(&[
+                ExecuteBatchStatement {
+                    label: None,
+                    sql: "SELECT 1 AS value".to_string(),
+                    params: Vec::new(),
+                },
+                ExecuteBatchStatement {
+                    label: None,
+                    sql: "SELECT 2 AS value".to_string(),
+                    params: Vec::new(),
+                },
+            ])
+            .await
+            .expect("read batch should run");
+        assert!(reads.iter().all(|result| result.commit().is_none()));
+
+        // Inside an explicit transaction the commit is the write, so its
+        // statements report no span of their own.
+        let mut transaction = session.begin_transaction().await.unwrap();
+        let staged = transaction
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('span-e', 'one')",
+                &[],
+            )
+            .await
+            .expect("statement should stage");
+        assert_eq!(staged.rows_affected(), 1);
+        assert_eq!(staged.commit(), None);
+        transaction.commit().await.expect("transaction should commit");
     }
 
     #[derive(Clone)]

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -149,12 +149,15 @@ struct ColumnarResult {
     batches: Arc<[RecordBatch]>,
 }
 
+/// Equality compares what a statement returned: its position, label, rows,
+/// affected count, and notices. Where it ran (`commit`, telemetry) is
+/// execution context and stays out, so a result can be compared with one
+/// built from its parts.
 impl PartialEq for ExecuteResult {
     fn eq(&self, other: &Self) -> bool {
         self.statement_index == other.statement_index
             && self.statement_label == other.statement_label
             && self.rows_affected == other.rows_affected
-            && self.commit == other.commit
             && (matches!(
                 (&self.backing, &other.backing),
                 (Some(left), Some(right)) if Arc::ptr_eq(left, right)

--- a/packages/lix/src/session/idempotency.rs
+++ b/packages/lix/src/session/idempotency.rs
@@ -9,7 +9,7 @@ use crate::storage_adapter::{
 };
 use crate::{LixError, LixNotice, ResultColumnType, Value};
 
-use super::execute::ExecuteResult;
+use super::execute::{CommitSpan, ExecuteResult};
 
 /// Opaque replay identity for one HTTP SQL mutation.
 ///
@@ -106,6 +106,15 @@ struct StoredExecuteResult {
     rows: Vec<Vec<StoredValue>>,
     rows_affected: u64,
     notices: Vec<LixNotice>,
+    /// Receipts written before spans existed replay without one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    commit: Option<StoredCommitSpan>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct StoredCommitSpan {
+    before: String,
+    after: String,
 }
 
 /// Replay-storage form of a SQL value.
@@ -214,6 +223,16 @@ impl ExecuteIdempotencyReceipt {
             && self.request_fingerprint == BASE64.encode(idempotency.request_fingerprint())
     }
 
+    /// Points every stored span at `before`: the commit parent the write
+    /// actually published on, known only once its transaction commits.
+    pub(crate) fn set_commit_before(&mut self, before: &str) {
+        for result in &mut self.results {
+            if let Some(span) = &mut result.commit {
+                span.before = before.to_owned();
+            }
+        }
+    }
+
     pub(crate) fn into_single_result(self) -> Result<ExecuteResult, LixError> {
         let mut results = self.into_results()?;
         if results.len() != 1 {
@@ -251,6 +270,10 @@ impl StoredExecuteResult {
             rows,
             rows_affected: result.rows_affected(),
             notices: result.notices().to_vec(),
+            commit: result.commit().map(|span| StoredCommitSpan {
+                before: span.before().to_owned(),
+                after: span.after().to_owned(),
+            }),
         })
     }
 
@@ -270,6 +293,8 @@ impl StoredExecuteResult {
             rows,
             self.rows_affected,
             self.notices,
+            self.commit
+                .map(|span| CommitSpan::new(span.before, span.after)),
         ))
     }
 }

--- a/packages/lix/src/session/mod.rs
+++ b/packages/lix/src/session/mod.rs
@@ -44,8 +44,8 @@ pub use context::SessionContext;
 pub(crate) use context::{SessionBranch, load_default_branch_id_from_index};
 pub use create_branch::{CreateBranchOptions, CreateBranchReceipt};
 pub use execute::{
-    CoherentReadBatch, ExecuteBatchStatement, ExecuteOptions, ExecuteResult, ResultRowRef, Row,
-    TryFromValue,
+    CoherentReadBatch, CommitSpan, ExecuteBatchStatement, ExecuteOptions, ExecuteResult,
+    ResultRowRef, Row, TryFromValue,
 };
 pub(crate) use execute::{ExecutionDisposition, FileRead};
 pub(crate) use idempotency::ExecuteIdempotency;

--- a/packages/lix/src/transaction/commit_coordinator.rs
+++ b/packages/lix/src/transaction/commit_coordinator.rs
@@ -399,6 +399,9 @@ where
                 outcomes.iter_mut().zip(checkpoint_gc_sequences)
             {
                 if let Ok(outcome) = outcome {
+                    // Cohort commits serve explicit transactions, whose
+                    // statements carry no commit span by design; the span
+                    // is deliberately left unset here.
                     *outcome = TransactionCommitOutcome {
                         checkpoint_gc_sequence,
                         ..TransactionCommitOutcome::default()

--- a/packages/lix/src/transaction/context.rs
+++ b/packages/lix/src/transaction/context.rs
@@ -153,6 +153,11 @@ pub(crate) struct TransactionCommitOutcome {
     pub(crate) storage_stats: StorageWriteSetStats,
     pub(crate) commit_cohort_id: Option<String>,
     pub(crate) checkpoint_gc_sequence: Option<u64>,
+    /// The active branch's head before this commit and the head it
+    /// published, so a write can report exactly which commits it sits
+    /// between. Equal when the transaction published no commit on that
+    /// branch. `None` when the branch had no head to commit on.
+    pub(crate) active_branch_commit_span: Option<(CommitId, CommitId)>,
 }
 
 fn typed_transaction_validation_counters(rows: &RawWriteBatch) -> WasmTransitionCounters {
@@ -725,6 +730,13 @@ pub(crate) struct Transaction<StorageImpl: Storage + 'static = Memory> {
     trust_filesystem_planner: bool,
     origin_key: Option<SharedStr>,
     idempotency_receipt: Option<(crate::storage_adapter::StorageKey, Vec<u8>)>,
+    /// The receipt as staged, with the active head it was staged against, so
+    /// the commit can re-encode it if stale reconciliation moved the parent.
+    idempotency_receipt_source: Option<(
+        ExecuteIdempotency,
+        ExecuteIdempotencyReceipt,
+        Option<CommitId>,
+    )>,
     /// Storage-native metadata that must publish in the same backend commit as
     /// this transaction's file rows and history. Resumable media finalization
     /// uses this lane for its completed manifest and upload receipt.
@@ -1742,6 +1754,7 @@ where
             trust_filesystem_planner: false,
             origin_key: None,
             idempotency_receipt: None,
+            idempotency_receipt_source: None,
             atomic_metadata_writes: None,
             atomic_metadata_preconditions: Vec::new(),
             sync_role: crate::sync::SyncRole::Disabled,
@@ -1816,6 +1829,24 @@ where
         let _phase =
             crate::storage_bench::enter_crud_phase(crate::storage_bench::CRUD_PHASE_COMMIT);
         let transaction = &mut self;
+        // The staged commit id is fixed at staging time; the prepared writes
+        // are consumed by materialization below, so read it now. The head it
+        // parents is read after commit, once stale reconciliation has settled
+        // on the real parent.
+        let published_active_branch_commit_id = prepared_writes
+            .commit_change_refs_by_branch
+            .get(&transaction.active_branch_id)
+            .filter(|refs| !refs.is_empty() || refs.allow_empty)
+            .map(|refs| refs.commit_id)
+            // A restore moves the head to an existing commit without
+            // authoring one; the restore intent is consumed below, so read
+            // it here.
+            .or_else(|| {
+                transaction
+                    .pending_restore_targets
+                    .get(&transaction.active_branch_id)
+                    .map(|intent| intent.target_commit_id)
+            });
         let commit_boundary = transaction.commit_boundary.clone();
         let _commit_guard = begin_commit_boundary(commit_boundary.as_ref());
         let (
@@ -2122,6 +2153,17 @@ where
                     ),
                 );
             }
+            // Stale reconciliation may have moved this transaction onto a
+            // newer parent after the receipt was staged. The replayed span
+            // must match the response, so re-encode it against that parent.
+            if let Some((idempotency, mut receipt, staged_head)) =
+                transaction.idempotency_receipt_source.take()
+                && staged_head != transaction.opening_active_branch_head
+                && let Some(before) = transaction.opening_active_branch_head
+            {
+                receipt.set_commit_before(&before.to_string());
+                transaction.idempotency_receipt = Some(encode_receipt(&idempotency, &receipt)?);
+            }
             if let Some((key, value)) = transaction.idempotency_receipt.take() {
                 writes.put(EXECUTE_IDEMPOTENCY_RECEIPT_SPACE, key.clone(), value);
                 // The mutation and this receipt share one atomic storage commit.
@@ -2278,7 +2320,37 @@ where
             storage_stats,
             commit_cohort_id: Some(commit_cohort_id),
             checkpoint_gc_sequence: transaction.pending_checkpoint_gc_sequence,
+            active_branch_commit_span: transaction
+                .opening_active_branch_head
+                .map(|before| (before, published_active_branch_commit_id.unwrap_or(before))),
         })
+    }
+
+    /// The active-branch commit span this transaction is set to publish: the
+    /// head it opened on (or was reconciled onto) and the commit it has
+    /// staged, or that same head when nothing is staged for the branch.
+    ///
+    /// The staged id is the one the commit will carry, since stale
+    /// reconciliation rewrites rows onto it rather than minting another. The
+    /// parent can still move if the transaction is reconciled at commit, so
+    /// callers that need the exact published span read it from the commit
+    /// outcome instead.
+    pub(crate) fn staged_active_branch_commit_span(
+        &self,
+    ) -> Result<Option<(CommitId, CommitId)>, LixError> {
+        let Some(before) = self.opening_active_branch_head else {
+            return Ok(None);
+        };
+        let after = self
+            .staged_writes
+            .staged_commit_id(&self.active_branch_id)?
+            .or_else(|| {
+                self.pending_restore_targets
+                    .get(&self.active_branch_id)
+                    .map(|intent| intent.target_commit_id)
+            })
+            .unwrap_or(before);
+        Ok(Some((before, after)))
     }
 
     /// Large import documents are more valuable as transient parser state than
@@ -7541,6 +7613,11 @@ where
             ));
         }
         self.idempotency_receipt = Some(encode_receipt(idempotency, receipt)?);
+        self.idempotency_receipt_source = Some((
+            idempotency.clone(),
+            receipt.clone(),
+            self.opening_active_branch_head,
+        ));
         Ok(())
     }
 

--- a/packages/lix/src/transaction/staging.rs
+++ b/packages/lix/src/transaction/staging.rs
@@ -1752,6 +1752,22 @@ impl PreparedWriteSet {
 }
 
 impl TransactionWriteBuffer {
+    /// The commit this buffer will publish on `branch_id`, once anything is
+    /// staged there. A branch with nothing staged publishes no commit unless
+    /// it was explicitly allowed to publish an empty one.
+    pub(crate) fn staged_commit_id(&self, branch_id: &str) -> Result<Option<CommitId>, LixError> {
+        let commit_change_refs = self.commit_change_refs_by_branch.lock().map_err(|_| {
+            LixError::new(
+                LixError::CODE_INTERNAL_ERROR,
+                "failed to acquire transaction staged commit change refs",
+            )
+        })?;
+        Ok(commit_change_refs
+            .get(branch_id)
+            .filter(|refs| !refs.is_empty() || refs.allow_empty)
+            .map(|refs| refs.commit_id))
+    }
+
     pub(crate) fn new(functions: FunctionProviderHandle) -> Self {
         Self {
             functions,


### PR DESCRIPTION
## Summary

Write results now report the commits they moved the active branch between.

`execute` and `executeBatch` results carry `commit: { before, after }` for every statement that committed a write: `before` is the active branch's head before the write, `after` the head it published. `lix_diff('lix_file', before, after)` is then exactly what the write changed, with no readback and no correlation through `origin_key`. Every statement of a batch carries the batch's one span. Reads, and statements inside an explicit transaction, carry no span.

This is the write-level counterpart to `RETURNING`: PostgreSQL correlates a write's effects through the transaction id and Dolt through the root hash the write produced; Lix already mints a head commit per write, so the write now says which one.

## Why

Consumers that need to know what a write touched (LixRay's MCP result links, review UIs) had to stamp a per-request `origin_key` and read `lix_change` back, then reconstruct paths for deletions and directories. That overloads `origin_key`, which means *who* made a change, with correlation, and it costs one to three reads per write. With the span, one `lix_diff` over the exact commits answers it, and `origin_key` goes back to attribution.

## Change

Rust first, bindings follow.

- `packages/lix`: `CommitSpan { before, after }` (accessors, exported from the crate root) and `ExecuteResult::commit() -> Option<&CommitSpan>`. `Transaction::commit_prepared` records the span on `TransactionCommitOutcome` (the staged commit id for the active branch, read before materialization consumes the prepared writes; the parent read after commit so stale reconciliation has settled). Session wrappers `with_write_transaction_*_spanned` return it and every auto-committed write path stamps it: single statements, batches (one span for all statements), prepared DML batches, and idempotent writes. Idempotency receipts store the span known at staging time (the staged id is the one the commit carries), so a replay reports it too; receipts written before this change replay without one.
- Server protocol: `commit` on execute responses, omitted for reads. Rust remote client decodes it when present.
- `packages/js-sdk`: napi and wasm DTOs, `ExecuteResult.commit?: CommitSpan` (exported type), remote decoder validates a present span and tolerates its absence from older servers.
- CLI: `lix sql --json` emits `commit` for writes; the table output prints the span after `OK`.
- Docs: `docs/js-api-reference.md`, a cross-reference in `docs/diff-commands.md`. Changenote: `.changenotes/execute-commit-span.md` (minor).

Edge cases settled during review (two independent reviewer passes):
- A SQL restore (`INSERT INTO lix_restore …`) moves the head to a commit it did not author; `after` falls back to the restore target rather than reporting an equal span.
- Read-only batches that run on the transaction lane because a statement is nondeterministic (`SELECT uuidv7()`) carry no span; only batches that write do.
- If stale reconciliation moves a transaction onto a newer parent at commit, the idempotency receipt is re-encoded against that parent, so a replay returns the same span as the original response.
- A write that publishes no commit on the active branch (0 rows matched, or a global-only write) reports `before == after`. The first commit on a branch that had no head reports no span; documented.

Not in this PR: the span for explicit transactions, whose write is the `commit()` call. `TransactionCommitOutcome` already carries it; exposing it is a return-type change on `LixTransaction::commit` (200+ call sites) and can follow separately. Also not included: a test that exercises receipt re-encoding under a concurrent commit; the reconciliation path is covered by the existing certified-batch test and the re-encoding is a pure function of the reconciled head.

## Tests

- `session::execute::tests::write_results_carry_the_commit_span_they_published`: reads carry none; a write's `before` is the prior head and `after` the new head; the next write parents the previous `after`; `RETURNING` keeps rows and span; a batch's statements share one span.
- `session::execute::tests::spans_are_absent_where_nothing_auto_committed`: a 0-row write still reports where it stands; a restore reports its target; a nondeterministic read-only batch and a read-only batch carry none; a statement inside an explicit transaction carries none.
- `authority_client::wire::commit_span_tests`: the Rust remote client decodes responses with and without the field.
- `server_protocol::handler::tests::execute_responses_carry_the_commit_span_of_writes`: JSON shape on execute and execute-batch, absent on reads.
- `packages/e2e/tests/rust_sdk_api.rs::rs_sdk_writes_return_the_commit_span_they_published`: public Rust API.
- `packages/js-sdk/src/commit-span.test.ts` and `remote/server-protocol.test.ts`: JS SDK (write, read, batch, explicit transaction) and decoder, including the strict-when-present rule.

`cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt`, the CLI check, the session execute, server handler, idempotency, remote-client, observe, and sync test groups, and the JS SDK typecheck and tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
