### PR TITLE
Remove public lixcol_schema_key SQL column

### DIFF
--- a/.changenotes/remove-schema-key-column.md
+++ b/.changenotes/remove-schema-key-column.md
@@ -1,0 +1,7 @@
+---
+type: minor
+---
+
+Removed the redundant `lixcol_schema_key` SQL column.
+
+Schema tables, historical reads, diff/history results, and SQL metadata no longer expose this column. Queries that explicitly reference it now fail; use the relation name to identify the schema. The `schema_key` column on `lix_change` is unchanged.

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1503,7 +1503,7 @@ mod tests {
     #[test]
     fn bind_statement_rejects_hidden_insert_columns() {
         let statement = parse_statement(
-            "INSERT INTO lix_file (id, path, directory_id, name, content, lixcol_schema_key) VALUES ('file1', '/a', null, 'a', null, 'schema')",
+            "INSERT INTO lix_file (id, path, directory_id, name, content, lixcol_file_id) VALUES ('file1', '/a', null, 'a', null, 'schema')",
         );
         let error = bind_statement(&statement, &[], "branch1")
             .expect_err("hidden columns should not bind through statement binder");
@@ -1677,7 +1677,7 @@ mod tests {
 
     #[test]
     fn bind_statement_rejects_hidden_predicate_columns() {
-        let statement = parse_statement("DELETE FROM lix_file WHERE lixcol_schema_key = 'schema'");
+        let statement = parse_statement("DELETE FROM lix_file WHERE lixcol_file_id = 'schema'");
         let error = bind_statement(&statement, &[], "branch1")
             .expect_err("hidden predicate columns should not bind");
 

--- a/packages/lix/src/sql2/bind/table.rs
+++ b/packages/lix/src/sql2/bind/table.rs
@@ -178,7 +178,7 @@ mod tests {
             .expect("filesystem created timestamp should be public");
         require_public_column(&table, "lixcol_updated_at")
             .expect("filesystem updated timestamp should be public");
-        let error = require_public_column(&table, "lixcol_schema_key")
+        let error = require_public_column(&table, "lixcol_file_id")
             .expect_err("hidden column should not bind");
         assert!(error.message.contains("not part of public SQL surface"));
     }

--- a/packages/lix/src/sql2/catalog/registry.rs
+++ b/packages/lix/src/sql2/catalog/registry.rs
@@ -441,7 +441,6 @@ fn filesystem_schema(include_data: bool) -> SchemaRef {
         ]
     };
     fields.extend([
-        Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         Field::new("lixcol_global", DataType::Boolean, true),
         Field::new("lixcol_change_id", DataType::Utf8, true),
@@ -542,7 +541,6 @@ fn row_hidden_columns(spec: &SchemaSurfaceSpec) -> Vec<PublicColumn> {
 
 fn filesystem_system_columns() -> Vec<PublicColumn> {
     vec![
-        PublicColumn::hidden("lixcol_schema_key", false),
         PublicColumn::hidden("lixcol_file_id", true),
         PublicColumn::public_insert_only("lixcol_global", false).with_default("FALSE"),
         PublicColumn::public_read_only("lixcol_change_id", true),
@@ -559,7 +557,6 @@ fn row_system_columns(
     _variant: SchemaSurfaceShape,
 ) -> Vec<PublicColumn> {
     vec![
-        PublicColumn::public_read_only("lixcol_schema_key", false),
         PublicColumn::public_insert_only("lixcol_file_id", true).optional_on_insert(),
         PublicColumn::public("lixcol_metadata", true).optional_on_insert(),
         PublicColumn::public_read_only("lixcol_created_at", false),

--- a/packages/lix/src/sql2/catalog/schema_surface.rs
+++ b/packages/lix/src/sql2/catalog/schema_surface.rs
@@ -17,8 +17,7 @@ pub(crate) enum SchemaSurfaceShape {
 /// Relation payload must never use these names or introduce another
 /// `lixcol_` segment. Derived surfaces may preserve these names directly or
 /// through a structural side prefix such as `from_lixcol_created_at`.
-pub(crate) const TRACKED_ROW_SYSTEM_COLUMN_NAMES: [&str; 9] = [
-    "lixcol_schema_key",
+pub(crate) const TRACKED_ROW_SYSTEM_COLUMN_NAMES: [&str; 8] = [
     "lixcol_file_id",
     "lixcol_metadata",
     "lixcol_created_at",
@@ -422,7 +421,6 @@ pub(crate) fn row_visible_fields(spec: &SchemaSurfaceSpec) -> Vec<Field> {
 
 pub(crate) fn row_system_fields(_shape: SchemaSurfaceShape) -> Vec<Field> {
     vec![
-        Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         json_field("lixcol_metadata", true),
         Field::new("lixcol_created_at", DataType::Utf8, true),

--- a/packages/lix/src/sql2/exec/bound_public_write.rs
+++ b/packages/lix/src/sql2/exec/bound_public_write.rs
@@ -3438,7 +3438,7 @@ fn returning_expr_column_type(
         {
             "lixcol_metadata" => Some(crate::ResultColumnType::Jsonb),
             "lixcol_global" | "lixcol_untracked" => Some(crate::ResultColumnType::Boolean),
-            "lixcol_schema_key" | "lixcol_file_id" | "lixcol_created_at" | "lixcol_updated_at"
+            "lixcol_file_id" | "lixcol_created_at" | "lixcol_updated_at"
             | "lixcol_change_id" | "lixcol_commit_id" => Some(crate::ResultColumnType::Text),
             _ => None,
         },
@@ -5515,13 +5515,6 @@ enum RowEvalRowRef<'a> {
 }
 
 impl<'a> RowEvalRowRef<'a> {
-    fn schema_key(self) -> &'a str {
-        match self {
-            Self::Live(row) => row.schema_key(),
-            Self::Staged(row) => row.schema_key.as_str(),
-        }
-    }
-
     fn file_id(self) -> Option<&'a str> {
         match self {
             Self::Live(row) => row.file_id(),
@@ -7084,9 +7077,6 @@ fn column_eval_value(
         return Ok(RowEvalValue::SqlNull);
     };
     match column_name {
-        "lixcol_schema_key" => Ok(RowEvalValue::Json(JsonValue::String(
-            row.schema_key().to_string(),
-        ))),
         "lixcol_file_id" => Ok(row
             .file_id()
             .map(|value| RowEvalValue::Json(JsonValue::String(value.to_string())))
@@ -7158,9 +7148,6 @@ fn excluded_column_eval_value(
         return Ok(RowEvalValue::SqlNull);
     };
     match column_name {
-        "lixcol_schema_key" => Ok(RowEvalValue::Json(JsonValue::String(
-            row.schema_key.to_string(),
-        ))),
         "lixcol_file_id" => Ok(row
             .file_id
             .map(|value| RowEvalValue::Json(JsonValue::String(value.to_string())))

--- a/packages/lix/src/sql2/providers/diff.rs
+++ b/packages/lix/src/sql2/providers/diff.rs
@@ -699,7 +699,7 @@ impl DiffRoute {
                 .any(|(_, column)| {
                     !matches!(
                         column,
-                        "id" | "lixcol_schema_key"
+                        "id"
                             | "lixcol_file_id"
                             | "lixcol_created_at"
                             | "lixcol_updated_at"
@@ -773,7 +773,6 @@ struct DiffSqlRow {
 #[derive(Clone)]
 struct DiffSide {
     id: Option<String>,
-    schema_key: String,
     global: bool,
     file_id: Option<String>,
     created_at: String,
@@ -1174,7 +1173,6 @@ fn diff_side(
         payload.and_then(|payload| payload.metadata.map(|value| value.as_value().clone()));
     Ok(Some(DiffSide {
         id: single_row_pk_string(entry.identity.row_pk()),
-        schema_key: entry.identity.schema_key().to_string(),
         global: global_rows.contains(&TrackedStateKey {
             schema_key: entry.identity.schema_key().to_owned(),
             file_id: entry.identity.file_id().map(str::to_owned),
@@ -1434,7 +1432,7 @@ where
         .any(|(_, column)| {
             !matches!(
                 column,
-                "id" | "lixcol_schema_key"
+                "id"
                     | "lixcol_file_id"
                     | "lixcol_created_at"
                     | "lixcol_updated_at"
@@ -1705,7 +1703,6 @@ fn materialized_side(row: Option<MaterializedTrackedStateRowRef<'_>>) -> Result<
         .transpose()?;
     Ok(Some(DiffSide {
         id: single_row_pk_string(row.row_pk()),
-        schema_key: row.schema_key().to_string(),
         global: false, // Filled from effective endpoint overlay provenance by the caller.
         file_id: row.file_id().map(str::to_string),
         created_at: row.created_at().to_string(),
@@ -1979,7 +1976,6 @@ fn side_value(side: Option<&DiffSide>, column: &str) -> Result<Option<lix_schema
     Ok(match column {
         "id" => side.id.clone().map(lix_schema::Value::Text),
         "path" => side.path.clone().map(lix_schema::Value::Text),
-        "lixcol_schema_key" => Some(lix_schema::Value::Text(side.schema_key.clone())),
         "lixcol_file_id" => side.file_id.clone().map(lix_schema::Value::Text),
         "lixcol_created_at" => Some(lix_schema::Value::Text(side.created_at.clone())),
         "lixcol_updated_at" => Some(lix_schema::Value::Text(side.updated_at.clone())),

--- a/packages/lix/src/sql2/providers/directory.rs
+++ b/packages/lix/src/sql2/providers/directory.rs
@@ -1208,7 +1208,6 @@ fn lix_directory_surface_name(branch_binding: &BranchBinding) -> &'static str {
 }
 
 trait DirectoryLiveRow {
-    fn schema_key(&self) -> &str;
     fn file_id(&self) -> Option<&str>;
     fn global(&self) -> bool;
     fn change_id(&self) -> Option<String>;
@@ -1220,10 +1219,6 @@ trait DirectoryLiveRow {
 }
 
 impl DirectoryLiveRow for MaterializedHotStateRow {
-    fn schema_key(&self) -> &str {
-        &self.schema_key
-    }
-
     fn file_id(&self) -> Option<&str> {
         self.file_id.as_deref()
     }
@@ -1258,10 +1253,6 @@ impl DirectoryLiveRow for MaterializedHotStateRow {
 }
 
 impl DirectoryLiveRow for MaterializedHotStateRowRef<'_> {
-    fn schema_key(&self) -> &str {
-        (*self).schema_key()
-    }
-
     fn file_id(&self) -> Option<&str> {
         (*self).file_id()
     }
@@ -1591,7 +1582,6 @@ fn lix_directory_write_rows_from_batch_with_options_and_path_resolvers(
     let mut rows = RawWriteBatch::with_capacity(batch.num_rows().saturating_mul(3));
     for row_index in 0..batch.num_rows() {
         if reject_read_only_fields {
-            reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_schema_key")?;
             reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_change_id")?;
             reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_created_at")?;
             reject_read_only_lix_directory_insert_field(batch, row_index, "lixcol_updated_at")?;
@@ -1932,7 +1922,6 @@ where
     let mut paths = Vec::new();
     let mut parent_ids = Vec::new();
     let mut names = Vec::new();
-    let mut schema_keys = Vec::new();
     let mut file_ids = Vec::new();
     let mut globals = Vec::new();
     let mut change_ids = Vec::new();
@@ -1947,7 +1936,6 @@ where
         paths.push(path);
         parent_ids.push(directory.parent_id);
         names.push(Some(directory.name));
-        schema_keys.push(Some(directory.live.schema_key().to_owned()));
         file_ids.push(directory.live.file_id().map(str::to_owned));
         globals.push(Some(directory.live.global()));
         change_ids.push(directory.live.change_id());
@@ -1965,7 +1953,6 @@ where
             "path" => Arc::new(StringArray::from(paths.clone())),
             "parent_id" => Arc::new(StringArray::from(parent_ids.clone())),
             "name" => Arc::new(StringArray::from(names.clone())),
-            "lixcol_schema_key" => Arc::new(StringArray::from(schema_keys.clone())),
             "lixcol_file_id" => Arc::new(StringArray::from(file_ids.clone())),
             "lixcol_global" => Arc::new(BooleanArray::from(globals.clone())),
             "lixcol_change_id" => Arc::new(StringArray::from(change_ids.clone())),
@@ -2198,7 +2185,6 @@ pub(super) fn lix_directory_schema() -> SchemaRef {
         Field::new("path", DataType::Utf8, true),
         Field::new("parent_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, false),
-        Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         Field::new("lixcol_global", DataType::Boolean, true),
         Field::new("lixcol_change_id", DataType::Utf8, true),

--- a/packages/lix/src/sql2/providers/file.rs
+++ b/packages/lix/src/sql2/providers/file.rs
@@ -4004,7 +4004,6 @@ fn lix_file_stage_from_batch_with_options_and_path_resolvers(
 
     for row_index in 0..batch.num_rows() {
         if reject_read_only_fields {
-            reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_schema_key")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_change_id")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_created_at")?;
             reject_read_only_lix_file_insert_field(batch, row_index, "lixcol_updated_at")?;
@@ -4682,12 +4681,6 @@ fn lix_file_record_batch_from_path_selection(
             "content" => Arc::new(LargeBinaryArray::from(
                 entries.iter().map(|_| Some(&[][..])).collect::<Vec<_>>(),
             )),
-            "lixcol_schema_key" => {
-                Arc::new(StringArray::from(vec![
-                    Some(FILE_DESCRIPTOR_SCHEMA_KEY);
-                    row_count
-                ]))
-            }
             "lixcol_file_id" => Arc::new(StringArray::from(
                 entries
                     .iter()
@@ -4777,7 +4770,6 @@ struct LixFileRecordBatchColumns {
     directory_ids: Vec<Option<String>>,
     names: Vec<Option<String>>,
     data_values: Vec<Option<Vec<u8>>>,
-    schema_keys: Vec<Option<String>>,
     file_ids: Vec<Option<String>>,
     globals: Vec<Option<bool>>,
     change_ids: Vec<Option<String>>,
@@ -4795,8 +4787,6 @@ impl LixFileRecordBatchColumns {
         self.directory_ids.push(row.directory_id);
         self.names.push(Some(row.name));
         self.data_values.push(row.data);
-        self.schema_keys
-            .push(Some(FILE_DESCRIPTOR_SCHEMA_KEY.to_string()));
         self.file_ids.push(row.file_id);
         self.globals.push(Some(row.global));
         self.change_ids.push(row.change_id);
@@ -4815,7 +4805,6 @@ impl LixFileRecordBatchColumns {
             directory_ids,
             names,
             data_values,
-            schema_keys,
             file_ids,
             globals,
             change_ids,
@@ -4835,7 +4824,6 @@ impl LixFileRecordBatchColumns {
                 .map(|value| value.as_deref())
                 .collect::<Vec<_>>(),
         ));
-        let schema_keys: ArrayRef = Arc::new(StringArray::from(schema_keys));
         let file_ids: ArrayRef = Arc::new(StringArray::from(file_ids));
         let globals: ArrayRef = Arc::new(BooleanArray::from(globals));
         let change_ids: ArrayRef = Arc::new(StringArray::from(change_ids));
@@ -4853,7 +4841,6 @@ impl LixFileRecordBatchColumns {
                 "directory_id" => Arc::clone(&directory_ids),
                 "name" => Arc::clone(&names),
                 "content" => Arc::clone(&data_values),
-                "lixcol_schema_key" => Arc::clone(&schema_keys),
                 "lixcol_file_id" => Arc::clone(&file_ids),
                 "lixcol_global" => Arc::clone(&globals),
                 "lixcol_change_id" => Arc::clone(&change_ids),
@@ -6796,7 +6783,6 @@ pub(super) fn lix_file_schema() -> SchemaRef {
         Field::new("directory_id", DataType::Utf8, true),
         Field::new("name", DataType::Utf8, false),
         Field::new("content", DataType::LargeBinary, false),
-        Field::new("lixcol_schema_key", DataType::Utf8, false),
         Field::new("lixcol_file_id", DataType::Utf8, true),
         Field::new("lixcol_global", DataType::Boolean, true),
         Field::new("lixcol_change_id", DataType::Utf8, true),
@@ -7455,7 +7441,6 @@ mod tests {
             "path",
             "directory_id",
             "name",
-            "lixcol_schema_key",
             "lixcol_commit_id",
             "lixcol_metadata",
         ]
@@ -7493,10 +7478,6 @@ mod tests {
             "01920000-0000-7000-8000-0000000000d3"
         );
         assert_eq!(string_value("name"), "readme.md");
-        assert_eq!(
-            string_value("lixcol_schema_key"),
-            super::FILE_DESCRIPTOR_SCHEMA_KEY
-        );
         assert_eq!(
             string_value("lixcol_commit_id"),
             CommitId::for_test_label("commit-01920000-0000-7000-8000-0000000000d2").to_string()

--- a/packages/lix/src/sql2/providers/schema.rs
+++ b/packages/lix/src/sql2/providers/schema.rs
@@ -3912,9 +3912,6 @@ fn row_system_column_array(
 ) -> Result<ArrayRef> {
     #[expect(trivial_casts)]
     let array = match column_name {
-        "schema_key" => Arc::new(StringArray::from_iter(
-            rows.iter().map(|row| Some(row.schema_key())),
-        )) as ArrayRef,
         "file_id" => {
             Arc::new(StringArray::from_iter(rows.iter().map(|row| row.file_id()))) as ArrayRef
         }
@@ -5113,7 +5110,6 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 "body",
-                "lixcol_schema_key",
                 "lixcol_file_id",
                 "lixcol_metadata",
                 "lixcol_created_at",

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -709,7 +709,7 @@ simulation_test!(
                    table_name = 'engine_column_contract' \
                    AND column_name IN (\
                      'lixcol_change_id', 'lixcol_commit_id', 'lixcol_created_at', \
-                     'lixcol_global', 'lixcol_schema_key', \
+                     'lixcol_global', \
                      'lixcol_untracked', 'lixcol_updated_at'\
                    )\
                  ) \
@@ -748,13 +748,6 @@ simulation_test!(
                     Value::Text("NO".to_string()),
                     Value::Text("FALSE".to_string()),
                     Value::Text("DEFAULT".to_string()),
-                ],
-                vec![
-                    Value::Text("engine_column_contract".to_string()),
-                    Value::Text("lixcol_schema_key".to_string()),
-                    Value::Text("NO".to_string()),
-                    Value::Null,
-                    Value::Text("READ_ONLY".to_string()),
                 ],
                 vec![
                     Value::Text("engine_column_contract".to_string()),
@@ -2135,5 +2128,99 @@ simulation_test!(
                 ],
             ],
         );
+    }
+);
+
+simulation_test!(
+    schema_key_system_column_is_removed_from_public_sql,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(
+            engine.open_session().await.expect("session should open"),
+            &engine,
+        );
+        session
+            .execute(
+                "INSERT INTO lix_key_value (key, value) VALUES ('example', 'value')",
+                &[],
+            )
+            .await
+            .expect("tracked row should insert");
+        let commit = session
+            .execute("SELECT lix_active_branch_commit_id()", &[])
+            .await
+            .expect("commit should load");
+        let [Value::Text(commit_id)] = commit.rows()[0].values() else {
+            panic!("expected commit id");
+        };
+
+        for relation in ["lix_key_value", "lix_file", "lix_directory"] {
+            for surface in [
+                relation.to_string(),
+                format!("lix_as_of('{relation}', '{commit_id}')"),
+                format!("lix_diff('{relation}', lix_root_commit_id(), '{commit_id}')"),
+                format!("lix_history('{relation}')"),
+            ] {
+                let is_diff = surface.starts_with("lix_diff(")
+                    || surface.starts_with("lix_history(");
+                // File diffs expose content names but intentionally reject byte projection.
+                let projection = if relation == "lix_file" && is_diff {
+                    "id, from_path, to_path"
+                } else {
+                    "*"
+                };
+                let result = session
+                    .execute(&format!("SELECT {projection} FROM {surface}"), &[])
+                    .await
+                    .expect("public relation query should succeed");
+                assert!(
+                    result
+                        .columns()
+                        .iter()
+                        .all(|column| !column.contains("lixcol_schema_key")),
+                    "removed column leaked through {surface}: {:?}",
+                    result.columns(),
+                );
+                let columns = if is_diff {
+                    &["from_lixcol_schema_key", "to_lixcol_schema_key"][..]
+                } else {
+                    &["lixcol_schema_key"][..]
+                };
+                for column in columns {
+                    session
+                        .execute(&format!("SELECT {column} FROM {surface}"), &[])
+                        .await
+                        .expect_err("removed column must not resolve");
+                }
+            }
+        }
+
+        for sql in [
+            "SELECT column_name FROM information_schema.columns WHERE column_name LIKE '%lixcol_schema_key%'",
+            "SELECT result_column FROM information_schema.table_functions WHERE result_column LIKE '%lixcol_schema_key%'",
+        ] {
+            assert_rows_eq(
+                session.execute(sql, &[]).await.expect("catalog should load"),
+                vec![],
+            );
+        }
+
+        for sql in [
+            "INSERT INTO lix_key_value (key, value, lixcol_schema_key) VALUES ('removed', 'value', 'lix_key_value')",
+            "UPDATE lix_key_value SET lixcol_schema_key = 'lix_key_value' WHERE key = 'example'",
+            "DELETE FROM lix_key_value WHERE lixcol_schema_key = 'lix_key_value'",
+            "UPDATE lix_key_value SET value = 'updated' WHERE key = 'example' RETURNING lixcol_schema_key",
+        ] {
+            let error = session
+                .execute(sql, &[])
+                .await
+                .expect_err("removed column must not bind in writes");
+            assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND, "{sql}: {error}");
+        }
+        let result = session
+            .execute("SELECT value FROM lix_key_value WHERE key = 'example'", &[])
+            .await
+            .expect("row should remain unchanged");
+        assert_rows_eq(result, vec![vec![Value::Jsonb(serde_json::json!("value").into())]]);
     }
 );

--- a/packages/lix/tests/integration/sql/lix_file.rs
+++ b/packages/lix/tests/integration/sql/lix_file.rs
@@ -1130,7 +1130,7 @@ simulation_test!(
 
         let result = session
             .execute(
-                "SELECT id, path, content, lixcol_schema_key \
+                "SELECT id, path, content \
              FROM lix_file \
              WHERE id = '66696c65-2d72-8561-846d-650000000000'",
                 &[],
@@ -1145,7 +1145,6 @@ simulation_test!(
                 Value::Text("66696c65-2d72-8561-846d-650000000000".to_string()),
                 Value::Text("/docs/guides/readme.md".to_string()),
                 Value::Blob(b"hello".to_vec().into()),
-                Value::Text("lix_file_descriptor".to_string()),
             ]
         );
 

--- a/packages/lix/tests/integration/sql/state_at.rs
+++ b/packages/lix/tests/integration/sql/state_at.rs
@@ -279,7 +279,7 @@ simulation_test!(
             .await
             .expect("unrelated row should insert");
 
-        let columns = "key, value, lixcol_schema_key, lixcol_file_id, lixcol_metadata, \
+        let columns = "key, value, lixcol_file_id, lixcol_metadata, \
                    lixcol_created_at, lixcol_updated_at, lixcol_global, lixcol_change_id, \
                    lixcol_commit_id, lixcol_untracked";
         let live = session


### PR DESCRIPTION
Remove the redundant `lixcol_schema_key` column from Lix's SQL surface. Schema-table reads, `lix_as_of`, diff/history results, and metadata no longer expose it; explicit references fail with no compatibility alias.

Deletes the corresponding catalog fields, projection buffers, diff-side copies, write-expression handling, and unused helpers. Updates existing expectations and adds regression coverage for reads, metadata, and rejected writes. Internal schema identities and `lix_change.schema_key` remain intact.

Validation:
- `cargo nextest run -p lix --features all-simulations --no-fail-fast` — 3,557 passed, 67 skipped
- `cargo test -p lix --doc` — 10 passed
- `cargo fmt --all --check`
- `git diff --check`
