### PR TITLE
Fix mixed-schema native commits and transaction terminal ownership

### DIFF
--- a/packages/js-sdk/src/lix-lifecycle.test.ts
+++ b/packages/js-sdk/src/lix-lifecycle.test.ts
@@ -144,3 +144,66 @@ function deferred<T>() {
 	});
 	return { promise, resolve, reject };
 }
+
+test.each(["commit", "rollback"] as const)(
+	"a pending %s exclusively owns the transaction until it settles",
+	async (kind) => {
+		const completion = deferred<void>();
+		const transactionBinding = {
+			execute: vi.fn(),
+			commit: vi.fn(async () => completion.promise),
+			rollback: vi.fn(async () => completion.promise),
+		};
+		const binding = {
+			beginTransaction: vi.fn(async () => transactionBinding),
+			close: vi.fn(async () => undefined),
+		} as unknown as LixBinding;
+		const lix = new Lix(binding);
+		const transaction = await lix.beginTransaction();
+		const finishing = transaction[kind]();
+		const closed = { code: "LIX_INVALID_TRANSACTION_STATE" };
+
+		await expect(transaction.commit()).rejects.toMatchObject(closed);
+		await expect(transaction.rollback()).rejects.toMatchObject(closed);
+		await expect(transaction.execute("SELECT 1")).rejects.toMatchObject(closed);
+		expect(transactionBinding.execute).not.toHaveBeenCalled();
+		expect(transactionBinding[kind]).toHaveBeenCalledOnce();
+		expect(
+			transactionBinding[kind === "commit" ? "rollback" : "commit"],
+		).not.toHaveBeenCalled();
+		await expect(lix.close()).rejects.toMatchObject(closed);
+
+		completion.resolve();
+		await finishing;
+		await lix.close();
+		expect(binding.close).toHaveBeenCalledOnce();
+	},
+);
+
+test.each(["commit", "rollback"] as const)(
+	"a failed %s preserves its error and consumes the transaction",
+	async (kind) => {
+		const failure = new Error(`${kind} failed`);
+		const transactionBinding = {
+			execute: vi.fn(),
+			commit: vi.fn(async () => {
+				throw failure;
+			}),
+			rollback: vi.fn(async () => {
+				throw failure;
+			}),
+		};
+		const binding = {
+			beginTransaction: vi.fn(async () => transactionBinding),
+			close: vi.fn(async () => undefined),
+		} as unknown as LixBinding;
+		const lix = new Lix(binding);
+		const transaction = await lix.beginTransaction();
+		await expect(transaction[kind]()).rejects.toBe(failure);
+		await expect(transaction.execute("SELECT 1")).rejects.toMatchObject({
+			code: "LIX_INVALID_TRANSACTION_STATE",
+		});
+		expect(transactionBinding.execute).not.toHaveBeenCalled();
+		await lix.close();
+	},
+);

--- a/packages/js-sdk/src/lix.ts
+++ b/packages/js-sdk/src/lix.ts
@@ -521,7 +521,6 @@ export class ObserveEvents {
 }
 
 export class LixTransaction {
-	private finishPromise: Promise<void> | undefined;
 	private finished = false;
 
 	constructor(
@@ -555,6 +554,7 @@ export class LixTransaction {
 		params: SqlParam[] = [],
 		options?: ExecuteOptions,
 	): Promise<ExecuteResult<ResultRow>> {
+		if (this.finished) throw transactionClosedError();
 		assertExecuteArgs("lixTransaction", sql, params, options);
 		const { rowMode = "object", ...bindingOptions } = options ?? {};
 		return wrapExecuteResult(
@@ -581,21 +581,18 @@ export class LixTransaction {
 		kind: "transaction.commit" | "transaction.rollback",
 	): Promise<void> {
 		if (this.finished) throw transactionClosedError();
-		if (!this.finishPromise) {
-			this.finishPromise = (async () => {
-				try {
-					if (kind === "transaction.commit") await this.binding.commit();
-					else await this.binding.rollback();
-				} finally {
-					// A terminal binding call consumes the underlying transaction even
-					// when its durable commit or rollback reports an error.
-					this.finished = true;
-					transactionFinalizer.unregister(this);
-					this.onFinish();
-				}
-			})();
+		// The first terminal call owns the handle immediately. In particular,
+		// a concurrent rollback must never report a pending commit's success.
+		this.finished = true;
+		try {
+			if (kind === "transaction.commit") await this.binding.commit();
+			else await this.binding.rollback();
+		} finally {
+			// Keep the parent transaction lease until the binding settles. A
+			// terminal call consumes the handle even when it reports an error.
+			transactionFinalizer.unregister(this);
+			this.onFinish();
 		}
-		await this.finishPromise;
 	}
 }
 

--- a/packages/lix/src/migration/api.rs
+++ b/packages/lix/src/migration/api.rs
@@ -1649,6 +1649,12 @@ fn validate_v74_registered_schema(
 }
 
 fn storage_error(error: StorageError) -> LixError {
+    // Repository open restarts a coherent read only when this typed storage
+    // classification survives migration context. Concurrent initialization
+    // may invalidate even the first format-marker inspection.
+    if matches!(error, StorageError::ReadExpired) {
+        return LixError::from(error);
+    }
     LixError::new(
         LixError::CODE_INTERNAL_ERROR,
         format!("repository migration storage error: {error}"),

--- a/packages/lix/src/migration/publish.rs
+++ b/packages/lix/src/migration/publish.rs
@@ -212,6 +212,11 @@ fn plan_error(message: impl Into<String>) -> LixError {
 }
 
 fn storage_error(error: StorageError) -> LixError {
+    // Preserve the restartable storage failure without conflating it with
+    // publication conflicts or an unknown durable commit outcome.
+    if matches!(error, StorageError::ReadExpired) {
+        return LixError::from(error);
+    }
     let code = match &error {
         StorageError::CommitOutcomeUnknown(_) => "LIX_ERROR_MIGRATION_COMMIT_OUTCOME_UNKNOWN",
         StorageError::PreconditionFailed(_)

--- a/packages/lix/src/plugin/wire/typed.rs
+++ b/packages/lix/src/plugin/wire/typed.rs
@@ -479,6 +479,10 @@ impl CertifiedNativeProjectionSegment {
         })
     }
 
+    pub(crate) fn into_validated_payloads(self) -> Box<[ValidatedNativePayload]> {
+        validated_payload_ranges(self.owner, self.payload_ranges)
+    }
+
     pub(crate) fn owner_len(&self) -> usize {
         self.owner.len()
     }
@@ -508,15 +512,42 @@ impl CertifiedNativeProjectionSegment {
     }
 }
 
-/// Fully validates native payload ranges once and records direct scalar
-/// locators. No schema or storage-envelope authority is inferred here.
+/// Wire validity does not imply a common layout. Both outcomes certify every
+/// payload; only a uniform segment can expose direct column locators.
+#[derive(Debug)]
+pub(crate) enum NativeProjectionCertification {
+    Uniform(CertifiedNativeProjectionSegment),
+    Heterogeneous(Box<[ValidatedNativePayload]>),
+}
+
+// Only called after every range passed full wire validation, or by consuming
+// an existing projection certificate. Never construct these proofs from input
+// whose remaining rows were skipped after a layout mismatch.
+fn validated_payload_ranges(
+    owner: NativePayloadOwner,
+    ranges: Box<[Range<u32>]>,
+) -> Box<[ValidatedNativePayload]> {
+    ranges
+        .into_iter()
+        .map(|range| ValidatedNativePayload {
+            bytes: owner.clone(),
+            range: range.start as usize..range.end as usize,
+        })
+        .collect()
+}
+
+/// Fully validates every native payload, retaining direct scalar locators when
+/// all rows share one layout. Layout differences disable projection, not wire
+/// validation: even a malformed row after a layout change must be rejected.
+/// No schema or storage-envelope authority is inferred here.
 pub(crate) fn certify_native_projection_segment(
     owner: NativePayloadOwner,
     payload_ranges: Box<[Range<u32>]>,
-) -> Result<CertifiedNativeProjectionSegment, Error> {
+) -> Result<NativeProjectionCertification, Error> {
     use std::cell::Cell;
 
     let row_capacity = payload_ranges.len();
+    let uniform = Cell::new(true);
     let mut schema_fingerprint = None;
     let mut key_kinds = Vec::new();
     let mut fields = Vec::<CertifiedNativeFieldShape>::new();
@@ -535,6 +566,9 @@ pub(crate) fn certify_native_projection_segment(
         let fingerprint = visit_native_row_payload(
             payload,
             |index, value| {
+                if !uniform.get() {
+                    return;
+                }
                 let Ok(value) = CertifiedNativeValue::from_borrowed(&owner, value) else {
                     invalid.set(Some("native key locator is outside its owner"));
                     return;
@@ -546,11 +580,14 @@ pub(crate) fn certify_native_projection_segment(
                 if row_ordinal == 0 {
                     key_kinds.push(kind);
                 } else if key_kinds.get(index) != Some(&kind) {
-                    invalid.set(Some("native primary-key layout differs between rows"));
+                    uniform.set(false);
                 }
                 keys.push(value);
             },
             |name, value| {
+                if !uniform.get() {
+                    return;
+                }
                 let field_ordinal = values.len().saturating_sub(value_start);
                 let Ok(value) = CertifiedNativeValue::from_borrowed(&owner, value) else {
                     invalid.set(Some("native field locator is outside its owner"));
@@ -564,20 +601,18 @@ pub(crate) fn certify_native_projection_segment(
                     });
                 } else if let Some(field) = fields.get_mut(field_ordinal) {
                     if field.name.as_ref() != name {
-                        invalid.set(Some("native field layout differs between rows"));
+                        uniform.set(false);
                     }
                     match value.kind() {
                         Some(kind) => match field.observed_non_null_kind {
-                            Some(expected) if expected != kind => {
-                                invalid.set(Some("native field scalar kind differs between rows"))
-                            }
+                            Some(expected) if expected != kind => uniform.set(false),
                             None => field.observed_non_null_kind = Some(kind),
                             _ => {}
                         },
                         None => field.saw_null = true,
                     }
                 } else {
-                    invalid.set(Some("native field count differs between rows"));
+                    uniform.set(false);
                 }
                 values.push(value);
             },
@@ -589,9 +624,7 @@ pub(crate) fn certify_native_projection_segment(
         let row_field_count = values.len().saturating_sub(value_start);
         if row_ordinal > 0 && (row_key_count != key_kinds.len() || row_field_count != fields.len())
         {
-            return Err(Error::Invalid(
-                "native row layout differs between segment members",
-            ));
+            uniform.set(false);
         }
         if row_ordinal == 0 {
             let remaining = row_capacity.saturating_sub(1);
@@ -600,13 +633,16 @@ pub(crate) fn certify_native_projection_segment(
         }
         if let Some(expected) = schema_fingerprint {
             if expected != fingerprint {
-                return Err(Error::Invalid(
-                    "native schema fingerprint differs between segment members",
-                ));
+                uniform.set(false);
             }
         } else {
             schema_fingerprint = Some(fingerprint);
             key_field_equal.resize(row_key_count.saturating_mul(row_field_count), true);
+        }
+        if !uniform.get() {
+            // The full visitor continues validating subsequent rows without
+            // retaining unused projection locators.
+            continue;
         }
         for (key_ordinal, key) in keys[key_start..].iter().enumerate() {
             let row_fields = &values[value_start..];
@@ -621,17 +657,24 @@ pub(crate) fn certify_native_projection_segment(
     let schema_fingerprint = schema_fingerprint.ok_or(Error::Invalid(
         "native projection segment must contain at least one row",
     ))?;
-    Ok(CertifiedNativeProjectionSegment {
-        owner,
-        payload_ranges,
-        schema_fingerprint,
-        key_kinds: key_kinds.into_boxed_slice(),
-        fields: fields.into_boxed_slice(),
-        keys: keys.into_boxed_slice(),
-        values: values.into_boxed_slice(),
-        key_field_equal: key_field_equal.into_boxed_slice(),
-        row_count,
-    })
+    if !uniform.get() {
+        return Ok(NativeProjectionCertification::Heterogeneous(
+            validated_payload_ranges(owner, payload_ranges),
+        ));
+    }
+    Ok(NativeProjectionCertification::Uniform(
+        CertifiedNativeProjectionSegment {
+            owner,
+            payload_ranges,
+            schema_fingerprint,
+            key_kinds: key_kinds.into_boxed_slice(),
+            fields: fields.into_boxed_slice(),
+            keys: keys.into_boxed_slice(),
+            values: values.into_boxed_slice(),
+            key_field_equal: key_field_equal.into_boxed_slice(),
+            row_count,
+        },
+    ))
 }
 
 /// Validates and streams a durable native row without constructing an owned
@@ -1953,6 +1996,9 @@ mod tests {
         )
         .expect("uniform native segment certifies");
 
+        let super::NativeProjectionCertification::Uniform(certified) = certified else {
+            panic!("uniform native segment must retain its projection");
+        };
         assert_eq!(certified.row_count(), 2);
         assert_eq!(certified.schema_fingerprint(), [7; 32]);
         assert_eq!(
@@ -1988,7 +2034,7 @@ mod tests {
     }
 
     #[test]
-    fn projection_certificate_rejects_mixed_fingerprints() {
+    fn projection_certificate_retains_mixed_fingerprints_as_validated_rows() {
         let value: lix_schema::Jsonb = serde_json::json!(null).into();
         let first = super::encode_native_path_value_payload(&[1; 32], "/a", &value)
             .expect("first native row encodes");
@@ -2004,12 +2050,132 @@ mod tests {
                 end: u32::try_from(first.len() + second.len()).unwrap(),
             },
         ];
-        let error = super::certify_native_projection_segment(
+        let expected = [first.clone(), second.clone()];
+        let certified = super::certify_native_projection_segment(
             bytes::Bytes::from([first, second].concat()),
             Box::new(ranges),
         )
-        .expect_err("mixed fingerprints must not certify");
-        assert!(matches!(error, super::Error::Invalid(_)));
+        .expect("mixed fingerprints are valid native rows");
+        let super::NativeProjectionCertification::Heterogeneous(rows) = certified else {
+            panic!("mixed fingerprints must not share a projection");
+        };
+        for (row, expected) in rows.iter().zip(expected) {
+            assert_eq!(row.as_bytes(), expected);
+        }
+    }
+
+    #[test]
+    fn heterogeneous_projection_validates_all_layouts_and_the_entire_tail() {
+        use super::{NativeProjectionCertification, certify_native_projection_segment};
+
+        let encode = |key: Vec<Value>, row: Row| {
+            super::encode_native_row_payload_with_identity(&[9; 32], &key, &row).unwrap()
+        };
+        let first = encode(
+            vec![Value::Text("a".into())],
+            Row::from([("value", Value::Text("one".into()))]),
+        );
+        // These all have valid wire encodings but cannot use the first row's
+        // locators. A schema fingerprint alone is not a layout proof.
+        let variants = [
+            encode(
+                vec![Value::Text("b".into())],
+                Row::from([
+                    ("value", Value::Text("two".into())),
+                    ("extra", Value::Boolean(true)),
+                ]),
+            ),
+            encode(
+                vec![Value::Text("b".into())],
+                Row::from([("other", Value::Text("two".into()))]),
+            ),
+            encode(
+                vec![Value::Text("b".into())],
+                Row::from([("value", Value::Int8(2))]),
+            ),
+            encode(
+                vec![Value::Int8(2)],
+                Row::from([("value", Value::Text("two".into()))]),
+            ),
+            encode(
+                vec![Value::Text("b".into()), Value::Int8(2)],
+                Row::from([("value", Value::Text("two".into()))]),
+            ),
+            super::encode_native_row_payload(
+                &[9; 32],
+                &[Value::Text("b".into())],
+                &Row::from([("value", Value::Text("two".into()))]),
+            )
+            .unwrap(),
+        ];
+        let certify = |rows: &[Vec<u8>]| {
+            let mut owner = Vec::new();
+            let ranges = rows
+                .iter()
+                .map(|row| {
+                    let start = owner.len() as u32;
+                    owner.extend_from_slice(row);
+                    start..owner.len() as u32
+                })
+                .collect();
+            certify_native_projection_segment(bytes::Bytes::from(owner), ranges)
+        };
+        for other in variants {
+            // Exercise both more/fewer fields and native/storage ordering.
+            for pair in [
+                [first.clone(), other.clone()],
+                [other.clone(), first.clone()],
+            ] {
+                let NativeProjectionCertification::Heterogeneous(validated) =
+                    certify(&pair).expect("layout diversity is valid wire")
+                else {
+                    panic!("different layouts must not share column locators");
+                };
+                for (row, expected) in validated.iter().zip(&pair) {
+                    assert_eq!(row.as_bytes(), expected);
+                }
+                let mut malformed = first.clone();
+                malformed.push(0);
+                assert!(
+                    certify(&[pair[0].clone(), pair[1].clone(), malformed]).is_err(),
+                    "layout ineligibility must not skip malformed trailing rows"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn projection_certificate_preserves_nullable_uniform_columns() {
+        let first = super::encode_native_row_payload(
+            &[4; 32],
+            &[Value::Text("row".into())],
+            &Row::from([("value", Value::Null)]),
+        )
+        .unwrap();
+        let second = super::encode_native_row_payload(
+            &[4; 32],
+            &[Value::Text("row".into())],
+            &Row::from([("value", Value::Text("present".into()))]),
+        )
+        .unwrap();
+        let split = first.len() as u32;
+        let end = split + second.len() as u32;
+        let certified = super::certify_native_projection_segment(
+            bytes::Bytes::from([first, second].concat()),
+            Box::new([0..split, split..end]),
+        )
+        .unwrap();
+        let super::NativeProjectionCertification::Uniform(projection) = certified else {
+            panic!("null is compatible with the observed non-null kind");
+        };
+        assert_eq!(
+            projection.field_value(0, 0),
+            Some(super::BorrowedNativeValue::Null)
+        );
+        assert_eq!(
+            projection.field_value(1, 0),
+            Some(super::BorrowedNativeValue::Text("present"))
+        );
     }
 
     #[test]

--- a/packages/lix/src/schema/tests.rs
+++ b/packages/lix/src/schema/tests.rs
@@ -188,3 +188,169 @@ async fn postgresql_jsonb_syntax_registers_queries_and_updates_rows() {
         .expect_err("PostgreSQL JSONB rejects Unicode NUL");
     assert!(nul_error.message.contains("NUL"), "{nul_error:?}");
 }
+
+// Paraglide creates three different row layouts per translation. 171 translations
+// cross the 512-row native segment boundary; insertion order must not change
+// whether those layouts can coexist in one commit.
+async fn mixed_schema_segment_roundtrip(count: usize, order: &str) {
+    use crate::{Value, engine::Engine, storage::Memory};
+
+    let storage = Memory::new();
+    Engine::initialize(storage.clone()).await.unwrap();
+    let engine = Engine::new(storage.clone()).await.unwrap();
+    let session = engine.open_session().await.unwrap();
+    let layouts = [
+        ("acme_bundle", json!([])),
+        (
+            "acme_message",
+            json!([{ "name": "body", "type": "text", "nullable": false }]),
+        ),
+        (
+            "acme_variant",
+            json!([
+                { "name": "rank", "type": "int8", "nullable": false },
+                { "name": "payload", "type": "jsonb", "nullable": false }
+            ]),
+        ),
+    ];
+    for (key, extra) in layouts {
+        let mut columns = vec![json!({ "name": "id", "type": "text", "nullable": false })];
+        columns.extend(extra.as_array().unwrap().iter().cloned());
+        let definition = json!({
+            "$schema": "https://lix.dev/schema-v1.json",
+            "key": key, "columns": columns, "primary_key": ["id"]
+        });
+        session
+            .execute(
+                "INSERT INTO lix_registered_schema (schema_key, value) VALUES ($1, $2)",
+                &[Value::Text(key.into()), Value::Jsonb(definition.into())],
+            )
+            .await
+            .unwrap();
+    }
+    let mut ids: Vec<_> = (0..count).collect();
+    match order {
+        "swapped" => ids.swap(0, 1),
+        "reversed" => ids.reverse(),
+        "sorted" => {}
+        _ => unreachable!(),
+    }
+    let mut tx = session.begin_transaction().await.unwrap();
+    for (table, columns) in [
+        ("acme_bundle", "id"),
+        ("acme_message", "id, body"),
+        ("acme_variant", "id, rank, payload"),
+    ] {
+        let values = ids
+            .iter()
+            .map(|id| match table {
+                "acme_bundle" => format!("('key_{id:04}')"),
+                "acme_message" => format!("('key_{id:04}', 'message {id}')"),
+                _ => format!("('key_{id:04}', {id}, '{{\"index\":{id}}}'::jsonb)"),
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        tx.execute(
+            &format!("INSERT INTO {table} ({columns}) VALUES {values}"),
+            &[],
+        )
+        .await
+        .unwrap();
+    }
+    tx.commit().await.unwrap();
+    let queries = [
+        "SELECT id FROM acme_bundle ORDER BY id",
+        "SELECT id, body FROM acme_message ORDER BY id",
+        "SELECT id, rank, payload FROM acme_variant ORDER BY id",
+    ];
+    let mut expected = Vec::new();
+    for (layout, query) in queries.iter().enumerate() {
+        let result = session.execute(query, &[]).await.unwrap();
+        assert_eq!(result.rows().len(), count);
+        for (id, row) in result.rows().iter().enumerate() {
+            let mut values = vec![Value::Text(format!("key_{id:04}"))];
+            match layout {
+                0 => {}
+                1 => values.push(Value::Text(format!("message {id}"))),
+                2 => values.extend([
+                    Value::Integer(id as i64),
+                    Value::Jsonb(json!({"index": id}).into()),
+                ]),
+                _ => unreachable!(),
+            }
+            assert_eq!(row.values(), values);
+        }
+        expected.push(result);
+    }
+    drop(session);
+    drop(engine);
+    let engine = Engine::new(storage.clone()).await.unwrap();
+    let session = engine.open_session().await.unwrap();
+    for (query, expected) in queries.into_iter().zip(&expected) {
+        assert_eq!(
+            session.execute(query, &[]).await.unwrap().rows(),
+            expected.rows()
+        );
+    }
+    // Rewrite a persisted mixed-layout root, including tombstones and JSONB.
+    let mut tx = session.begin_transaction().await.unwrap();
+    tx.execute("UPDATE acme_message SET body = 'updated'", &[])
+        .await
+        .unwrap();
+    tx.execute(
+        "UPDATE acme_variant SET payload = '{\"updated\":true}'::jsonb",
+        &[],
+    )
+    .await
+    .unwrap();
+    tx.execute("DELETE FROM acme_bundle WHERE id = 'key_0000'", &[])
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    let updated_queries = [
+        "SELECT id FROM acme_bundle ORDER BY id",
+        "SELECT id FROM acme_message WHERE body = 'updated' ORDER BY id",
+        "SELECT id FROM acme_variant WHERE payload ->> 'updated' = 'true' ORDER BY id",
+    ];
+    let mut updated = Vec::new();
+    for (index, query) in updated_queries.iter().enumerate() {
+        let result = session.execute(query, &[]).await.unwrap();
+        assert_eq!(result.rows().len(), count - usize::from(index == 0));
+        updated.push(result);
+    }
+    drop(session);
+    drop(engine);
+    let reopened = Engine::new(storage).await.unwrap();
+    let session = reopened.open_session().await.unwrap();
+    for (query, expected) in updated_queries.into_iter().zip(updated) {
+        assert_eq!(
+            session.execute(query, &[]).await.unwrap().rows(),
+            expected.rows()
+        );
+    }
+}
+
+#[tokio::test]
+async fn mixed_schema_segment_170_sorted() {
+    mixed_schema_segment_roundtrip(170, "sorted").await;
+}
+
+#[tokio::test]
+async fn mixed_schema_segment_171_sorted() {
+    mixed_schema_segment_roundtrip(171, "sorted").await;
+}
+
+#[tokio::test]
+async fn mixed_schema_segment_171_swapped() {
+    mixed_schema_segment_roundtrip(171, "swapped").await;
+}
+
+#[tokio::test]
+async fn mixed_schema_segment_171_reversed() {
+    mixed_schema_segment_roundtrip(171, "reversed").await;
+}
+
+#[tokio::test]
+async fn mixed_schema_segment_400_sorted() {
+    mixed_schema_segment_roundtrip(400, "sorted").await;
+}

--- a/packages/lix/src/tracked_state/replacement_part.rs
+++ b/packages/lix/src/tracked_state/replacement_part.rs
@@ -796,28 +796,34 @@ pub(crate) fn decode_native_replacement_part(
     encoded: Bytes,
 ) -> Result<Option<Arc<PreparedReplacementNativePart>>, LixError> {
     let decoded = decode_raw_replacement_part(expected_digest, encoded)?;
-    if decoded.payload_ranges.iter().any(|range| {
-        !matches!(
-            decoded.payload_arena.get(range.start).copied(),
+    let owner = decoded.payload_arena.clone();
+    let mut payloads = Vec::with_capacity(decoded.payload_ranges.len());
+    for range in &decoded.payload_ranges {
+        if !matches!(
+            owner.get(range.start).copied(),
             Some(crate::plugin::wire::typed::NATIVE_ROW_PAYLOAD_VERSION)
                 | Some(crate::plugin::wire::typed::STORAGE_ROW_PAYLOAD_VERSION)
-        )
-    }) {
+        ) {
+            continue;
+        }
+        // Projection eligibility is separate from wire validity. Even when a
+        // non-native member prevents this fast path, malformed native members
+        // must fail validation rather than disappear into the fallback.
+        payloads.push(
+            crate::plugin::wire::typed::ValidatedNativePayload::try_new_range(
+                owner.clone(),
+                range.clone(),
+            )
+            .map_err(|error| {
+                replacement_part_error(format!(
+                    "native payload failed canonical wire validation: {error:?}"
+                ))
+            })?,
+        );
+    }
+    if payloads.len() != decoded.payload_ranges.len() {
         return Ok(None);
     }
-    let owner = decoded.payload_arena.clone();
-    let Ok(payloads) = decoded
-        .payload_ranges
-        .iter()
-        .cloned()
-        .map(|range| {
-            crate::plugin::wire::typed::ValidatedNativePayload::try_new_range(owner.clone(), range)
-                .map_err(|_| ())
-        })
-        .collect::<Result<Vec<_>, _>>()
-    else {
-        return Ok(None);
-    };
     Ok(Some(Arc::new(PreparedReplacementNativePart {
         key_arena: decoded.key_arena,
         key_ranges: decoded.key_ranges,
@@ -1105,6 +1111,91 @@ mod tests {
                 .expect("native descriptor should be recognized");
         assert_eq!(decoded_native.key(0), Some(b"typed-row".as_slice()));
         assert_eq!(decoded_native.payload(0).unwrap().as_bytes(), payload);
+    }
+
+    #[test]
+    fn native_part_rejects_malformed_wire_even_with_non_native_members() {
+        use crate::plugin::wire::typed::{NATIVE_ROW_PAYLOAD_VERSION, STORAGE_ROW_PAYLOAD_VERSION};
+
+        for version in [NATIVE_ROW_PAYLOAD_VERSION, STORAGE_ROW_PAYLOAD_VERSION] {
+            let malformed = [version];
+            for snapshots in [
+                vec![malformed.as_slice()],
+                vec![b"typed".as_slice(), malformed.as_slice()],
+                vec![malformed.as_slice(), b"typed".as_slice()],
+            ] {
+                let keys = [b"alpha".as_slice(), b"beta".as_slice()];
+                let rows = snapshots
+                    .iter()
+                    .zip(keys)
+                    .map(|(snapshot, encoded_key)| ReplacementPartRowRef {
+                        encoded_key,
+                        metadata: None,
+                        snapshot,
+                    })
+                    .collect::<Vec<_>>();
+                let encoded = encode_replacement_part(&rows).expect("physical part encodes");
+                let error = super::decode_native_replacement_part(
+                    encoded.digest(),
+                    encoded.bytes().clone(),
+                )
+                .expect_err("malformed native wire must not select the fallback");
+                assert!(error.message.contains("canonical wire validation"));
+            }
+        }
+    }
+
+    #[test]
+    fn native_part_accepts_heterogeneous_rows_and_falls_back_for_non_native_wire() {
+        let first = crate::plugin::wire::typed::encode_native_row_payload_with_identity(
+            &[1; 32],
+            &[lix_schema::Value::Text("alpha".to_owned())],
+            &lix_schema::Row::from([("id", lix_schema::Value::Text("alpha".to_owned()))]),
+        )
+        .expect("native payload encodes");
+        let second = crate::plugin::wire::typed::encode_native_row_payload(
+            &[2; 32],
+            &[lix_schema::Value::Int8(42)],
+            &lix_schema::Row::from([
+                ("id", lix_schema::Value::Int8(42)),
+                ("value", lix_schema::Value::Boolean(true)),
+            ]),
+        )
+        .expect("storage payload encodes");
+        let rows = [
+            ReplacementPartRowRef {
+                encoded_key: b"alpha",
+                metadata: None,
+                snapshot: &first,
+            },
+            ReplacementPartRowRef {
+                encoded_key: b"beta",
+                metadata: None,
+                snapshot: &second,
+            },
+        ];
+        let encoded = encode_replacement_part(&rows).expect("heterogeneous part encodes");
+        let decoded =
+            super::decode_native_replacement_part(encoded.digest(), encoded.bytes().clone())
+                .expect("heterogeneous native wire is valid")
+                .expect("all rows carry native wire proofs");
+        assert_eq!(decoded.payload(0).unwrap().as_bytes(), first);
+        assert_eq!(decoded.payload(1).unwrap().as_bytes(), second);
+
+        let rows = [
+            rows[0],
+            ReplacementPartRowRef {
+                encoded_key: b"beta",
+                metadata: None,
+                snapshot: b"typed",
+            },
+        ];
+        let encoded = encode_replacement_part(&rows).expect("mixed part encodes");
+        assert!(
+            super::decode_native_replacement_part(encoded.digest(), encoded.bytes().clone())
+                .expect("valid mixed part is not corruption")
+                .is_none()
+        );
     }
 
     #[test]

--- a/packages/lix/src/tracked_state/storage.rs
+++ b/packages/lix/src/tracked_state/storage.rs
@@ -17,8 +17,8 @@ use crate::changelog::{
 };
 use crate::common::SharedStr;
 use crate::plugin::wire::typed::{
-    BorrowedNativeValue, CertifiedNativeProjectionSegment, ValidatedNativePayload,
-    certify_native_projection_segment,
+    BorrowedNativeValue, CertifiedNativeProjectionSegment, NativeProjectionCertification,
+    ValidatedNativePayload, certify_native_projection_segment, visit_validated_native_row_payload,
 };
 use crate::row_pk::RowPk;
 use crate::storage_adapter::{
@@ -2099,49 +2099,115 @@ fn validate_native_commit_delta_payloads(
             all_native = false;
             continue;
         }
-        native_ranges.push(
+        native_ranges.push((
+            ordinal,
             u32::try_from(range.start)
                 .map_err(|_| replacement_payload_error("native payload offset exceeds u32"))?
                 ..u32::try_from(range.end).map_err(|_| {
                     replacement_payload_error("native payload end offset exceeds u32")
                 })?,
-        );
+        ));
     }
     if native_ranges.is_empty() {
         return Ok((None, None));
     }
     let owner = payloads.sidecar.clone();
     if all_native {
-        let projection =
-            certify_native_projection_segment(owner.clone(), native_ranges.into_boxed_slice())
-                .map_err(|error| {
-                    replacement_payload_error(&format!(
-                        "native commit-delta projection certification failed: {error:?}"
-                    ))
-                })?;
-        let certified_native_projection =
-            bind_native_projection_to_leaf(leaf, projection)?.map(Arc::new);
-        return Ok((None, certified_native_projection));
+        let certification = certify_native_projection_segment(
+            owner.clone(),
+            native_ranges.into_iter().map(|(_, range)| range).collect(),
+        )
+        .map_err(|error| {
+            replacement_payload_error(&format!(
+                "native commit-delta payload failed canonical wire validation: {error:?}"
+            ))
+        })?;
+        let validated = match certification {
+            NativeProjectionCertification::Uniform(projection) => {
+                if let Some((scope, outer_row_keys)) =
+                    bind_native_projection_to_leaf(leaf, &projection)?
+                {
+                    return Ok((
+                        None,
+                        Some(Arc::new(EnvelopeCertifiedNativeProjectionSegment {
+                            projection,
+                            scope,
+                            outer_row_keys,
+                            arrow_columns: OnceLock::new(),
+                        })),
+                    ));
+                }
+                projection.into_validated_payloads()
+            }
+            NativeProjectionCertification::Heterogeneous(validated) => validated,
+        };
+        for (ordinal, payload) in validated.iter().enumerate() {
+            validate_native_payload_identity(leaf, ordinal, payload)?;
+        }
+        return Ok((Some(Arc::from(validated)), None));
     }
-    let validated = native_ranges
-        .into_iter()
-        .map(|range| {
-            let range = usize::try_from(range.start).expect("u32 payload offset fits usize")
-                ..usize::try_from(range.end).expect("u32 payload offset fits usize");
+    native_ranges.into_iter().try_for_each(|(ordinal, range)| {
+        let range = usize::try_from(range.start).expect("u32 payload offset fits usize")
+            ..usize::try_from(range.end).expect("u32 payload offset fits usize");
+        let payload =
             ValidatedNativePayload::try_new_range(owner.clone(), range).map_err(|error| {
                 replacement_payload_error(&format!(
                     "native commit-delta payload failed canonical wire validation: {error:?}"
                 ))
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok((Some(Arc::from(validated)).filter(|_| all_native), None))
+            })?;
+        validate_native_payload_identity(leaf, ordinal, &payload)
+    })?;
+    Ok((None, None))
+}
+
+/// Embedded native keys must agree with their durable identity regardless of
+/// whether neighboring rows can share a projection. Storage payloads omit keys.
+fn validate_native_payload_identity(
+    leaf: &DecodedLeafNodeRef,
+    ordinal: usize,
+    payload: &ValidatedNativePayload,
+) -> Result<(), LixError> {
+    if payload.as_bytes().first() == Some(&crate::plugin::wire::typed::STORAGE_ROW_PAYLOAD_VERSION)
+    {
+        return Ok(());
+    }
+    let encoded_key = leaf
+        .key_owned(ordinal)
+        .ok_or_else(|| replacement_payload_error("native payload leaf omitted an identity"))?;
+    let decoded = decode_key_shared(encoded_key).map_err(|error| {
+        replacement_payload_error(&format!("native payload leaf identity is invalid: {error}"))
+    })?;
+    let mut key_count = 0;
+    let mut matches = true;
+    visit_validated_native_row_payload(
+        payload,
+        |index, value| {
+            key_count += 1;
+            matches &= decoded
+                .row_pk
+                .components
+                .get(index)
+                .is_some_and(|component| native_key_matches_row_pk(value, component));
+        },
+        |_, _| {},
+    )
+    .map_err(|error| {
+        replacement_payload_error(&format!(
+            "native payload identity cannot be read: {error:?}"
+        ))
+    })?;
+    if !matches || key_count != decoded.row_pk.components.len() {
+        return Err(replacement_payload_error(
+            "native payload key disagrees with its immutable leaf identity",
+        ));
+    }
+    Ok(())
 }
 
 fn bind_native_projection_to_leaf(
     leaf: &DecodedLeafNodeRef,
-    projection: CertifiedNativeProjectionSegment,
-) -> Result<Option<EnvelopeCertifiedNativeProjectionSegment>, LixError> {
+    projection: &CertifiedNativeProjectionSegment,
+) -> Result<Option<(CommitDeltaReplacementScope, Option<EncodedOuterRowKeys>)>, LixError> {
     if leaf.len() != projection.row_count() {
         return Err(replacement_payload_error(
             "native projection row count disagrees with its immutable leaf",
@@ -2194,12 +2260,7 @@ fn bind_native_projection_to_leaf(
                 ));
             }
         }
-        return Ok(Some(EnvelopeCertifiedNativeProjectionSegment {
-            projection,
-            scope,
-            outer_row_keys: Some(EncodedOuterRowKeys { owner, ranges }),
-            arrow_columns: OnceLock::new(),
-        }));
+        return Ok(Some((scope, Some(EncodedOuterRowKeys { owner, ranges }))));
     }
     let mut scope = None::<CommitDeltaReplacementScope>;
     let mut identity_prefix = None::<Vec<u8>>;
@@ -2254,12 +2315,7 @@ fn bind_native_projection_to_leaf(
             ));
         }
     }
-    Ok(scope.map(|scope| EnvelopeCertifiedNativeProjectionSegment {
-        projection,
-        scope,
-        outer_row_keys: None,
-        arrow_columns: OnceLock::new(),
-    }))
+    Ok(scope.map(|scope| (scope, None)))
 }
 
 fn native_key_matches_row_pk(
@@ -18221,7 +18277,10 @@ mod tests {
         )
         .expect("wire-valid payload certifies");
 
-        let error = super::bind_native_projection_to_leaf(&leaf, projection)
+        let super::NativeProjectionCertification::Uniform(projection) = projection else {
+            panic!("single native row must have a uniform projection");
+        };
+        let error = super::bind_native_projection_to_leaf(&leaf, &projection)
             .expect_err("mismatched envelope identity must reject");
         assert!(error.message.contains("disagrees"));
     }
@@ -18441,6 +18500,204 @@ mod tests {
             super::admit_new_authored_typed_commit_delta_segment(encode(&invalid), &mut bounds)
                 .is_err(),
             "self-consistent physical storage cannot cache an invalid native payload"
+        );
+    }
+
+    fn check_native_segment_validation(
+        rows: &[(&str, Option<&str>, &str, &[u8])],
+        check: impl Fn(Result<std::sync::Arc<DecodedCommitDeltaSegment>, LixError>),
+    ) {
+        let commit_id = CommitId::for_test_label("native-segment-validation");
+        let entries = rows
+            .iter()
+            .enumerate()
+            .map(
+                |(ordinal, (schema_key, file_id, row_key, _))| EncodedLeafEntry {
+                    key: encode_key_ref(TrackedStateKeyRef {
+                        schema_key,
+                        file_id: *file_id,
+                        row_pk: &RowPk::single(*row_key),
+                    })
+                    .into(),
+                    value: encode_value_ref(TrackedStateIndexValueRef {
+                        change_id: super::change_id_from_packed_address(
+                            commit_id,
+                            ordinal as u32 + 1,
+                        ),
+                        commit_id,
+                        deleted: false,
+                        created_at: LixTimestamp::from_unix_millis_utc_lossy(1),
+                        updated_at: LixTimestamp::from_unix_millis_utc_lossy(2),
+                    })
+                    .into(),
+                },
+            )
+            .collect::<Vec<_>>();
+        let payloads = rows
+            .iter()
+            .map(|(_, _, _, snapshot)| CommitDeltaPayloadRef {
+                metadata: None,
+                snapshot: Some(snapshot),
+                origin_key: None,
+                base_coordinate: None,
+                authored: true,
+            })
+            .collect::<Vec<_>>();
+        let encoded = try_encode_commit_delta_segment_with_payloads(&entries, &payloads, &mut None)
+            .map_err(CommitDeltaSegmentEncodeError::into_lix_error)
+            .expect("native validation fixture physically encodes");
+        let bounds = CommitDeltaSegmentBounds {
+            first_key: entries.first().unwrap().key.to_vec(),
+            last_key: entries.last().unwrap().key.to_vec(),
+            replacement_part: None,
+            content_digest: [0; 32],
+        };
+        // Eager write-through admission and cold durable reads must agree.
+        check(super::decode_owned_commit_delta_segment(
+            &encoded.encoded,
+            Some(&bounds),
+        ));
+        check(
+            prepare_new_authored_typed_commit_delta_segment(encoded, &bounds)
+                .map(|(_, decoded)| decoded.expect("authored native segment is eagerly prepared")),
+        );
+    }
+
+    #[test]
+    fn native_segment_retains_heterogeneous_wire_proofs() {
+        let first = crate::plugin::wire::typed::encode_native_row_payload_with_identity(
+            &[1; 32],
+            &[lix_schema::Value::Text("a".into())],
+            &lix_schema::Row::from([("id", lix_schema::Value::Text("a".into()))]),
+        )
+        .unwrap();
+        let second = crate::plugin::wire::typed::encode_native_row_payload_with_identity(
+            &[2; 32],
+            &[lix_schema::Value::Text("b".into())],
+            &lix_schema::Row::from([
+                ("id", lix_schema::Value::Text("b".into())),
+                ("value", lix_schema::Value::Boolean(true)),
+            ]),
+        )
+        .unwrap();
+        check_native_segment_validation(
+            &[("alpha", None, "a", &first), ("beta", None, "b", &second)],
+            |result| {
+                let decoded = result.expect("heterogeneous native rows are valid");
+                assert!(decoded.certified_native_projection.is_none());
+                assert_eq!(decoded.validated_native_payloads.as_ref().unwrap().len(), 2);
+                assert_eq!(
+                    decoded
+                        .validated_native_payload_owned(0)
+                        .unwrap()
+                        .as_bytes(),
+                    first
+                );
+                assert_eq!(
+                    decoded
+                        .validated_native_payload_owned(1)
+                        .unwrap()
+                        .as_bytes(),
+                    second
+                );
+            },
+        );
+        check_native_segment_validation(
+            &[
+                ("alpha", None, "a", &first),
+                ("beta", None, "b", &second),
+                (
+                    "gamma",
+                    None,
+                    "c",
+                    &[crate::plugin::wire::typed::STORAGE_ROW_PAYLOAD_VERSION],
+                ),
+            ],
+            |result| {
+                assert!(
+                    result
+                        .expect_err("heterogeneity cannot hide corrupt tail wire")
+                        .message
+                        .contains("canonical wire validation")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn native_segment_retains_uniform_payload_proofs_across_file_scopes() {
+        let payload = crate::plugin::wire::typed::encode_native_row_payload_with_identity(
+            &[1; 32],
+            &[lix_schema::Value::Text("a".into())],
+            &lix_schema::Row::from([("id", lix_schema::Value::Text("a".into()))]),
+        )
+        .unwrap();
+        check_native_segment_validation(
+            &[
+                ("schema", Some("file-a"), "a", &payload),
+                ("schema", Some("file-b"), "a", &payload),
+            ],
+            |result| {
+                let decoded = result.expect("uniform rows in different scopes are valid");
+                assert!(decoded.certified_native_projection.is_none());
+                assert_eq!(decoded.validated_native_payloads.as_ref().unwrap().len(), 2);
+                for ordinal in 0..2 {
+                    assert_eq!(
+                        decoded
+                            .validated_native_payload_owned(ordinal)
+                            .unwrap()
+                            .as_bytes(),
+                        payload
+                    );
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn native_segment_checks_identity_independently_of_projection_eligibility() {
+        let native = crate::plugin::wire::typed::encode_native_row_payload_with_identity(
+            &[1; 32],
+            &[lix_schema::Value::Text("payload".into())],
+            &lix_schema::Row::from([("id", lix_schema::Value::Text("payload".into()))]),
+        )
+        .unwrap();
+        let storage = crate::plugin::wire::typed::encode_native_row_payload(
+            &[2; 32],
+            &[lix_schema::Value::Text("a".into())],
+            &lix_schema::Row::from([("id", lix_schema::Value::Text("a".into()))]),
+        )
+        .unwrap();
+        for neighbor in [storage.as_slice(), b"generic".as_slice()] {
+            check_native_segment_validation(
+                &[
+                    ("schema", None, "a", neighbor),
+                    ("schema", None, "b", &native),
+                ],
+                |result| {
+                    assert!(
+                        result
+                            .expect_err("native key mismatch must reject every layout")
+                            .message
+                            .contains("disagrees")
+                    );
+                },
+            );
+        }
+        // A uniform layout with different scopes also takes the row-proof path.
+        check_native_segment_validation(
+            &[
+                ("schema", Some("file-a"), "payload", &native),
+                ("schema", Some("file-b"), "wrong", &native),
+            ],
+            |result| {
+                assert!(
+                    result
+                        .expect_err("scope differences cannot hide identity mismatches")
+                        .message
+                        .contains("disagrees")
+                );
+            },
         );
     }
 

--- a/packages/lix/tests/integration/read_retry.rs
+++ b/packages/lix/tests/integration/read_retry.rs
@@ -224,6 +224,35 @@ async fn repository_open_restarts_after_its_snapshot_expires() {
 }
 
 #[tokio::test]
+async fn fresh_repository_open_restarts_each_early_coherent_read() {
+    // Two OPFS clients can race while admitting an empty repository: a commit
+    // from one expires the other's format-marker inspection. Exercise every
+    // early read, including inspection before an epoch has been published.
+    for calls_before_expiry in 0..12 {
+        let storage = ExpiringReadStorage::new();
+        storage.expire_read_call_after(calls_before_expiry);
+        let lix = crate::open_lix()
+            .with_storage(storage.clone())
+            .await
+            .unwrap_or_else(|error| {
+                panic!("fresh admission must restart after read {calls_before_expiry}: {error:?}")
+            });
+        assert_eq!(
+            storage.expired_calls(),
+            1,
+            "read {calls_before_expiry} must expire"
+        );
+        lix.execute(
+            "INSERT INTO lix_key_value (key, value) VALUES ('admission-retry', 'ready')",
+            &[],
+        )
+        .await
+        .expect("restarted admission leaves a writable repository");
+        lix.close().await.expect("close initialized repository");
+    }
+}
+
+#[tokio::test]
 async fn initialized_repository_reopen_restarts_each_early_coherent_read() {
     let storage = ExpiringReadStorage::new();
     crate::open_lix()


### PR DESCRIPTION
Compiling 171 sorted messages creates 513 bundle/message/variant rows and fails when an ordered commit segment tries to certify their different layouts as one native projection. Smaller or reordered imports avoid that path. Native wire validity and uniform projection eligibility are now separate outcomes: heterogeneous rows retain their validation proofs, while homogeneous rows keep direct column locators.

Validate every row even after a layout mismatch, retain proofs when a uniform layout spans multiple file scopes, and check embedded row identities independently of projection eligibility. The compact replacement decoder now rejects malformed native wire instead of silently selecting another decoder, including when native and non-native rows coexist.

Preserve the typed expired-read error through migration inspection and publication. Concurrent OPFS initialization can invalidate the initial format-marker read; the existing whole-open retry now receives that classification instead of a generic internal error. A deterministic regression expires each of the first twelve fresh-admission reads and verifies the recovered repository remains writable.

The related transaction audit also fixes the JS transaction wrapper: the first commit or rollback consumes the public handle immediately, subsequent terminal calls and queries reject, and the parent lease stays held until the binding settles. A concurrent rollback can no longer report a pending commit's success. The inlang adapter's masking error and connection ownership bugs are addressed in companion https://github.com/opral/inlang/pull/4414.

Addresses https://github.com/opral/inlang/issues/4413 together with the companion adapter PR.

Validation:
- Full engine suite: `cargo nextest run -p lix --features all-simulations` — 3,568 passed, 67 skipped. `cargo test -p lix --doc` — 10 passed.
- New engine regressions reproduce the original failure on unmodified main: 170 sorted and reordered 171 pass; sorted 171 and 400 fail at commit. They cover every field, reopening, updates, deletes, and reopening again.
- Focused all-simulations tests: 40 passed, including layout/fingerprint/key/scalar variations, malformed tails, eager and cold reads, mixed scopes, and replacement decoding.
- JS lifecycle tests: 9 passed; all four new cases fail against unmodified main. Typecheck passed.
- Rebuilt the native SDK and ran Paraglide 2.25.1 with both fixes: 170/171/400 sorted keys, swapped/reversed 171 keys, and 103 sorted keys in each of two locales all compile. Verified all 103 generated functions return the expected text in both locales.
- Fresh-admission fault injection reproduces the exact OPFS CI error before the fix and passes afterward. All 48 OPFS browser tests and the packaged Vite production smoke pass against the rebuilt WASM SDK.
- Independent sub-agent review and QA found and verified the related decoder and lifecycle fixes.
