### PR TITLE
Fix partial replica browser sessions and checkpoint sync

### DIFF
--- a/.changenotes/partial-replica-browser-tabs.md
+++ b/.changenotes/partial-replica-browser-tabs.md
@@ -1,0 +1,10 @@
+---
+type: patch
+---
+
+OPFS partial replicas now share loaded data and offline edits across browser tabs.
+
+Tabs coordinate one engine automatically through a SharedWorker, keeping the same
+storage identity and `openLix()` API. Closing a tab leaves the other sessions
+operational. Checkpoint history also fetches missing commit metadata on demand
+and retains it for subsequent offline reads.

--- a/.changenotes/partial-replica-browser-tabs.md
+++ b/.changenotes/partial-replica-browser-tabs.md
@@ -13,3 +13,7 @@ File checkpoints upload their blob dependencies before publishing, including
 after an offline checkpoint or a lost acknowledgment. Each browser session keeps
 its own telemetry callback and trace parent; shared background spans go to live
 subscribers.
+
+Pending edits and checkpoint dependencies upload in bounded waves, including
+recovery after lost replies. SQL retries preserve the completion boundary: an
+error reported after execution or commit cannot replay the operation.

--- a/.changenotes/partial-replica-browser-tabs.md
+++ b/.changenotes/partial-replica-browser-tabs.md
@@ -17,3 +17,6 @@ subscribers.
 Pending edits and checkpoint dependencies upload in bounded waves, including
 recovery after lost replies. SQL retries preserve the completion boundary: an
 error reported after execution or commit cannot replay the operation.
+
+Read-interest journal flushing retries expired snapshots internally, so concurrent
+tab startup can complete without replaying the SQL that registered its inputs.

--- a/.changenotes/partial-replica-browser-tabs.md
+++ b/.changenotes/partial-replica-browser-tabs.md
@@ -8,3 +8,8 @@ Tabs coordinate one engine automatically through a SharedWorker, keeping the sam
 storage identity and `openLix()` API. Closing a tab leaves the other sessions
 operational. Checkpoint history also fetches missing commit metadata on demand
 and retains it for subsequent offline reads.
+
+File checkpoints upload their blob dependencies before publishing, including
+after an offline checkpoint or a lost acknowledgment. Each browser session keeps
+its own telemetry callback and trace parent; shared background spans go to live
+subscribers.

--- a/docs/checkpoints.md
+++ b/docs/checkpoints.md
@@ -92,3 +92,14 @@ Selective checkpoint source dependencies remain available for offline sync.
 
 See [History](./history.md) for log, endpoint history, snapshots, and paged
 previews, and [Diff commands](./diff-commands.md) for scoped checkpoints.
+
+Partial replicas upload ordinary pending edits and checkpoint dependencies in
+bounded waves of at most 32 commits and 1 MiB of commit/ref JSON. Intermediate ordinary uploads keep
+the authority's previous checkpoint; checkpoint publication waits for its native
+dependencies. Lost replies resume the durable captured wave. Binary file content
+uses the separate bounded blob uploader and is not counted as commit JSON.
+
+A single commit or minimal checkpoint publication closure that exceeds the 1 MiB
+request budget still requires multipart body preparation, which is not implemented
+by this lane. Its local data remains pending; splitting a long sequence into waves
+does not remove that atomic-body limit.

--- a/packages/js-sdk/native/wasm.rs
+++ b/packages/js-sdk/native/wasm.rs
@@ -864,7 +864,11 @@ impl WasmLix {
     }
 
     #[wasm_bindgen(js_name = openAnotherSession)]
-    pub async fn open_another_session(&self, options: JsValue) -> Result<WasmLix, JsValue> {
+    pub async fn open_another_session(
+        &self,
+        options: JsValue,
+        telemetry_dispatch: Option<Function>,
+    ) -> Result<WasmLix, JsValue> {
         let options: OpenAnotherSessionOptionsDto = from_js(options)?;
         let inner = self
             .instrument_operation(crate::session::SessionOperations::open_another_session(
@@ -874,15 +878,30 @@ impl WasmLix {
             ))
             .await
             .map_err(lix_error_to_js)?;
+        let inner = if let Some(dispatch) = telemetry_dispatch {
+            let dispatch = BrowserTelemetryDispatch(dispatch);
+            let sink = CallbackTelemetrySink::new(move |span| {
+                let Ok(span) = to_js(&crate::telemetry::TelemetrySpanDto::from(span)) else {
+                    return;
+                };
+                let _ = dispatch.0.call1(&JsValue::UNDEFINED, &span);
+            });
+            inner
+                .with_session_telemetry(Some(Arc::new(sink)))
+                .map_err(lix_error_to_js)?
+        } else {
+            inner
+        };
         self.storage_sessions
             .set(self.storage_sessions.get().saturating_add(1));
+        let telemetry_parent = inner.telemetry().map(|_| Rc::new(RefCell::new(None)));
         Ok(WasmLix {
             inner,
             storage: self.storage.clone(),
             storage_sessions: self.storage_sessions.clone(),
             closed: Cell::new(false),
             browser_sync_transport_id: self.browser_sync_transport_id.clone(),
-            telemetry_parent: self.telemetry_parent.clone(),
+            telemetry_parent,
         })
     }
 

--- a/packages/js-sdk/src/binding-types.ts
+++ b/packages/js-sdk/src/binding-types.ts
@@ -77,7 +77,7 @@ export type LixBinding = {
 	): Promise<import("./types.js").HostedLix>;
 	openReport?(): LixOpenReport | undefined;
 	setTelemetryParent(parent?: TelemetryParentContext): void;
-	openAnotherSession(options: OpenAnotherSessionOptions): Promise<LixBinding>;
+	openAnotherSession(options: OpenAnotherSessionOptions, telemetry?: TelemetryDispatch): Promise<LixBinding>;
 	execute(
 		sql: string,
 		params: BindingParam[],

--- a/packages/js-sdk/src/open-lix.browser.test.ts
+++ b/packages/js-sdk/src/open-lix.browser.test.ts
@@ -277,3 +277,30 @@ test("executes a globally ordered union plan in browser WASM", async () => {
 		await lix.close();
 	}
 });
+
+test("WASM child sessions route SQL telemetry independently and nested sessions inherit", async () => {
+ const { openLixBinding } = await import("./binding.browser.js");
+ const rootSpans: import("./types.js").LixTelemetrySpan[] = [];
+ const childSpans: import("./types.js").LixTelemetrySpan[] = [];
+ const root = await openLixBinding({kind:"memory"}, span => rootSpans.push(span));
+ const child = await root.openAnotherSession({}, span => childSpans.push(span));
+ const nested = await child.openAnotherSession({});
+ try {
+  rootSpans.length=0; childSpans.length=0;
+  child.setTelemetryParent({traceId:"11111111111111111111111111111111",spanId:"1111111111111111",traceFlags:1});
+  nested.setTelemetryParent({traceId:"22222222222222222222222222222222",spanId:"2222222222222222",traceFlags:1});
+  await child.execute("SELECT 41 AS child_value", []);
+  await nested.execute("SELECT 42 AS nested_value", []);
+  expect(childSpans.filter(span => span.name === "lix.sql.query").map(span => span.attributes["db.query.text"])).toEqual([
+   "SELECT ? AS child_value", "SELECT ? AS nested_value",
+  ]);
+  expect(childSpans.filter(span => span.name === "lix.sql.query").map(span => span.traceId)).toEqual([
+   "11111111111111111111111111111111", "22222222222222222222222222222222",
+  ]);
+  expect(rootSpans.filter(span => span.name === "lix.sql.query")).toEqual([]);
+  childSpans.length=0;
+  await root.execute("SELECT 43 AS root_value", []);
+  expect(rootSpans.some(span=>span.name === "lix.sql.query")).toBe(true);
+  expect(childSpans).toEqual([]);
+ } finally { await nested.close(); await child.close(); await root.close(); }
+});

--- a/packages/js-sdk/src/worker/client.ts
+++ b/packages/js-sdk/src/worker/client.ts
@@ -1,4 +1,4 @@
-import { createWorkerConnection, openDirectLixBinding } from "#worker-factory";
+import { createWorkerConnection, createSharedWorkerConnection, openDirectLixBinding } from "#worker-factory";
 import type {
 	LixBinding,
 	LixStorageConfig,
@@ -46,7 +46,12 @@ export async function openLixWorker(
 	onProgress?: (progress: LixOpenProgress) => void,
 	snapshot?: ReadableStream<Uint8Array>,
 ): Promise<LixWorkerClient> {
-	let client = idleWorkers.pop();
+	const providerOptions = storage.kind === "jsStorage" ? storage.options : undefined;
+	const sharedKey = !snapshot && server && providerOptions && typeof providerOptions === "object"
+		&& "sharedEngineKey" in providerOptions && typeof providerOptions.sharedEngineKey === "string"
+		&& providerOptions.sharedEngineKey.startsWith("lix:opfs:") ? providerOptions.sharedEngineKey : undefined;
+	const sharedConnection = sharedKey ? createSharedWorkerConnection(sharedKey) : undefined;
+	let client = sharedConnection ? new LixWorkerClient(sharedConnection, false) : idleWorkers.pop();
 	while (client?.isDisposed) client = idleWorkers.pop();
 	client ??= new LixWorkerClient();
 	client.beginLease(onDisposed, telemetry, server, onProgress);
@@ -471,7 +476,7 @@ function workerObserveBinding(
 
 async function releaseWorker(client: LixWorkerClient): Promise<void> {
 	client.endLease();
-	if (!client.isDisposed && idleWorkers.length < MAX_IDLE_WORKERS) {
+	if (client.reusable && !client.isDisposed && idleWorkers.length < MAX_IDLE_WORKERS) {
 		idleWorkers.push(client);
 		return;
 	}
@@ -506,6 +511,7 @@ export class LixWorkerClient {
 
 	constructor(
 		private readonly connection: WorkerConnection = createWorkerConnection(),
+        readonly reusable = true,
 	) {
 		connection.onMessage((message) => this.handleMessage(message));
 		connection.onFatal((error) => this.handleFatal(error));

--- a/packages/js-sdk/src/worker/entry.shared.browser.ts
+++ b/packages/js-sdk/src/worker/entry.shared.browser.ts
@@ -86,8 +86,8 @@ scope.onconnect = (event) => {
         },
       };
       if (!owner) {
-        owner = new SharedEngineOwner(async (transport) => {
-          const root = await openLixBinding(storage, telemetry, parent, transport, progress);
+        owner = new SharedEngineOwner(async (transport, backgroundTelemetry) => {
+          const root = await openLixBinding(storage, backgroundTelemetry, parent, transport, progress);
           try {
             rootAccount = await root.activeAccountId();
             return root;
@@ -99,6 +99,7 @@ scope.onconnect = (event) => {
       }
       client = {
         server: routed,
+        telemetry,
         rootAdmitted: (headers, account) => {
           admitted.record(raw.url, headers, account);
           verified.set(sharedCredentialKey(raw.url, headers), account);

--- a/packages/js-sdk/src/worker/entry.shared.browser.ts
+++ b/packages/js-sdk/src/worker/entry.shared.browser.ts
@@ -1,0 +1,150 @@
+/// <reference lib="webworker" />
+import { openLixBinding } from "#binding";
+import { openRemoteLixBinding } from "../remote/client.js";
+import {
+  SharedAdmissionCache,
+  SharedProbeNetworkFailure,
+  sharedCredentialKey,
+} from "./shared-admission.js";
+import { startWorkerHost } from "./host.js";
+import { SharedEngineOwner, type SharedEngineClient } from "./shared-engine.js";
+import type { SyncServerBindingOptions } from "../binding-types.js";
+import type { WorkerInput, WorkerResponse } from "./protocol.js";
+
+const scope = globalThis as unknown as SharedWorkerGlobalScope;
+let owner: SharedEngineOwner | undefined;
+let configuration: string | undefined;
+// Same-origin callers already control this physical store. Exact credentials
+// previously admitted in this worker may attach offline; new credentials need
+// an authenticated probe. Never persist these credentials.
+const admitted = new SharedAdmissionCache();
+let rootAccount: string | undefined;
+
+scope.onconnect = (event) => {
+  const port = event.ports[0]!;
+  let client: SharedEngineClient | undefined;
+  let disconnected = false;
+  let input: ((message: WorkerInput) => void) | undefined;
+  const controller = startWorkerHost(
+    {
+      postMessage: (message: WorkerResponse) => port.postMessage(message),
+      onMessage: (listener) => {
+        input = listener;
+      },
+    },
+    async (storage, telemetry, parent, server, progress, snapshot) => {
+      if (!server || snapshot)
+        throw new Error("Shared partial engines require a server and existing storage");
+      const config = JSON.stringify([storage, server.url]);
+      if (configuration !== undefined && config !== configuration)
+        throw new Error("Shared engine configuration mismatch");
+      configuration = config;
+      const raw = server;
+      const readHeaders = async () =>
+        raw.headerProvider ? await raw.headerProvider() : raw.headers;
+      const verified = new Map<string, string>();
+      const authenticate = async (headers: [string, string][], forceProbe = false) => {
+        const key = sharedCredentialKey(raw.url, headers);
+        if (!forceProbe && verified.has(key)) return verified.get(key)!;
+        const account = await admitted.verify(raw.url, headers, rootAccount!, async () => {
+          let networkFailure: unknown;
+          const fetcher = raw.fetch ?? globalThis.fetch;
+          let remote;
+          try {
+            remote = await openRemoteLixBinding({
+              url: raw.url,
+              headers,
+              fetch: async (input, init) => {
+                try {
+                  return await fetcher(input, init);
+                } catch (error) {
+                  if (error instanceof Error && error.name === "TypeError" && !init?.signal?.aborted) networkFailure = error;
+                  throw error;
+                }
+              },
+            });
+          } catch (error) {
+            if (networkFailure !== undefined) throw new SharedProbeNetworkFailure(networkFailure);
+            throw error;
+          }
+          try {
+            return await remote.activeAccountId();
+          } finally {
+            await remote.close();
+          }
+        });
+        if (verified.size >= 64) verified.delete(verified.keys().next().value!);
+        verified.set(key, account);
+        return account;
+      };
+      const routed: SyncServerBindingOptions = {
+        ...raw,
+        headerProvider: async () => {
+          const headers = await readHeaders();
+          if (rootAccount !== undefined) await authenticate(headers);
+          return headers;
+        },
+      };
+      if (!owner) {
+        owner = new SharedEngineOwner(async (transport) => {
+          const root = await openLixBinding(storage, telemetry, parent, transport, progress);
+          try {
+            rootAccount = await root.activeAccountId();
+            return root;
+          } catch (error) {
+            await root.close();
+            throw error;
+          }
+        });
+      }
+      client = {
+        server: routed,
+        rootAdmitted: (headers, account) => {
+          admitted.record(raw.url, headers, account);
+          verified.set(sharedCredentialKey(raw.url, headers), account);
+        },
+        verifyIdentity: async () => ({
+          authorityUrl: raw.url,
+          accountId: await (async () => {
+            const headers = await readHeaders();
+            return authenticate(headers, !verified.has(sharedCredentialKey(raw.url, headers)));
+          })(),
+        }),
+      };
+      const binding = await owner.attach(client);
+      if (disconnected) {
+        await binding.close();
+        throw new Error("Shared engine client disconnected during open");
+      }
+      return binding;
+    },
+  );
+  const disconnect = async () => {
+    if (disconnected) return;
+    disconnected = true;
+    if (client) owner?.deactivate(client);
+    try {
+      await controller.close();
+    } finally {
+      try {
+        if (client) await owner?.detach(client);
+      } finally {
+        port.close();
+      }
+    }
+  };
+  port.onmessage = (event) => {
+    const message = event.data;
+    if (message?.kind === "shared.disconnect") {
+      void disconnect();
+      return;
+    }
+    if (message?.kind === "shared.clientLease") {
+      // The page holds this lock. Acquisition means it closed or crashed.
+      void navigator.locks.request(message.name, () => disconnect());
+      return;
+    }
+    input?.(message as WorkerInput);
+  };
+  port.start();
+};

--- a/packages/js-sdk/src/worker/factory.browser.ts
+++ b/packages/js-sdk/src/worker/factory.browser.ts
@@ -48,3 +48,34 @@ export function createWorkerConnection(): WorkerConnection {
 		},
 	};
 }
+
+// TypeScript's worker-only library omits the window SharedWorker constructor.
+// Keep the literal constructor spelling for bundlers' worker-entry detection.
+declare const SharedWorker: new (url: URL, options: {type: string; name: string}) => {
+ port: MessagePort;
+ onerror: ((event: ErrorEvent) => void) | null;
+};
+
+/** Package-private provider identity selects one engine, not one engine per tab. */
+export function createSharedWorkerConnection(key: string): WorkerConnection {
+ if (typeof SharedWorker === "undefined" || !navigator.locks) throw new Error("Shared partial replicas require SharedWorker and Web Locks");
+ const worker = new SharedWorker(new URL("./entry.shared.browser.js", import.meta.url), {type:"module",name:key});
+ const port = worker.port;
+ const leaseName = `lix:shared-client:${crypto.randomUUID()}`;
+ let release!: () => void;
+ const lifetime = new Promise<void>(resolve => {release=resolve;});
+ let ready!: () => void;
+ const acquired = new Promise<void>(resolve => {ready=resolve;});
+ let failure: ((error: Error) => void) | undefined;
+ void navigator.locks.request(leaseName, async () => {ready(); await lifetime;}).catch(error => failure?.(error));
+ void acquired.then(() => port.postMessage({kind:"shared.clientLease",name:leaseName}));
+ port.start();
+ let closed = false;
+ return {
+  postMessage(message) {if (closed) throw new Error("Shared engine connection closed"); port.postMessage(message);},
+  onMessage(listener) {port.onmessage = event => listener(event.data);},
+  onFatal(listener) {failure=listener; worker.onerror=event => listener(new Error(event.message || "Shared engine failed"));},
+  ref() {}, unref() {},
+  async terminate() {if(closed)return;closed=true;port.postMessage({kind:"shared.disconnect"});release();port.close();},
+ };
+}

--- a/packages/js-sdk/src/worker/factory.node.ts
+++ b/packages/js-sdk/src/worker/factory.node.ts
@@ -82,3 +82,7 @@ export const openDirectLixBinding = async (
 		snapshot,
 	);
 };
+
+export function createSharedWorkerConnection(_key: string): WorkerConnection | undefined {
+ return undefined;
+}

--- a/packages/js-sdk/src/worker/host.test.ts
+++ b/packages/js-sdk/src/worker/host.test.ts
@@ -127,3 +127,27 @@ test("observation setup bypasses a blocked finite operation", async () => {
 	firstExecute.resolve();
 	await vi.waitFor(() => expect(executeCalls).toBe(2));
 });
+
+test("disconnect drains active work but rejects queued writes and closes late observers", async () => {
+ const active=deferred<void>();const observed=deferred<ObserveEventsBinding>();
+ const responses:WorkerResponse[]=[];let receive!:(message:WorkerInput)=>void;
+ const writes:string[]=[];const closed=vi.fn(async()=>{});const observationClose=vi.fn();
+ const binding={setTelemetryParent(){},close:closed,
+  execute:async(sql:string)=>{writes.push(sql);await active.promise;return {columns:[],rows:[],rowsAffected:0,notices:[]};},
+  observe:async()=>observed.promise,
+ } as unknown as LixBinding;
+ const controller=startWorkerHost({postMessage:message=>responses.push(message),onMessage:listener=>{receive=listener;}},async()=>binding);
+ receive({id:1,sessionId:0,operation:{kind:"open",storage:{kind:"memory"},telemetryEnabled:false,progressEnabled:false}});
+ await vi.waitFor(()=>expect(responses).toContainEqual(expect.objectContaining({id:1,ok:true})));
+ receive({id:2,sessionId:0,operation:{kind:"execute",sql:"active write",params:[]}});
+ await vi.waitFor(()=>expect(writes).toEqual(["active write"]));
+ receive({id:3,sessionId:0,operation:{kind:"execute",sql:"queued write",params:[]}});
+ receive({id:4,sessionId:0,operation:{kind:"observe",sql:"SELECT value",params:[]}});
+ const closing=controller.close();expect(closed).not.toHaveBeenCalled();
+ observed.resolve({setTelemetryParent(){},next:async()=>undefined,close:observationClose});
+ active.resolve();await closing;
+ expect(writes).toEqual(["active write"]);
+ expect(responses).toContainEqual(expect.objectContaining({id:3,ok:false}));
+ expect(responses).toContainEqual(expect.objectContaining({id:4,ok:false}));
+ expect(observationClose).toHaveBeenCalledTimes(1);expect(closed).toHaveBeenCalledTimes(1);
+});

--- a/packages/js-sdk/src/worker/host.ts
+++ b/packages/js-sdk/src/worker/host.ts
@@ -31,7 +31,8 @@ import {
 export function startWorkerHost(
 	endpoint: WorkerHostEndpoint,
 	openBinding: typeof openLixBinding = openLixBinding,
-): void {
+): { close(): Promise<void> } {
+	let closed = false;
 	const sessions = new Map<number, LixBinding>();
 	let nextSessionId = 1;
 	let nextTransactionId = 1;
@@ -69,8 +70,10 @@ export function startWorkerHost(
 	>();
 	const syncStreamCleanup = new Map<number, () => void>();
 	let finiteQueue = Promise.resolve();
+	const registrations = new Set<Promise<void>>();
 
 	endpoint.onMessage((message: WorkerInput) => {
+		if (closed && "id" in message) return;
 		if (!("id" in message)) {
 			handleNotification(message);
 			return;
@@ -114,18 +117,21 @@ export function startWorkerHost(
 			// finite-operation queue lets a long-running operation block a newly
 			// mounted query, including one that needs lazy history hydration.
 			// The live `next()` lane is already independent for the same reason.
-			void respond(message, () =>
+			const registration = respond(message, () =>
 				handleObserveRegistration(
 					message.sessionId,
 					operation.sql,
 					operation.params,
 				),
 			);
+            registrations.add(registration);
+            void registration.finally(() => registrations.delete(registration));
 			return;
 		}
 		finiteQueue = finiteQueue.then(async () => {
 			try {
 				await respond(message, async () => {
+                    if (closed) throw workerStateError("Worker client disconnected");
 					if (
 						message.operation.kind !== "open" &&
 						message.operation.kind !== "hosted.create" &&
@@ -449,6 +455,34 @@ export function startWorkerHost(
 		await input.writer.close();
 	}
 
+    return { async close() {
+        if (closed) return;
+        closed = true;
+        const failure = workerStateError("Worker client disconnected");
+        for (const pending of pendingSyncHeaders.values()) pending.reject(failure);
+        pendingSyncHeaders.clear();
+        for (const pending of pendingSyncFetch.values()) pending.reject(failure);
+        pendingSyncFetch.clear();
+        for (const cleanup of syncStreamCleanup.values()) cleanup();
+        syncStreamCleanup.clear();
+        for (const pending of pendingSyncStreamPulls.values()) { pending.controller.error(failure); pending.reject(failure); }
+        pendingSyncStreamPulls.clear();
+        for (const observation of observations.values()) observation.close();
+        observations.clear();
+        for (const snapshot of snapshotExports.values()) await Promise.resolve(snapshot.cancel()).catch(() => undefined);
+        snapshotExports.clear();
+        await finiteQueue.catch(() => undefined);
+        await Promise.allSettled(registrations);
+        // The active finite operation has finished; never roll back a handle
+        // concurrently with its execute/commit operation.
+        for (const transaction of transactions.values()) await transaction.rollback().catch(() => undefined);
+        transactions.clear();
+        for (const snapshot of snapshotExports.values()) await Promise.resolve(snapshot.cancel()).catch(() => undefined);
+        snapshotExports.clear();
+        for (const session of sessions.values()) await session.close();
+        sessions.clear();
+    } };
+
 	function createSyncServerBridge(server: WorkerSyncServerOptions | undefined, transportScope?: number):
 		| {
 				url: string;
@@ -463,7 +497,8 @@ export function startWorkerHost(
 			headers: server.headers ?? [],
 			headerProvider: server.dynamicHeaders
 				? () => {
-						const requestId = nextSyncRequestId++;
+						if (closed) throw workerStateError("Worker client disconnected");
+                    const requestId = nextSyncRequestId++;
 						return new Promise((resolve, reject) => {
 							pendingSyncHeaders.set(requestId, { resolve, reject });
 							endpoint.postMessage({ kind: "sync.headers", requestId, transportScope });
@@ -495,7 +530,8 @@ export function startWorkerHost(
 		) {
 			throw new TypeError("Browser sync fetch has no valid response limit");
 		}
-		const requestId = nextSyncRequestId++;
+		if (closed) throw workerStateError("Worker client disconnected");
+                    const requestId = nextSyncRequestId++;
 		const requestBase = {
 			url:
 				typeof input === "string"
@@ -623,6 +659,7 @@ export function startWorkerHost(
 		// serialized finite lane. Each `observe.next` supplies telemetry directly
 		// to its observation binding.
 		const events = await requiredLix(sessionId).observe(sql, params);
+        if (closed) { events.close(); throw workerStateError("Worker client disconnected"); }
 		const observeId = nextObserveId++;
 		observations.set(observeId, events);
 		return observeId;

--- a/packages/js-sdk/src/worker/shared-admission.test.ts
+++ b/packages/js-sdk/src/worker/shared-admission.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { SharedAdmissionCache, SharedProbeNetworkFailure } from "./shared-admission.js";
+const url = "https://example.test/lix/repo";
+const headers: [string, string][] = [["Authorization", "Bearer exact-token"]];
+test("a new port probes and rejects changed account despite matching headers", async () => {
+  const cache = new SharedAdmissionCache();
+  cache.record(url, headers, "a");
+  await expect(cache.verify(url, headers, "a", async () => "b")).rejects.toMatchObject({
+    code: "LIX_SHARED_ENGINE_IDENTITY_MISMATCH",
+  });
+});
+test("only network failure can reuse exact known authenticated credentials offline", async () => {
+  const cache = new SharedAdmissionCache();
+  cache.record(url, headers, "a");
+  expect(
+    await cache.verify(url, headers, "a", async () => {
+      throw new SharedProbeNetworkFailure(new TypeError("Failed to fetch"));
+    }),
+  ).toBe("a");
+  const auth = Object.assign(new Error("denied"), { code: "AUTH_DENIED" });
+  await expect(
+    cache.verify(url, headers, "a", async () => {
+      throw auth;
+    }),
+  ).rejects.toBe(auth);
+  await expect(
+    cache.verify(url, [["Authorization", "other-token"]], "a", async () => {
+      throw new SharedProbeNetworkFailure(new TypeError());
+    }),
+  ).rejects.toBeInstanceOf(SharedProbeNetworkFailure);
+});
+test("invisible custom-fetch credentials cannot authorize a new port offline", async () => {
+  const cache = new SharedAdmissionCache();
+  cache.record(url, [], "authenticated-account");
+  await expect(
+    cache.verify(url, [], "authenticated-account", async () => {
+      throw new SharedProbeNetworkFailure(new TypeError());
+    }),
+  ).rejects.toBeInstanceOf(SharedProbeNetworkFailure);
+});

--- a/packages/js-sdk/src/worker/shared-admission.ts
+++ b/packages/js-sdk/src/worker/shared-admission.ts
@@ -1,0 +1,51 @@
+/** Only a fetch rejection, not an HTTP/protocol rejection, permits offline reuse. */
+export class SharedProbeNetworkFailure extends Error {
+  constructor(readonly original: unknown) {
+    super("Shared identity probe could not reach the authority");
+  }
+}
+const ANONYMOUS_ACCOUNT_ID = "00000000-0000-7000-8000-000000000002";
+export function sharedCredentialKey(url: string, headers: [string, string][]): string {
+  const entries: [string, string][] = [];
+  new Headers(headers).forEach((value, key) => entries.push([key, value]));
+  return JSON.stringify([url, entries]);
+}
+
+/** Bounded, memory-only proofs; no credentials are written to storage. */
+export class SharedAdmissionCache {
+  private readonly proofs = new Map<string, string>();
+  record(url: string, headers: [string, string][], account: string): void {
+    const normalized = new Headers(headers);
+    // A custom fetch can inject credentials invisible here. An empty/telemetry-
+    // only header set is not an offline proof of a non-anonymous principal.
+    if (
+      !normalized.get("authorization") &&
+      !normalized.get("cookie") &&
+      account !== ANONYMOUS_ACCOUNT_ID
+    )
+      return;
+    if (this.proofs.size >= 64) this.proofs.delete(this.proofs.keys().next().value!);
+    this.proofs.set(sharedCredentialKey(url, headers), account);
+  }
+  async verify(
+    url: string,
+    headers: [string, string][],
+    expected: string,
+    probe: () => Promise<string>,
+  ): Promise<string> {
+    let account: string;
+    try {
+      account = await probe();
+    } catch (error) {
+      const known = this.proofs.get(sharedCredentialKey(url, headers));
+      if (!(error instanceof SharedProbeNetworkFailure) || known === undefined) throw error;
+      account = known;
+    }
+    if (account !== expected)
+      throw Object.assign(new Error("Shared engine account mismatch"), {
+        code: "LIX_SHARED_ENGINE_IDENTITY_MISMATCH",
+      });
+    this.record(url, headers, account);
+    return account;
+  }
+}

--- a/packages/js-sdk/src/worker/shared-engine.browser.test.ts
+++ b/packages/js-sdk/src/worker/shared-engine.browser.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "vitest";
+import type { WorkerOperation, WorkerResponse } from "./protocol.js";
+
+test("actual shared-worker ports isolate IDs and survive abrupt client-context loss", async () => {
+  const name = `shared-engine-test-${crypto.randomUUID()}`;
+  const first = new SharedWorker(
+    new URL("./shared-engine.fixture.bench.worker.ts", import.meta.url),
+    { type: "module", name },
+  );
+  const second = new SharedWorker(
+    new URL("./shared-engine.fixture.bench.worker.ts", import.meta.url),
+    { type: "module", name },
+  );
+  let nextId = 0;
+  const pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: unknown) => void }
+  >();
+  first.port.onmessage = (event: MessageEvent<WorkerResponse>) => {
+    const response = event.data;
+    if ("kind" in response) return;
+    const request = pending.get(response.id);
+    pending.delete(response.id);
+    if (response.ok) request?.resolve(response.value);
+    else request?.reject(response.error);
+  };
+  first.port.start();
+  const call = (operation: WorkerOperation) =>
+    new Promise<unknown>((resolve, reject) => {
+      const id = ++nextId;
+      pending.set(id, { resolve, reject });
+      first.port.postMessage({ id, sessionId: 0, operation });
+    });
+  const open: WorkerOperation = {
+    kind: "open",
+    storage: { kind: "memory" },
+    telemetryEnabled: false,
+    progressEnabled: false,
+  };
+  const frame = document.createElement("iframe");
+  const token = crypto.randomUUID();
+  frame.srcdoc = `<script>onmessage=async(event)=>{const port=event.ports[0];const token=event.data.token;let id=0;const pending=new Map();port.onmessage=e=>{const r=e.data;const p=pending.get(r.id);if(p){pending.delete(r.id);r.ok?p.resolve(r.value):p.reject(r.error)}};port.start();const call=operation=>new Promise((resolve,reject)=>{const n=++id;pending.set(n,{resolve,reject});port.postMessage({id:n,sessionId:0,operation})});navigator.locks.request(token,async()=>{port.postMessage({kind:'lease',name:token});await call(event.data.open);parent.postMessage({token,ready:true},'*');await call({kind:'execute',sql:'write:key:from-frame',params:[]});parent.postMessage({token,done:true},'*');await new Promise(()=>{})}).catch(error=>parent.postMessage({token,error:String(error)},'*'))};</script>`;
+  const done = new Promise<void>((resolve, reject) => {
+    const listener = (event: MessageEvent) => {
+      if (
+        event.source !== frame.contentWindow ||
+        event.data?.token !== token ||
+        (!event.data?.done && !event.data?.error)
+      )
+        return;
+      window.removeEventListener("message", listener);
+      event.data.error ? reject(new Error(event.data.error)) : resolve();
+    };
+    window.addEventListener("message", listener);
+  });
+  const ready = new Promise<void>((resolve, reject) => {
+    const listener = (event: MessageEvent) => {
+      if (event.source !== frame.contentWindow || event.data?.token !== token) return;
+      window.removeEventListener("message", listener);
+      event.data.error ? reject(new Error(event.data.error)) : resolve();
+    };
+    window.addEventListener("message", listener);
+  });
+  try {
+    await call(open);
+    const loaded = new Promise<void>((resolve) => {
+      frame.onload = () => resolve();
+    });
+    document.body.append(frame);
+    await loaded;
+    frame.contentWindow!.postMessage({ token, open }, "*", [second.port]);
+    await ready;
+    const read = async (sql: string) =>
+      (await call({ kind: "execute", sql, params: [] })) as { rows: unknown[][] };
+    // Both clients now have request ID 2 in flight on their own ports.
+    expect((await read("write:parent:independent")).rows).toEqual([["independent"]]);
+    await done;
+    expect((await read("read:key")).rows).toEqual([["from-frame"]]);
+    expect(JSON.parse(String((await read("stats")).rows[0]![0]))).toEqual({
+      opens: 1,
+      closes: 0,
+      sessions: 2,
+    });
+    // Removing the client document releases its Web Lock without graceful RPC.
+    frame.remove();
+    await navigator.locks.request(token, () => undefined);
+    await read("write:key:survivor-offline");
+    expect((await read("read:key")).rows).toEqual([["survivor-offline"]]);
+    expect(JSON.parse(String((await read("stats")).rows[0]![0])).closes).toBe(0);
+    const observation = (await call({ kind: "observe", sql: "read:key", params: [] })) as number;
+    const event = (await call({ kind: "observe.next", observeId: observation })) as {
+      result: { rows: unknown[][] };
+    };
+    expect(event.result.rows).toEqual([["survivor-offline"]]);
+    first.port.postMessage({ kind: "observe.close", observeId: observation });
+    await call({ kind: "close" });
+  } finally {
+    frame.remove();
+    first.port.postMessage({ kind: "disconnect" });
+    first.port.close();
+  }
+}, 30000);

--- a/packages/js-sdk/src/worker/shared-engine.fixture.bench.worker.ts
+++ b/packages/js-sdk/src/worker/shared-engine.fixture.bench.worker.ts
@@ -1,0 +1,101 @@
+/// <reference lib="webworker" />
+// Injectable browser-test host: production session/RPC ownership, no authority.
+import { startWorkerHost } from "./host.js";
+import { SharedEngineOwner, type SharedEngineClient } from "./shared-engine.js";
+import type { LixBinding } from "../binding-types.js";
+import type { WorkerInput } from "./protocol.js";
+const scope = globalThis as unknown as SharedWorkerGlobalScope;
+let opens = 0;
+let closes = 0;
+let sessions = 0;
+const values = new Map<string, string>();
+const session = (): LixBinding =>
+  ({
+    setTelemetryParent() {},
+    activeAccountId: async () => "account",
+    activeBranchId: async () => "branch",
+    openAnotherSession: async () => session(),
+    close: async () => {},
+    execute: async (sql: string) => {
+      const [operation, key, value] = sql.split(":");
+      if (operation === "write" && value === "from-frame")
+        await new Promise((resolve) => setTimeout(resolve, 30));
+      if (operation === "write") values.set(key!, value!);
+      return {
+        columns: [],
+        rows: [
+          [
+            operation === "stats"
+              ? JSON.stringify({ opens, closes, sessions })
+              : (values.get(key!) ?? null),
+          ],
+        ],
+        rowsAffected: 0,
+        notices: [],
+      };
+    },
+    observe: async (sql: string) => ({
+      setTelemetryParent() {},
+      next: async () => ({
+        sequence: 0,
+        mutationSequence: 0,
+        result: await session().execute(sql, []),
+      }),
+      close() {},
+    }),
+  }) as unknown as LixBinding;
+const owner = new SharedEngineOwner(async () => {
+  opens++;
+  const root = session();
+  return {
+    ...root,
+    openAnotherSession: async () => {
+      sessions++;
+      return session();
+    },
+    close: async () => {
+      closes++;
+    },
+  };
+});
+scope.onconnect = (event) => {
+  const port = event.ports[0]!;
+  let receive!: (message: WorkerInput) => void;
+  const client: SharedEngineClient = {
+    server: { url: "https://example.test", headers: [] },
+    verifyIdentity: async () => ({ authorityUrl: "https://example.test", accountId: "account" }),
+  };
+  const host = startWorkerHost(
+    {
+      postMessage: (message) => port.postMessage(message),
+      onMessage: (listener) => {
+        receive = listener;
+      },
+    },
+    async () => owner.attach(client),
+  );
+  let closed = false;
+  const close = async () => {
+    if (closed) return;
+    closed = true;
+    owner.deactivate(client);
+    try {
+      await host.close();
+    } finally {
+      await owner.detach(client);
+      port.close();
+    }
+  };
+  port.onmessage = (event) => {
+    if (event.data.kind === "lease") {
+      void navigator.locks.request(event.data.name, close);
+      return;
+    }
+    if (event.data.kind === "disconnect") {
+      void close();
+      return;
+    }
+    receive(event.data);
+  };
+  port.start();
+};

--- a/packages/js-sdk/src/worker/shared-engine.test.ts
+++ b/packages/js-sdk/src/worker/shared-engine.test.ts
@@ -1,0 +1,145 @@
+import { expect, test, vi } from "vitest";
+import type { LixBinding, SyncServerBindingOptions } from "../binding-types.js";
+import { SharedEngineOwner, type SharedEngineClient } from "./shared-engine.js";
+
+function fixture() {
+  const values = new Map<string, string>();
+  const sessions: LixBinding[] = [];
+  const rootClose = vi.fn(async () => {});
+  const root = {
+    activeAccountId: async () => "account-a",
+    close: rootClose,
+    openAnotherSession: vi.fn(async () => {
+      const session = {
+        execute: async (sql: string) => {
+          if (sql.startsWith("write:")) values.set("value", sql.slice(6));
+          return values.get("value");
+        },
+        close: vi.fn(async () => {}),
+      } as unknown as LixBinding;
+      sessions.push(session);
+      return session;
+    }),
+  } as unknown as LixBinding;
+  let transport: SyncServerBindingOptions | undefined;
+  const open = vi.fn(async (server: SyncServerBindingOptions) => {
+    transport = server;
+    return root;
+  });
+  const owner = new SharedEngineOwner(open);
+  const client = (account = "account-a"): SharedEngineClient => ({
+    server: {
+      url: "https://example.test/lix/repository",
+      headers: [["authorization", account]],
+      fetch: vi.fn(async () => new Response(account)),
+    },
+    verifyIdentity: async () => ({
+      authorityUrl: "https://example.test/lix/repository",
+      accountId: account,
+    }),
+  });
+  return { owner, open, rootClose, client, transport: () => transport!, sessions };
+}
+
+test("concurrent clients share one root and independent local sessions", async () => {
+  const f = fixture();
+  const a = f.client();
+  const b = f.client();
+  const [sa, sb] = await Promise.all([f.owner.attach(a), f.owner.attach(b)]);
+  expect(f.open).toHaveBeenCalledTimes(1);
+  expect(sa).not.toBe(sb);
+  await sa.execute("write:offline", []);
+  expect(await sb.execute("read", [])).toBe("offline");
+  await sa.close();
+  await f.owner.detach(a);
+  expect(f.rootClose).not.toHaveBeenCalled();
+  expect(await sb.execute("read", [])).toBe("offline");
+  await sb.close();
+  await f.owner.detach(b);
+  expect(f.rootClose).toHaveBeenCalledTimes(1);
+});
+
+test("a different authenticated account cannot receive a session or replace transport", async () => {
+  const f = fixture();
+  const a = f.client();
+  await f.owner.attach(a);
+  await expect(f.owner.attach(f.client("account-b"))).rejects.toMatchObject({
+    code: "LIX_SHARED_ENGINE_IDENTITY_MISMATCH",
+  });
+  expect(f.sessions).toHaveLength(1);
+  await f.transport().fetch!("https://example.test", {});
+  expect(a.server.fetch).toHaveBeenCalledTimes(1);
+});
+
+test("transport hands off only to attached clients and rejects when none remain", async () => {
+  const f = fixture();
+  const a = f.client();
+  const b = f.client();
+  await f.owner.attach(a);
+  await f.owner.attach(b);
+  f.owner.deactivate(a);
+  await f.transport().fetch!("https://example.test", {});
+  expect(a.server.fetch).not.toHaveBeenCalled();
+  expect(b.server.fetch).toHaveBeenCalledTimes(1);
+  f.owner.deactivate(b);
+  await expect(f.transport().fetch!("https://example.test", {})).rejects.toMatchObject({
+    code: "LIX_NETWORK_ERROR",
+  });
+  await f.owner.detach(b);
+});
+
+test("root admission records the exact frozen opening credentials", async () => {
+  let value = "old-token";
+  const admitted = vi.fn();
+  const child = {} as LixBinding;
+  const root = {
+    activeAccountId: async () => "account-a",
+    openAnotherSession: async () => child,
+    close: async () => {},
+  } as unknown as LixBinding;
+  const sent: string[] = [];
+  const owner = new SharedEngineOwner(async (server) => {
+    value = "new-token";
+    await server.fetch!("https://example.test/handshake", {});
+    return root;
+  });
+  await owner.attach({
+    server: {
+      url: "https://example.test",
+      headers: [],
+      headerProvider: async () => [["Authorization", value]],
+      fetch: async (_input, init) => {
+        sent.push(new Headers(init?.headers).get("authorization")!);
+        return new Response();
+      },
+    },
+    verifyIdentity: async () => ({ authorityUrl: "https://example.test", accountId: "account-a" }),
+    rootAdmitted: admitted,
+  });
+  expect(sent).toEqual(["old-token"]);
+  expect(admitted).toHaveBeenCalledWith([["Authorization", "old-token"]], "account-a");
+});
+
+test("only the first attachment receives the root initialization report", async () => {
+  const report = { format: 79, initialized: true };
+  const close = vi.fn(async () => {});
+  const child = { close, activeAccountId: async () => "account-a" } as unknown as LixBinding;
+  const root = {
+    activeAccountId: async () => "account-a",
+    openReport: () => report,
+    openAnotherSession: async () => child,
+    close: async () => {},
+  } as unknown as LixBinding;
+  const owner = new SharedEngineOwner(async () => root);
+  const client = (): SharedEngineClient => ({
+    server: { url: "https://example.test", headers: [] },
+    verifyIdentity: async () => ({ authorityUrl: "https://example.test", accountId: "account-a" }),
+  });
+  const first = await owner.attach(client());
+  const second = await owner.attach(client());
+  expect(first.openReport?.()).toBe(report);
+  expect(second.openReport?.()).toBeUndefined();
+  expect(await first.activeAccountId()).toBe("account-a");
+  await first.close();
+  expect(close).toHaveBeenCalledTimes(1);
+});

--- a/packages/js-sdk/src/worker/shared-engine.test.ts
+++ b/packages/js-sdk/src/worker/shared-engine.test.ts
@@ -143,3 +143,34 @@ test("only the first attachment receives the root initialization report", async 
   await first.close();
   expect(close).toHaveBeenCalledTimes(1);
 });
+
+test("telemetry joins after a disabled opener and remains after its departure", async () => {
+  const a = vi.fn();
+  const b = vi.fn();
+  const children: Array<import("../binding-types.js").TelemetryDispatch | undefined> = [];
+  let background!: import("../binding-types.js").TelemetryDispatch;
+  const root = {
+    activeAccountId: async () => "account",
+    close: async () => {},
+    openAnotherSession: async (_options: unknown, sink: import("../binding-types.js").TelemetryDispatch) => {
+      children.push(sink);
+      return {close: async () => {}} as unknown as LixBinding;
+    },
+  } as unknown as LixBinding;
+  const owner = new SharedEngineOwner(async (_server, sink) => {background=sink;return root;});
+  const make = (telemetry?: import("../binding-types.js").TelemetryDispatch): SharedEngineClient => ({
+    server:{url:"https://example.test",headers:[]},telemetry,
+    verifyIdentity:async()=>({authorityUrl:"https://example.test",accountId:"account"}),
+  });
+  const first=make(); const second=make(a); const third=make(b);
+  await owner.attach(first); await owner.attach(second); await owner.attach(third);
+  const span={} as Parameters<typeof background>[0];
+  children[1]!(span);
+  expect(a).toHaveBeenCalledTimes(1); expect(b).not.toHaveBeenCalled();
+  await owner.detach(first); await owner.detach(second);
+  background(span);
+  expect(a).toHaveBeenCalledTimes(1); expect(b).toHaveBeenCalledTimes(1);
+  children[2]!(span);
+  expect(b).toHaveBeenCalledTimes(2);
+  await owner.detach(third);
+});

--- a/packages/js-sdk/src/worker/shared-engine.ts
+++ b/packages/js-sdk/src/worker/shared-engine.ts
@@ -1,7 +1,8 @@
-import type { LixBinding, SyncServerBindingOptions } from "../binding-types.js";
+import type { LixBinding, SyncServerBindingOptions, TelemetryDispatch } from "../binding-types.js";
 
 export type SharedEngineClient = {
   server: SyncServerBindingOptions;
+  telemetry?: TelemetryDispatch;
   rootAdmitted?(headers: [string, string][], accountId: string): void;
   verifyIdentity(): Promise<{ authorityUrl: string; accountId: string }>;
 };
@@ -11,7 +12,13 @@ export class SharedEngineOwner {
   private root: LixBinding | undefined;
   private readonly clients = new Set<SharedEngineClient>();
   private queue: Promise<unknown> = Promise.resolve();
-  constructor(private readonly open: (server: SyncServerBindingOptions) => Promise<LixBinding>) {}
+  constructor(private readonly open: (server: SyncServerBindingOptions, telemetry: TelemetryDispatch) => Promise<LixBinding>) {}
+
+  private readonly backgroundTelemetry: TelemetryDispatch = span => {
+    for (const client of this.clients) {
+      try { client.telemetry?.(span); } catch { /* Host telemetry cannot interrupt engine work. */ }
+    }
+  };
 
   attach(client: SharedEngineClient): Promise<LixBinding> {
     const operation = this.queue.then(async () => {
@@ -26,7 +33,7 @@ export class SharedEngineOwner {
         client.server = { ...originalServer, headers, headerProvider: undefined };
         this.clients.add(client);
         try {
-          this.root = await this.open(this.transport());
+          this.root = await this.open(this.transport(), this.backgroundTelemetry);
           client.rootAdmitted?.(headers, await this.root.activeAccountId());
         } catch (error) {
           this.clients.delete(client);
@@ -49,7 +56,7 @@ export class SharedEngineOwner {
         }
         this.clients.add(client);
         const report = opensRoot ? root.openReport?.() : undefined;
-        const child = await root.openAnotherSession({});
+        const child = await root.openAnotherSession({}, client.telemetry ?? (() => {}));
         if (report === undefined) return child;
         // Only the opening caller performed initialization/migration. Later
         // attachments must not inherit that first caller's opening report.

--- a/packages/js-sdk/src/worker/shared-engine.ts
+++ b/packages/js-sdk/src/worker/shared-engine.ts
@@ -1,0 +1,117 @@
+import type { LixBinding, SyncServerBindingOptions } from "../binding-types.js";
+
+export type SharedEngineClient = {
+  server: SyncServerBindingOptions;
+  rootAdmitted?(headers: [string, string][], accountId: string): void;
+  verifyIdentity(): Promise<{ authorityUrl: string; accountId: string }>;
+};
+
+/** One physical owner; ports receive independent sessions, never the root. */
+export class SharedEngineOwner {
+  private root: LixBinding | undefined;
+  private readonly clients = new Set<SharedEngineClient>();
+  private queue: Promise<unknown> = Promise.resolve();
+  constructor(private readonly open: (server: SyncServerBindingOptions) => Promise<LixBinding>) {}
+
+  attach(client: SharedEngineClient): Promise<LixBinding> {
+    const operation = this.queue.then(async () => {
+      const opensRoot = this.root === undefined;
+      if (!this.root) {
+        const originalServer = client.server;
+        const headers = originalServer.headerProvider
+          ? await originalServer.headerProvider()
+          : originalServer.headers;
+        // Bind native admission to the exact credentials actually used during
+        // opening; a later dynamic-header read cannot authorize another principal.
+        client.server = { ...originalServer, headers, headerProvider: undefined };
+        this.clients.add(client);
+        try {
+          this.root = await this.open(this.transport());
+          client.rootAdmitted?.(headers, await this.root.activeAccountId());
+        } catch (error) {
+          this.clients.delete(client);
+          throw error;
+        } finally {
+          client.server = originalServer;
+        }
+      }
+      const root = this.root;
+      try {
+        const identity = await client.verifyIdentity();
+        if (
+          client.server.url !== identity.authorityUrl ||
+          (await root.activeAccountId()) !== identity.accountId
+        ) {
+          throw Object.assign(
+            new Error("Shared engine repository/account does not match this client"),
+            { code: "LIX_SHARED_ENGINE_IDENTITY_MISMATCH" },
+          );
+        }
+        this.clients.add(client);
+        const report = opensRoot ? root.openReport?.() : undefined;
+        const child = await root.openAnotherSession({});
+        if (report === undefined) return child;
+        // Only the opening caller performed initialization/migration. Later
+        // attachments must not inherit that first caller's opening report.
+        return new Proxy(child, {
+          get(target, property) {
+            if (property === "openReport") return () => report;
+            const value = Reflect.get(target, property, target) as unknown;
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+      } catch (error) {
+        this.clients.delete(client);
+        if (this.clients.size === 0) {
+          await root.close();
+          this.root = undefined;
+        }
+        throw error;
+      }
+    });
+    this.queue = operation.catch(() => undefined);
+    return operation;
+  }
+
+  deactivate(client: SharedEngineClient): void {
+    this.clients.delete(client);
+  }
+
+  async detach(client: SharedEngineClient): Promise<void> {
+    const operation = this.queue.then(async () => {
+      this.clients.delete(client);
+      if (this.clients.size === 0 && this.root) {
+        const root = this.root;
+        // Keep ownership on a failed close; never open a second engine over it.
+        await root.close();
+        this.root = undefined;
+      }
+    });
+    this.queue = operation.catch(() => undefined);
+    await operation;
+  }
+
+  private transport(): SyncServerBindingOptions {
+    const current = () => {
+      const client = this.clients.values().next().value as SharedEngineClient | undefined;
+      if (!client)
+        throw Object.assign(new Error("No live shared-engine transport"), {
+          code: "LIX_NETWORK_ERROR",
+        });
+      return client.server;
+    };
+    return {
+      url: current().url,
+      headers: [],
+      // Pick transport and credentials together for every HTTP request. A tab
+      // departure cannot send A's dynamic credentials through B's callback.
+      fetch: async (input, init) => {
+        const server = current();
+        const supplied = server.headerProvider ? await server.headerProvider() : server.headers;
+        const headers = new Headers(init?.headers);
+        for (const [name, value] of supplied) headers.set(name, value);
+        return (server.fetch ?? globalThis.fetch)(input, { ...init, headers });
+      },
+    };
+  }
+}

--- a/packages/lix/src/commit_graph/context.rs
+++ b/packages/lix/src/commit_graph/context.rs
@@ -900,7 +900,12 @@ fn validate_first_parent_jump(
 }
 
 pub(crate) fn missing_commit_graph_error(commit_id: &CommitId) -> LixError {
-    LixError::commit_not_found(commit_id.to_string(), "walk_commit_graph", "graph_node")
+    crate::tracked_state::NativeMetadataRef::CommitGraphRecord(commit_id.to_string())
+        .annotate_missing(LixError::commit_not_found(
+            commit_id.to_string(),
+            "walk_commit_graph",
+            "graph_node",
+        ))
 }
 
 fn full_value_bytes(value: Option<StorageProjectedValue>) -> Option<Bytes> {
@@ -1261,6 +1266,18 @@ mod tests {
             .expect("commit load should succeed");
 
         assert_eq!(commit, None);
+    }
+
+    #[test]
+    fn missing_graph_node_retains_native_address_for_partial_history() {
+        let id = commit_id("missing-history-parent");
+        let error = super::missing_commit_graph_error(&id);
+        assert_eq!(error.code, crate::LixError::CODE_COMMIT_NOT_FOUND);
+        assert_eq!(
+            crate::tracked_state::NativeMetadataRef::from_missing_error(&error).unwrap(),
+            Some(crate::tracked_state::NativeMetadataRef::CommitGraphRecord(id.to_string()))
+        );
+        assert_eq!(error.details.as_ref().unwrap()["operation"], "walk_commit_graph");
     }
 
     #[tokio::test]

--- a/packages/lix/src/common/error.rs
+++ b/packages/lix/src/common/error.rs
@@ -215,6 +215,22 @@ impl LixError {
     /// The selected branch has no abandoned action available to replay.
     pub const CODE_NOTHING_TO_REDO: &'static str = "LIX_NOTHING_TO_REDO";
 
+    /// An operation may have completed even when its completion work failed.
+    /// Retry classification must check this before considering a transient code.
+    /// Reading an idempotency receipt remains safe; executing the operation again does not.
+    pub(crate) fn automatic_retry_is_forbidden(&self) -> bool {
+        self.code == Self::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+            || ["nonRetryableAfterCommit", "nonRetryableAfterExecution"]
+                .iter()
+                .any(|key| {
+                    self.details
+                        .as_ref()
+                        .and_then(|details| details.get(key))
+                        .and_then(JsonValue::as_bool)
+                        == Some(true)
+                })
+    }
+
     pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
         Self {
             code: code.into(),
@@ -497,6 +513,32 @@ impl std::error::Error for LixError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn automatic_retry_respects_completion_markers_before_error_category() {
+        for code in [
+            LixError::CODE_TRANSACTION_CONFLICT,
+            LixError::CODE_STORAGE_READ_EXPIRED,
+            LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN,
+            "typed-native-demand",
+        ] {
+            let error = LixError::new(code, "original diagnostic");
+            assert_eq!(
+                error.automatic_retry_is_forbidden(),
+                code == LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+            );
+            for marker in ["nonRetryableAfterCommit", "nonRetryableAfterExecution"] {
+                for value in [json!(true), json!(false), json!(null), json!("true")] {
+                    let marked = error.clone().with_details(json!({marker: value}));
+                    assert_eq!(
+                        marked.automatic_retry_is_forbidden(),
+                        value == json!(true)
+                            || code == LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn format_without_hint_omits_hint_line() {

--- a/packages/lix/src/common/read_retry.rs
+++ b/packages/lix/src/common/read_retry.rs
@@ -18,7 +18,8 @@ pub(crate) struct ExpiredReadRetryState {
 
 impl ExpiredReadRetryState {
     pub(crate) fn next_delay(&mut self, error: &LixError) -> Option<Duration> {
-        if error.code != LixError::CODE_STORAGE_READ_EXPIRED {
+        if error.automatic_retry_is_forbidden() || error.code != LixError::CODE_STORAGE_READ_EXPIRED
+        {
             return None;
         }
         let now = web_time::Instant::now();
@@ -33,5 +34,24 @@ impl ExpiredReadRetryState {
         } else {
             Duration::ZERO
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completed_execution_does_not_consume_expired_read_retry_budget() {
+        for marker in ["nonRetryableAfterCommit", "nonRetryableAfterExecution"] {
+            let mut state = ExpiredReadRetryState::default();
+            let error = LixError::new(LixError::CODE_STORAGE_READ_EXPIRED, "completion failed")
+                .with_details(serde_json::json!({marker: true}));
+            assert_eq!(state.next_delay(&error), None);
+            assert!(state.started_at.is_none());
+            assert_eq!(state.attempts, 0);
+            let ordinary = LixError::new(LixError::CODE_STORAGE_READ_EXPIRED, "read expired");
+            assert_eq!(state.next_delay(&ordinary), Some(Duration::ZERO));
+        }
     }
 }

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1491,7 +1491,8 @@ where
         }
         let mut opened = self
             .open_internal_session(active_branch_id.clone(), active_account_id)
-            .await?;
+            .await?
+            .with_session_telemetry(self.telemetry().cloned())?;
         opened.sync_lease = self.sync_lease.as_ref().map(|lease| lease.child());
 
         Ok(opened)
@@ -1970,9 +1971,25 @@ where
         self.engine.lix_id()
     }
 
-    /// Per-engine telemetry sink, if the host attached one.
+    /// Binding integration: replace the sink before exposing a new session.
+    #[doc(hidden)]
+    pub fn with_session_telemetry(
+        mut self,
+        telemetry: Option<Arc<dyn TelemetrySink>>,
+    ) -> Result<Self, LixError> {
+        let session = Arc::get_mut(&mut self.session).ok_or_else(|| {
+            LixError::new(
+                LixError::CODE_INVALID_PARAM,
+                "session telemetry must be configured before sharing the session",
+            )
+        })?;
+        session.set_telemetry(telemetry);
+        Ok(self)
+    }
+
+    /// Telemetry sink for this session, if the host attached one.
     pub fn telemetry(&self) -> Option<&Arc<dyn TelemetrySink>> {
-        self.engine.telemetry()
+        self.session.telemetry()
     }
 
     /// Records that this handle's session has bound to the repository.
@@ -2974,6 +2991,42 @@ mod tests {
             lix.open_report().initialized,
             "the rejected sync open must leave initialization to the next valid open"
         );
+    }
+
+    #[tokio::test]
+    async fn child_session_telemetry_isolated_and_inherited_by_nested_sessions() {
+        let root_spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
+        let captured = root_spans.clone();
+        let root = open_lix()
+            .with_telemetry(Arc::new(CallbackTelemetrySink::new(move |span| {
+                captured.lock().unwrap().push(span);
+            })))
+            .await
+            .unwrap();
+        let child_spans = Arc::new(Mutex::new(Vec::<CompletedTelemetrySpan>::new()));
+        let captured = child_spans.clone();
+        let child = root
+            .open_another_session()
+            .await
+            .unwrap()
+            .with_session_telemetry(Some(Arc::new(CallbackTelemetrySink::new(move |span| {
+                captured.lock().unwrap().push(span);
+            }))))
+            .unwrap();
+        let nested = child.open_another_session().await.unwrap();
+        root_spans.lock().unwrap().clear();
+        child_spans.lock().unwrap().clear();
+        child.execute("SELECT 41", &[]).await.unwrap();
+        nested.execute("SELECT 42", &[]).await.unwrap();
+        assert!(!child_spans.lock().unwrap().is_empty());
+        assert!(root_spans.lock().unwrap().is_empty());
+        child_spans.lock().unwrap().clear();
+        root.execute("SELECT 43", &[]).await.unwrap();
+        assert!(!root_spans.lock().unwrap().is_empty());
+        assert!(child_spans.lock().unwrap().is_empty());
+        nested.close().await.unwrap();
+        child.close().await.unwrap();
+        root.close().await.unwrap();
     }
 
     #[tokio::test]

--- a/packages/lix/src/session/context.rs
+++ b/packages/lix/src/session/context.rs
@@ -192,6 +192,14 @@ impl<StorageImpl> SessionContext<StorageImpl>
 where
     StorageImpl: Storage + Clone + Send + Sync + 'static,
 {
+    pub(crate) fn set_telemetry(&mut self, telemetry: Option<Arc<dyn TelemetrySink>>) {
+        self.telemetry = telemetry;
+    }
+
+    pub(crate) fn telemetry(&self) -> Option<&Arc<dyn TelemetrySink>> {
+        self.telemetry.as_ref()
+    }
+
     pub(crate) fn new(
         branch: SessionBranch,
         active_account_id: String,

--- a/packages/lix/src/session/execute.rs
+++ b/packages/lix/src/session/execute.rs
@@ -4451,6 +4451,9 @@ async fn retry_auto_commit(
     expired_read_retries: &mut ExpiredReadRetryState,
     error: &LixError,
 ) -> bool {
+    if error.automatic_retry_is_forbidden() {
+        return false;
+    }
     if retry_expired_auto_commit(expired_read_retries, error).await {
         return true;
     }
@@ -4497,6 +4500,108 @@ mod tests {
         Memory,
         engine::{Engine, EngineOptions},
     };
+
+    #[tokio::test]
+    async fn auto_commit_retry_policy_preserves_completion_boundaries() {
+        for code in [
+            LixError::CODE_TRANSACTION_CONFLICT,
+            LixError::CODE_STORAGE_READ_EXPIRED,
+            LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN,
+        ] {
+            for marker in [
+                None,
+                Some("nonRetryableAfterCommit"),
+                Some("nonRetryableAfterExecution"),
+            ] {
+                let mut error = LixError::new(code, "retry policy probe");
+                if let Some(marker) = marker {
+                    error = error.with_details(serde_json::json!({marker: true}));
+                }
+                let mut conflicts = 0;
+                let mut expired = ExpiredReadRetryState::default();
+                assert_eq!(
+                    retry_auto_commit(&mut conflicts, &mut expired, &error).await,
+                    marker.is_none() && code != LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
+                );
+                if marker.is_some() {
+                    assert_eq!(conflicts, 0);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn committed_sql_callback_conflict_and_expiry_are_not_replayed() {
+        for code in [
+            LixError::CODE_TRANSACTION_CONFLICT,
+            LixError::CODE_STORAGE_READ_EXPIRED,
+        ] {
+            let storage = Memory::default();
+            Engine::initialize(storage.clone()).await.unwrap();
+            let engine = Engine::new(storage.clone()).await.unwrap();
+            let session = engine.open_session().await.unwrap();
+            let access = session.begin_session_write_access().await.unwrap();
+            let error = session
+                .with_write_transaction_reserved_lending(
+                    access,
+                    async |transaction| {
+                        transaction
+                            .stage_engine_test_rows(RawWriteBatch::from_test_rows(vec![
+                                TransactionWriteRow {
+                                    row_pk: Some(RowPk::single("committed-retry-boundary")),
+                                    schema_key: "lix_key_value".into(),
+                                    file_id: None,
+                                    snapshot: Some(TransactionJson::from_value_for_test(
+                                        serde_json::json!({
+                                            "key": "committed-retry-boundary", "value": "persisted"
+                                        }),
+                                    )),
+                                    metadata: None,
+                                    origin: None,
+                                    created_at: None,
+                                    updated_at: None,
+                                    global: true,
+                                    change_id: None,
+                                    commit_id: None,
+                                    untracked: false,
+                                    branch_id: crate::GLOBAL_BRANCH_ID.into(),
+                                },
+                            ]))
+                            .await?;
+                        Ok(())
+                    },
+                    |_| Err(LixError::new(code, "injected completion failure")),
+                )
+                .await
+                .unwrap_err();
+            assert_eq!(error.code, code);
+            assert_eq!(error.message, "injected completion failure");
+            assert_eq!(
+                error.details.as_ref().unwrap()["nonRetryableAfterCommit"],
+                true
+            );
+            let mut conflicts = 0;
+            let mut expired = ExpiredReadRetryState::default();
+            assert!(!retry_auto_commit(&mut conflicts, &mut expired, &error).await);
+            assert_eq!(conflicts, 0);
+            drop(session);
+            drop(engine);
+            let reopened = Engine::new(storage).await.unwrap();
+            let reader = reopened.open_session().await.unwrap();
+            let rows = reader
+                .execute(
+                    "SELECT key FROM lix_key_value WHERE key = 'committed-retry-boundary'",
+                    &[],
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                rows.len(),
+                1,
+                "completion failure followed a durable mutation"
+            );
+        }
+    }
 
     async fn open_session() -> SessionContext<Memory> {
         let storage = Memory::default();

--- a/packages/lix/src/session/observe.rs
+++ b/packages/lix/src/session/observe.rs
@@ -240,10 +240,12 @@ where
                     return Ok(None);
                 }
                 Err(error)
-                    if matches!(
-                        error.code.as_str(),
-                        LixError::CODE_STORAGE_READ_EXPIRED | LixError::CODE_TRANSACTION_CONFLICT
-                    ) =>
+                    if !error.automatic_retry_is_forbidden()
+                        && matches!(
+                            error.code.as_str(),
+                            LixError::CODE_STORAGE_READ_EXPIRED
+                                | LixError::CODE_TRANSACTION_CONFLICT
+                        ) =>
                 {
                     // A concurrent commit invalidated this evaluation — an
                     // expired coherent read past its bounded in-execute

--- a/packages/lix/src/sql2/providers/mainline.rs
+++ b/packages/lix/src/sql2/providers/mainline.rs
@@ -384,7 +384,7 @@ impl<S: StorageAdapterRead + Clone + Send + Sync + 'static> TableSpec for Mainli
                     if limit.is_some_and(|n| emitted >= n) || remaining_ids.as_ref().is_some_and(|ids| ids.is_empty()) { break; }
                     record_work(false);
                     let node = graph.load_node(&id).await.map_err(lix_error_to_datafusion_error)?
-                        .ok_or_else(|| lix_error_to_datafusion_error(crate::LixError::commit_not_found(id.to_string(), "walk_commit_graph", "graph_node")))?;
+                        .ok_or_else(|| lix_error_to_datafusion_error(crate::commit_graph::missing_commit_graph_error(&id)))?;
                     next = node.parent_commit_ids.first().copied();
                     if let Some(ids) = remaining_ids.as_mut() { ids.remove(&id.to_string()); }
                     let current_position = position;

--- a/packages/lix/src/sync/partial_checkpoint_upload.rs
+++ b/packages/lix/src/sync/partial_checkpoint_upload.rs
@@ -47,6 +47,143 @@ pub(super) async fn prepare_partial_checkpoint_upload(
     max_commits: usize,
     max_wire_bytes: usize,
 ) -> Result<Option<PreparedPartialPush>, LixError> {
+    prepare_checkpoint_target(
+        read,
+        state,
+        branch_id,
+        attempt_id,
+        max_commits,
+        max_wire_bytes,
+        None,
+    )
+    .await
+}
+
+/// Find the direct first-parent child without walking the whole local suffix.
+async fn first_parent_child(
+    read: &(impl StorageAdapterRead + ?Sized),
+    head: CommitId,
+    boundary: CommitId,
+) -> Result<CommitId, LixError> {
+    let base = super::partial_upload::local_record(read, boundary).await?;
+    let goal = base
+        .generation
+        .checked_add(1)
+        .ok_or_else(|| blocked("checkpoint generation overflow"))?;
+    let mut current = super::partial_upload::local_record(read, head).await?;
+    for _ in 0..256 {
+        if current.generation == goal && current.parent_commit_ids.as_slice() == [boundary] {
+            return Ok(current.commit_id);
+        }
+        if current.generation <= goal || current.parent_commit_ids.len() != 1 {
+            return Err(blocked(
+                "checkpoint page does not extend the confirmed first-parent scope",
+            ));
+        }
+        let jump_generation = current
+            .generation
+            .checked_sub(current.first_parent_jump_span)
+            .ok_or_else(|| blocked("invalid checkpoint page jump"))?;
+        let (next, generation) = if current.first_parent_jump_span > 0 && jump_generation >= goal {
+            (current.first_parent_jump_commit_id, jump_generation)
+        } else {
+            (current.parent_commit_ids[0], current.generation - 1)
+        };
+        current = super::partial_upload::local_record(read, next).await?;
+        if current.generation != generation {
+            return Err(blocked("checkpoint page jump generation mismatch"));
+        }
+    }
+    Err(blocked("checkpoint page traversal exceeds its bound"))
+}
+
+/// Stage the earliest pending checkpoint, or a bounded ordinary prefix of its
+/// captured source. Every intermediate checkpoint has its original working
+/// child, preserving unselected rows; no body-only frontier is inferred.
+pub(super) async fn prepare_partial_checkpoint_page(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state: &PartialReplicaState,
+    branch_id: &str,
+    attempt_id: String,
+    max_commits: usize,
+    max_wire_bytes: usize,
+) -> Result<Option<PreparedPartialPush>, LixError> {
+    let (push, _, _) = load_partial_push_state(read, state, branch_id).await?;
+    if push.prepared.is_some() {
+        return Err(blocked("checkpoint page cannot replace a durable attempt"));
+    }
+    let control = crate::branch::BranchHeadControlContext::new()
+        .reader(read)
+        .load(branch_id)
+        .await?
+        .ok_or_else(|| blocked("checkpoint branch disappeared"))?;
+    let latest = control
+        .working_diff_checkpoint_commit_id
+        .ok_or_else(|| blocked("checkpoint missing"))?;
+    let checkpoint = first_parent_child(read, latest, id(&push.confirmed.checkpoint)?).await?;
+    let working_tip = if checkpoint == latest {
+        control.head_commit_id
+    } else {
+        let next = first_parent_child(read, latest, checkpoint).await?;
+        let (source_branch, source) = load_sync_checkpoint_source(read, next)
+            .await?
+            .ok_or_else(|| blocked("next checkpoint source is missing"))?;
+        if source_branch != branch_id {
+            return Err(blocked("next checkpoint source belongs to another branch"));
+        }
+        source
+    };
+    let head = if working_tip == checkpoint {
+        checkpoint
+    } else {
+        first_parent_child(read, working_tip, checkpoint).await?
+    };
+    let target = PartialPushCoordinate {
+        head: head.to_string(),
+        checkpoint: checkpoint.to_string(),
+    };
+    match prepare_checkpoint_target(
+        read,
+        state,
+        branch_id,
+        attempt_id.clone(),
+        max_commits,
+        max_wire_bytes,
+        Some(target),
+    )
+    .await
+    {
+        Err(error) if error.code == "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED" => {
+            match super::partial_upload::prepare_partial_checkpoint_prefix(
+                read,
+                state,
+                branch_id,
+                attempt_id,
+                max_commits,
+                max_wire_bytes,
+                checkpoint,
+            )
+            .await?
+            {
+                Some(page) => Ok(Some(page)),
+                None => Err(blocked(
+                    "minimal checkpoint closure exceeds the upload request budget; multipart body preparation is required",
+                )),
+            }
+        }
+        result => result,
+    }
+}
+
+async fn prepare_checkpoint_target(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state: &PartialReplicaState,
+    branch_id: &str,
+    attempt_id: String,
+    max_commits: usize,
+    max_wire_bytes: usize,
+    page_target: Option<PartialPushCoordinate>,
+) -> Result<Option<PreparedPartialPush>, LixError> {
     if max_commits == 0
         || max_commits > super::MAX_SYNC_REQUEST_ITEMS
         || max_wire_bytes == 0
@@ -70,6 +207,7 @@ pub(super) async fn prepare_partial_checkpoint_upload(
         .prepared
         .as_ref()
         .map(|upload| upload.target.clone())
+        .or(page_target)
         .unwrap_or(PartialPushCoordinate {
             head: control.head_commit_id.to_string(),
             checkpoint: control
@@ -95,6 +233,7 @@ pub(super) async fn prepare_partial_checkpoint_upload(
         );
     }
 
+    let mut global_ancestry = BTreeMap::new();
     let mut stack = vec![(id(&target.checkpoint)?, false), (id(&target.head)?, false)];
     let mut visiting = BTreeSet::new();
     let mut done = known.clone();
@@ -122,8 +261,9 @@ pub(super) async fn prepare_partial_checkpoint_upload(
             return Err(blocked("checkpoint dependency cycle"));
         }
         if commits.len() + loaded.len() >= max_commits {
-            return Err(blocked(
-                "checkpoint closure exceeds bounded preparation; paged body preparation required",
+            return Err(LixError::new(
+                "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED",
+                "checkpoint closure requires an earlier bounded upload wave",
             ));
         }
         let commit = load_sync_commit(read, current)
@@ -134,16 +274,25 @@ pub(super) async fn prepare_partial_checkpoint_upload(
                 "checkpoint dependency belongs to an unprepared account scope",
             ));
         }
-        if commit
-            .base_commit_id
-            .as_deref()
-            .map(id)
-            .transpose()?
-            .is_some_and(|base| !known.contains(&base))
-        {
-            return Err(blocked(
-                "checkpoint requires confirmed global base preparation",
-            ));
+        if let Some(base) = commit.base_commit_id.as_deref().map(id).transpose()? {
+            if !known.contains(&base)
+                && branch_id != crate::GLOBAL_BRANCH_ID
+                && super::partial_upload::is_confirmed_global_base(
+                    read,
+                    base,
+                    id(&global.confirmed.head)?,
+                    &mut global_ancestry,
+                )
+                .await?
+            {
+                known.insert(base);
+                done.insert(base);
+            }
+            if !known.contains(&base) {
+                return Err(blocked(
+                    "checkpoint requires confirmed global base preparation",
+                ));
+            }
         }
         // Blob manifests and chunks are prepared by the same bounded sender
         // used for ordinary uploads, before this checkpoint's refs are pushed.
@@ -169,8 +318,12 @@ pub(super) async fn prepare_partial_checkpoint_upload(
             }
             dependencies.insert(source);
         }
-        serde_json::to_writer(&mut body_budget, &commit)
-            .map_err(|_| blocked("checkpoint bodies exceed wire budget"))?;
+        serde_json::to_writer(&mut body_budget, &commit).map_err(|_| {
+            LixError::new(
+                "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED",
+                "checkpoint bodies exceed wire budget",
+            )
+        })?;
         loaded.insert(current, commit);
         stack.push((current, true));
         for dependency in dependencies.into_iter().rev() {
@@ -213,8 +366,12 @@ pub(super) async fn prepare_partial_checkpoint_upload(
         remaining: max_wire_bytes,
         written: 0,
     };
-    serde_json::to_writer(&mut budget, &request)
-        .map_err(|_| blocked("checkpoint request exceeds wire budget"))?;
+    serde_json::to_writer(&mut budget, &request).map_err(|_| {
+        LixError::new(
+            "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED",
+            "checkpoint request exceeds wire budget",
+        )
+    })?;
     let control_guard = if resumed {
         None
     } else {

--- a/packages/lix/src/sync/partial_checkpoint_upload.rs
+++ b/packages/lix/src/sync/partial_checkpoint_upload.rs
@@ -145,15 +145,8 @@ pub(super) async fn prepare_partial_checkpoint_upload(
                 "checkpoint requires confirmed global base preparation",
             ));
         }
-        if commit
-            .members
-            .iter()
-            .any(|member| member.schema_key == "lix_binary_blob_ref" && !member.deleted)
-        {
-            return Err(blocked(
-                "checkpoint requires binary manifest and chunk upload preparation",
-            ));
-        }
+        // Blob manifests and chunks are prepared by the same bounded sender
+        // used for ordinary uploads, before this checkpoint's refs are pushed.
         if commit.parent_commit_ids.len() > max_commits {
             return Err(blocked(
                 "checkpoint parent fanout exceeds preparation budget",

--- a/packages/lix/src/sync/partial_interest_journal.rs
+++ b/packages/lix/src/sync/partial_interest_journal.rs
@@ -176,56 +176,76 @@ where
     if registry.durability_is_clean()? {
         return Ok(());
     }
+    let mut expired_reads = crate::common::ExpiredReadRetryState::default();
     for _ in 0..16 {
-        let read = storage.begin_read(Default::default()).await?;
-        let (recipes, previous, epoch_guard) = load(&read, expected).await?;
-        registry.merge_persisted(recipes)?;
-        if registry.durability_is_clean()? {
-            return Ok(());
-        }
-        let snapshot = registry.snapshot()?;
-        let next = encode(
-            expected,
-            snapshot
-                .interests
-                .iter()
-                .map(|recipe| recipe.as_ref().clone())
-                .collect(),
-        )?;
-        let mut writes = storage.new_write_set();
-        writes.put(
-            PARTIAL_READ_INTEREST_SPACE,
-            key(expected)?,
-            crate::storage_adapter::StorageValue { bytes: next },
-        );
-        drop(read);
-        let result = storage
-            .commit_partial_replica_write_set(
-                super::partial_replica_write_capability(),
-                writes,
-                StorageWriteOptions {
-                    await_durable: true,
-                    preconditions: vec![
-                        epoch_guard,
-                        StoragePrecondition::KeyValueEquals {
-                            space: PARTIAL_READ_INTEREST_SPACE,
-                            key: key(expected)?,
-                            expected: previous,
-                        },
-                    ],
-                    ..Default::default()
-                },
-            )
-            .await;
-        match result {
-            Ok(_) => {
-                registry.acknowledge_durable(snapshot.revision)?;
-                return Ok(());
+        // Only this idempotent journal unit is restarted. Its caller may have
+        // already executed or committed SQL and must never replay that SQL.
+        let result: Result<bool, LixError> = async {
+            let read = storage.begin_read(Default::default()).await?;
+            let (recipes, previous, epoch_guard) = load(&read, expected).await?;
+            registry.merge_persisted(recipes)?;
+            if registry.durability_is_clean()? {
+                return Ok(true);
             }
-            Err(crate::storage_adapter::StorageWriteSetError::Storage(
-                crate::storage_adapter::StorageError::PreconditionFailed(_),
-            )) => continue,
-            Err(error) => return Err(error.into()),
+            let snapshot = registry.snapshot()?;
+            let next = encode(
+                expected,
+                snapshot
+                    .interests
+                    .iter()
+                    .map(|recipe| recipe.as_ref().clone())
+                    .collect(),
+            )?;
+            let mut writes = storage.new_write_set();
+            writes.put(
+                PARTIAL_READ_INTEREST_SPACE,
+                key(expected)?,
+                crate::storage_adapter::StorageValue { bytes: next },
+            );
+            drop(read);
+            let result = storage
+                .commit_partial_replica_write_set(
+                    super::partial_replica_write_capability(),
+                    writes,
+                    StorageWriteOptions {
+                        await_durable: true,
+                        preconditions: vec![
+                            epoch_guard,
+                            StoragePrecondition::KeyValueEquals {
+                                space: PARTIAL_READ_INTEREST_SPACE,
+                                key: key(expected)?,
+                                expected: previous,
+                            },
+                        ],
+                        ..Default::default()
+                    },
+                )
+                .await;
+            match result {
+                Err(crate::storage_adapter::StorageWriteSetError::Storage(
+                    crate::storage_adapter::StorageError::PreconditionFailed(_),
+                )) => return Ok(false),
+                other => {
+                    other.map_err(LixError::from)?;
+                }
+            }
+            registry.acknowledge_durable(snapshot.revision)?;
+            Ok(true)
+        }
+        .await;
+        match result {
+            Ok(true) => return Ok(()),
+            Ok(false) => continue,
+            Err(error) => {
+                if let Some(delay) = expired_reads.next_delay(&error) {
+                    tokio::task::yield_now().await;
+                    if !delay.is_zero() {
+                        crate::sync::sleep(delay).await;
+                    }
+                    continue;
+                }
+                return Err(error);
+            }
         }
     }
     Err(LixError::new(
@@ -237,6 +257,199 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[derive(Clone)]
+    struct ExpiringJournalStorage {
+        inner: crate::Memory,
+        remaining: Arc<std::sync::atomic::AtomicUsize>,
+        failures: Arc<std::sync::atomic::AtomicUsize>,
+    }
+    struct ExpiringJournalRead {
+        inner: crate::storage_adapter::MemoryRead,
+        storage: ExpiringJournalStorage,
+    }
+    impl Storage for ExpiringJournalStorage {
+        type Read<'a> = ExpiringJournalRead;
+        type Write<'a> = crate::storage_adapter::MemoryWrite;
+        async fn acquire_session(
+            &self,
+        ) -> Result<crate::storage_adapter::StorageSessionToken, crate::storage_adapter::StorageError>
+        {
+            self.inner.acquire_session().await
+        }
+        async fn begin_read(
+            &self,
+            opts: crate::storage_adapter::StorageReadOptions,
+        ) -> Result<Self::Read<'_>, crate::storage_adapter::StorageError> {
+            Ok(ExpiringJournalRead {
+                inner: self.inner.begin_read(opts).await?,
+                storage: self.clone(),
+            })
+        }
+        async fn begin_write(
+            &self,
+            opts: StorageWriteOptions,
+        ) -> Result<Self::Write<'_>, crate::storage_adapter::StorageError> {
+            self.inner.begin_write(opts).await
+        }
+    }
+    impl crate::storage_adapter::StorageRead for ExpiringJournalRead {
+        async fn get_many(
+            &self,
+            requests: &[crate::storage_adapter::StorageGetManyRequest<'_>],
+        ) -> Result<
+            crate::storage_adapter::StorageGetManyResult,
+            crate::storage_adapter::StorageError,
+        > {
+            use std::sync::atomic::Ordering;
+            if requests
+                .iter()
+                .any(|request| request.space == PARTIAL_READ_INTEREST_SPACE)
+                && self
+                    .storage
+                    .remaining
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                    .is_ok()
+            {
+                self.storage.failures.fetch_add(1, Ordering::SeqCst);
+                return Err(crate::storage_adapter::StorageError::ReadExpired);
+            }
+            crate::storage_adapter::StorageRead::get_many(&self.inner, requests).await
+        }
+        async fn begin_scan(
+            &self,
+            space: StorageSpace,
+            range: crate::storage_adapter::StorageKeyRange,
+            opts: crate::storage_adapter::StorageBeginScanOptions,
+        ) -> Result<
+            crate::storage_adapter::StorageScanCursor<'_>,
+            crate::storage_adapter::StorageError,
+        > {
+            crate::storage_adapter::StorageRead::begin_scan(&self.inner, space, range, opts).await
+        }
+    }
+    #[tokio::test]
+    async fn journal_expired_reads_retry_only_the_flush_and_remain_bounded() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let (memory_storage, state) = fixture().await;
+        let faults = ExpiringJournalStorage {
+            inner: memory_storage.storage().clone(),
+            remaining: Arc::new(AtomicUsize::new(2)),
+            failures: Arc::new(AtomicUsize::new(0)),
+        };
+        let storage = StorageAdapter::new(faults.clone());
+        storage.admit_partial_replica_writer(super::super::partial_replica_write_capability());
+        let registry = ReadInterestRegistry::new_durable(MAX_RECIPES, MAX_RECIPE_BYTES);
+        let operation = registry.begin_operation().await;
+        operation.register(recipe("survives-expiry")).unwrap();
+        drop(operation);
+        flush_partial_read_interests(&storage, &state, &registry)
+            .await
+            .unwrap();
+        assert_eq!(faults.failures.load(Ordering::SeqCst), 2);
+        assert!(registry.durability_is_clean().unwrap());
+        let revision = storage.load_mutation_revision().await.unwrap();
+        flush_partial_read_interests(&storage, &state, &registry)
+            .await
+            .unwrap();
+        assert_eq!(storage.load_mutation_revision().await.unwrap(), revision);
+        let restored = ReadInterestRegistry::new_durable(MAX_RECIPES, MAX_RECIPE_BYTES);
+        flush_partial_read_interests(&storage, &state, &restored)
+            .await
+            .unwrap();
+        assert_eq!(restored.snapshot().unwrap().interests.len(), 1);
+        faults.remaining.store(usize::MAX, Ordering::SeqCst);
+        let fresh = ReadInterestRegistry::new_durable(MAX_RECIPES, MAX_RECIPE_BYTES);
+        let error = flush_partial_read_interests(&storage, &state, &fresh)
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, LixError::CODE_TRANSACTION_CONFLICT);
+        assert_eq!(faults.failures.load(Ordering::SeqCst), 18);
+        assert!(!fresh.durability_is_clean().unwrap());
+    }
+
+    #[tokio::test]
+    async fn completed_insert_survives_expired_journal_without_sql_replay() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let authority = crate::open_lix().await.unwrap();
+        let (memory_storage, state) = fixture_from_authority(&authority).await;
+        let faults = ExpiringJournalStorage {
+            inner: memory_storage.storage().clone(),
+            remaining: Arc::new(AtomicUsize::new(0)),
+            failures: Arc::new(AtomicUsize::new(0)),
+        };
+        let storage = StorageAdapter::new(faults.clone());
+        let (engine, session) = crate::engine::Engine::new_partial_replica(
+            storage.clone(),
+            crate::engine::EngineOptions::new(),
+            &state,
+        )
+        .await
+        .unwrap();
+        engine.sync_mode().admit_partial_replica(
+            Arc::new(state.clone()),
+            super::super::partial_replica_write_capability(),
+        );
+        storage.admit_partial_replica_writer(super::super::partial_replica_write_capability());
+        let mut fetches = super::super::partial_sql_tests::Fetches::default();
+        // Warm native SQL inputs before injecting a fault solely in the
+        // post-execution journal. Failed cold attempts publish no mutation.
+        super::super::partial_sql_tests::execute_hydrating(
+            &session,
+            &storage,
+            &state,
+            &authority,
+            "SELECT value FROM lix_key_value WHERE key = 'journal-insert-once'",
+            &[],
+            &mut fetches,
+        )
+        .await
+        .unwrap();
+        let registry = engine.sync_mode().read_interests().unwrap();
+        let operation = registry.begin_operation().await;
+        operation
+            .register(recipe("new-completed-insert-scope"))
+            .unwrap();
+        drop(operation);
+        faults.remaining.store(2, Ordering::SeqCst);
+        super::super::partial_sql_tests::execute_hydrating(
+            &session,
+            &storage,
+            &state,
+            &authority,
+            "INSERT INTO lix_key_value (key, value) VALUES ('journal-insert-once', 'committed')",
+            &[],
+            &mut fetches,
+        )
+        .await
+        .unwrap();
+        assert_eq!(faults.failures.load(Ordering::SeqCst), 2);
+        assert!(registry.durability_is_clean().unwrap());
+        // Replaying this INSERT would hit its primary-key constraint. Success
+        // plus a fresh engine read proves completion bookkeeping preserved it.
+        drop(session);
+        drop(engine);
+        let (_engine, reopened) = crate::engine::Engine::new_partial_replica(
+            storage,
+            crate::engine::EngineOptions::new(),
+            &state,
+        )
+        .await
+        .unwrap();
+        let result = reopened
+            .execute(
+                "SELECT value FROM lix_key_value WHERE key = 'journal-insert-once'",
+                &[],
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.rows().len(), 1);
+        let value = match result.rows()[0].get::<crate::Value>("value").unwrap() {
+            crate::Value::Jsonb(value) => value.as_json_string().unwrap(),
+            crate::Value::Text(value) => value,
+            value => panic!("unexpected SQL value: {value:?}"),
+        };
+        assert_eq!(value, "committed");
+    }
     fn recipe(key: &str) -> LogicalReadInterest {
         LogicalReadInterest::scan(
             &crate::hot_state::HotStateScanRequest {
@@ -253,6 +466,11 @@ mod tests {
     }
     async fn fixture() -> (StorageAdapter<crate::Memory>, PartialReplicaState) {
         let authority = crate::open_lix().await.unwrap();
+        fixture_from_authority(&authority).await
+    }
+    async fn fixture_from_authority(
+        authority: &crate::Lix<crate::Memory>,
+    ) -> (StorageAdapter<crate::Memory>, PartialReplicaState) {
         let state = PartialReplicaState::new(
             format!("https://example.test/lix/{}", authority.lix_id()),
             authority.active_account_id().into(),

--- a/packages/lix/src/sync/partial_sql_tests.rs
+++ b/packages/lix/src/sync/partial_sql_tests.rs
@@ -17,7 +17,7 @@ use super::partial_hydration::hydrate_native_object;
 use super::partial_state::PartialReplicaState;
 
 #[derive(Default, Debug)]
-struct Fetches {
+pub(super) struct Fetches {
     object_requests: usize,
     metadata_requests: usize,
     payload_bytes: usize,
@@ -159,7 +159,9 @@ async fn prepare_baseline_jump_spines(
     Ok(())
 }
 
-async fn execute_hydrating<S: crate::storage_adapter::Storage + Clone + Send + Sync + 'static>(
+pub(super) async fn execute_hydrating<
+    S: crate::storage_adapter::Storage + Clone + Send + Sync + 'static,
+>(
     session: &SessionContext<S>,
     storage: &StorageAdapter<S>,
     state: &PartialReplicaState,

--- a/packages/lix/src/sync/partial_sql_tests/publication.rs
+++ b/packages/lix/src/sync/partial_sql_tests/publication.rs
@@ -12,6 +12,37 @@ async fn fixture() -> (
 ) {
     fixture_with_account(None).await
 }
+
+#[tokio::test]
+async fn checkpoint_log_hydrates_missing_graph_nodes_then_reads_offline() {
+    let authority = open_lix().await.unwrap();
+    authority.set_sync_role(crate::sync::SyncRole::Authority).unwrap();
+    for index in 0..4 {
+        authority.execute(
+            "INSERT INTO lix_key_value (key,value) VALUES ($1,'history')",
+            &[Value::Text(format!("history-{index}"))],
+        ).await.unwrap();
+    }
+    let (authority, engine, session, state) = fixture_from_authority(authority, None).await;
+    let sql = "SELECT commit_id, parent_commit_id, created_at FROM lix_log() WHERE is_checkpoint = true ORDER BY position ASC";
+    let expected = authority.execute(sql, &[]).await.unwrap();
+    let mut fetches = Fetches::default();
+    let actual = execute_hydrating(
+        &session,
+        &engine.storage(),
+        &state,
+        &authority,
+        sql,
+        &[],
+        &mut fetches,
+    )
+    .await
+    .unwrap();
+    assert_eq!(actual.rows(), expected.rows());
+    assert!(fetches.metadata_requests > 0, "test must cross the sparse graph frontier");
+    // A direct session has no network demand handler.
+    assert_eq!(session.execute(sql, &[]).await.unwrap().rows(), expected.rows());
+}
 async fn fixture_with_account(
     account: Option<&str>,
 ) -> (
@@ -37,6 +68,18 @@ async fn fixture_with_account(
         )
         .await
         .unwrap();
+    fixture_from_authority(authority, account).await
+}
+
+async fn fixture_from_authority(
+    authority: Lix<Memory>,
+    account: Option<&str>,
+) -> (
+    Lix<Memory>,
+    Arc<Engine<Memory>>,
+    SessionContext<Memory>,
+    Arc<PartialReplicaState>,
+) {
     let state = Arc::new(
         PartialReplicaState::new(
             format!("https://example.test/lix/{}", authority.lix_id()),

--- a/packages/lix/src/sync/partial_sql_tests/runtime_http.rs
+++ b/packages/lix/src/sync/partial_sql_tests/runtime_http.rs
@@ -205,3 +205,178 @@ async fn http_dispatcher_recovers_lost_wave_and_preserves_newer_local_edit() {
     assert!(format!("{local:?}").contains("L2"));
     assert!(format!("{remote:?}").contains("R"));
 }
+
+#[tokio::test]
+async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
+    let backing = Memory::new();
+    let authority = open_lix().with_storage(backing.clone()).await.unwrap();
+    authority
+        .set_sync_role(crate::sync::SyncRole::Authority)
+        .unwrap();
+    authority
+        .execute(
+            "INSERT INTO lix_file(path,content) VALUES('/checkpoint.bin',$1)",
+            &[Value::Blob(vec![17u8; 96 * 1024].into())],
+        )
+        .await
+        .unwrap();
+    let server = open_lix()
+        .with_storage(backing)
+        .serve()
+        .with_embedded_lix_id()
+        .await
+        .unwrap();
+    let transport = HttpSyncTransport::connect_with(
+        Client {
+            server,
+            lose_body: Arc::new(AtomicBool::new(false)),
+        },
+        &format!("https://example.test/lix/{}", authority.lix_id()),
+    )
+    .await
+    .unwrap();
+    let wrapper = transport.partial_replica_descriptor(None).await.unwrap();
+    let old = Arc::new(
+        PartialReplicaState::from_leased(
+            transport.protocol_url().into(),
+            authority.active_account_id().into(),
+            uuid::Uuid::now_v7().to_string(),
+            wrapper.wire,
+        )
+        .unwrap(),
+    );
+    let storage = StorageAdapter::new(Memory::new());
+    let read = storage.begin_read(Default::default()).await.unwrap();
+    let mut writes = storage.new_write_set();
+    let preconditions = stage_partial_bootstrap(&read, &mut writes, &old).unwrap();
+    crate::init::stage_partial_repository_protocol(&mut writes);
+    drop(read);
+    storage
+        .commit_write_set(
+            writes,
+            StorageWriteOptions {
+                preconditions,
+                await_durable: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let (engine, session) =
+        Engine::new_partial_replica(storage.clone(), EngineOptions::new(), &old)
+            .await
+            .unwrap();
+    let engine = Arc::new(engine);
+    engine
+        .sync_mode()
+        .admit_partial_replica(old.clone(), crate::sync::partial_replica_write_capability());
+    storage.admit_partial_replica_writer(crate::sync::partial_replica_write_capability());
+
+    let mut fetches = Fetches::default();
+    execute_hydrating(
+        &session,
+        &storage,
+        &old,
+        &authority,
+        "SELECT id,path FROM lix_file WHERE path='/checkpoint.bin'",
+        &[],
+        &mut fetches,
+    )
+    .await
+    .unwrap();
+    let content = vec![43u8; 96 * 1024];
+    execute_hydrating(
+        &session,
+        &storage,
+        &old,
+        &authority,
+        "UPDATE lix_file SET content=$1 WHERE path='/checkpoint.bin'",
+        &[Value::Blob(content.clone().into())],
+        &mut fetches,
+    )
+    .await
+    .unwrap();
+    execute_hydrating(&session, &storage, &old, &authority,
+        "SELECT commit_id FROM lix_create_checkpoint(ARRAY(SELECT row_ref FROM lix_diff('lix_file') WHERE to_path='/checkpoint.bin'))",
+        &[], &mut fetches,
+    ).await.unwrap();
+    let branch = &old.descriptor().selected_branch.branch_id;
+    let first = crate::sync::partial_upload_cycle::upload_partial_once(
+        &storage,
+        &old,
+        branch,
+        uuid::Uuid::now_v7().to_string(),
+        32,
+        1024 * 1024,
+        |request| {
+            let (storage, old, transport) = (&storage, &old, &transport);
+            async move {
+                crate::sync::partial_blob_upload::push_partial_with_blobs(
+                    storage, old, transport, &request,
+                )
+                .await?;
+                Err(LixError::new(
+                    "TEST_LOST_CHECKPOINT_ACK",
+                    "authority accepted checkpoint before reply was lost",
+                ))
+            }
+        },
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(first.code, "TEST_LOST_CHECKPOINT_ACK");
+    let read = storage.begin_read(Default::default()).await.unwrap();
+    let (pending, _, _) =
+        crate::sync::partial_push_state::load_partial_push_state(&read, &old, branch)
+            .await
+            .unwrap();
+    let captured = pending
+        .prepared
+        .expect("lost response retains exact upload");
+    drop(read);
+    assert!(
+        crate::sync::partial_upload_cycle::upload_partial_once(
+            &storage,
+            &old,
+            branch,
+            uuid::Uuid::now_v7().to_string(),
+            32,
+            1024 * 1024,
+            |request| {
+                let (storage, old, transport) = (&storage, &old, &transport);
+                async move {
+                    crate::sync::partial_blob_upload::push_partial_with_blobs(
+                        storage, old, transport, &request,
+                    )
+                    .await
+                }
+            },
+        )
+        .await
+        .unwrap()
+    );
+    let read = storage.begin_read(Default::default()).await.unwrap();
+    let (settled, _, _) =
+        crate::sync::partial_push_state::load_partial_push_state(&read, &old, branch)
+            .await
+            .unwrap();
+    assert!(settled.prepared.is_none());
+    assert_eq!(settled.confirmed, captured.target);
+    drop(read);
+    let descriptor = authority
+        .partial_replica_descriptor(Some(branch))
+        .await
+        .unwrap();
+    assert_eq!(
+        descriptor.selected_branch.checkpoint.commit_id,
+        captured.target.checkpoint
+    );
+    let result = authority
+        .execute(
+            "SELECT content FROM lix_file WHERE path='/checkpoint.bin'",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.rows()[0].get::<Vec<u8>>("content").unwrap(), content);
+}

--- a/packages/lix/src/sync/partial_sql_tests/runtime_http.rs
+++ b/packages/lix/src/sync/partial_sql_tests/runtime_http.rs
@@ -208,6 +208,25 @@ async fn http_dispatcher_recovers_lost_wave_and_preserves_newer_local_edit() {
 
 #[tokio::test]
 async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
+    file_checkpoint_upload_case(false, 1024 * 1024, false).await;
+}
+
+#[tokio::test]
+async fn file_checkpoint_upload_pages_offline_edits_and_repeated_checkpoints() {
+    file_checkpoint_upload_case(true, 1024 * 1024, false).await;
+}
+
+#[tokio::test]
+async fn file_checkpoint_upload_pages_aggregate_wire_bytes() {
+    file_checkpoint_upload_case(true, 8 * 1024, false).await;
+}
+
+#[tokio::test]
+async fn file_ordinary_upload_pages_aggregate_wire_bytes() {
+    file_checkpoint_upload_case(true, 8 * 1024, true).await;
+}
+
+async fn file_checkpoint_upload_case(paging: bool, wire_budget: usize, ordinary_only: bool) {
     let backing = Memory::new();
     let authority = open_lix().with_storage(backing.clone()).await.unwrap();
     authority
@@ -220,6 +239,15 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
         )
         .await
         .unwrap();
+    if paging {
+        authority
+            .execute(
+                "INSERT INTO lix_key_value(key,value) VALUES('checkpoint-excluded','before')",
+                &[],
+            )
+            .await
+            .unwrap();
+    }
     let server = open_lix()
         .with_storage(backing)
         .serve()
@@ -284,22 +312,56 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
     )
     .await
     .unwrap();
-    let content = vec![43u8; 96 * 1024];
-    execute_hydrating(
-        &session,
-        &storage,
-        &old,
-        &authority,
-        "UPDATE lix_file SET content=$1 WHERE path='/checkpoint.bin'",
-        &[Value::Blob(content.clone().into())],
-        &mut fetches,
-    )
-    .await
-    .unwrap();
-    execute_hydrating(&session, &storage, &old, &authority,
-        "SELECT commit_id FROM lix_create_checkpoint(ARRAY(SELECT row_ref FROM lix_diff('lix_file') WHERE to_path='/checkpoint.bin'))",
-        &[], &mut fetches,
-    ).await.unwrap();
+    if paging {
+        execute_hydrating(
+            &session,
+            &storage,
+            &old,
+            &authority,
+            "UPDATE lix_key_value SET value='still-pending' WHERE key='checkpoint-excluded'",
+            &[],
+            &mut fetches,
+        )
+        .await
+        .unwrap();
+    }
+    let mut content = Vec::new();
+    for checkpoint_index in 0..if paging { 2 } else { 1 } {
+        for edit in 0..if paging { 40 } else { 1 } {
+            content = vec![(43 + checkpoint_index * 41 + edit) as u8; 96 * 1024];
+            execute_hydrating(
+                &session,
+                &storage,
+                &old,
+                &authority,
+                "UPDATE lix_file SET content=$1 WHERE path='/checkpoint.bin'",
+                &[Value::Blob(content.clone().into())],
+                &mut fetches,
+            )
+            .await
+            .unwrap();
+        }
+        if !ordinary_only {
+            execute_hydrating(&session, &storage, &old, &authority,
+            "SELECT commit_id FROM lix_create_checkpoint(ARRAY(SELECT row_ref FROM lix_diff('lix_file') WHERE to_path='/checkpoint.bin'))",
+            &[], &mut fetches,
+        ).await.unwrap();
+        }
+    }
+    if paging {
+        content = vec![199u8; 96 * 1024];
+        execute_hydrating(
+            &session,
+            &storage,
+            &old,
+            &authority,
+            "UPDATE lix_file SET content=$1 WHERE path='/checkpoint.bin'",
+            &[Value::Blob(content.clone().into())],
+            &mut fetches,
+        )
+        .await
+        .unwrap();
+    }
     let branch = &old.descriptor().selected_branch.branch_id;
     let first = crate::sync::partial_upload_cycle::upload_partial_once(
         &storage,
@@ -307,10 +369,12 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
         branch,
         uuid::Uuid::now_v7().to_string(),
         32,
-        1024 * 1024,
+        wire_budget,
         |request| {
             let (storage, old, transport) = (&storage, &old, &transport);
             async move {
+                assert!(request.commits.len() <= 32);
+                assert!(serde_json::to_vec(&request).unwrap().len() <= wire_budget);
                 crate::sync::partial_blob_upload::push_partial_with_blobs(
                     storage, old, transport, &request,
                 )
@@ -334,6 +398,28 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
         .prepared
         .expect("lost response retains exact upload");
     drop(read);
+    if paging {
+        let too_small = crate::sync::partial_upload_cycle::upload_partial_once(
+            &storage,
+            &old,
+            branch,
+            uuid::Uuid::now_v7().to_string(),
+            32,
+            1,
+            |_| async {
+                panic!("a captured upload must not be recut or sent under a smaller retry budget")
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(too_small.code, "LIX_PARTIAL_UPLOAD_PREPARATION_REQUIRED");
+        let read = storage.begin_read(Default::default()).await.unwrap();
+        let (unchanged, _, _) =
+            crate::sync::partial_push_state::load_partial_push_state(&read, &old, branch)
+                .await
+                .unwrap();
+        assert_eq!(unchanged.prepared.as_ref(), Some(&captured));
+    }
     assert!(
         crate::sync::partial_upload_cycle::upload_partial_once(
             &storage,
@@ -341,7 +427,7 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
             branch,
             uuid::Uuid::now_v7().to_string(),
             32,
-            1024 * 1024,
+            wire_budget,
             |request| {
                 let (storage, old, transport) = (&storage, &old, &transport);
                 async move {
@@ -355,13 +441,134 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
         .await
         .unwrap()
     );
+    let mut extra_waves = 0;
+    let mut lost_checkpoint_ack = false;
+    if paging {
+        assert_eq!(
+            captured.target.checkpoint, captured.expected.checkpoint,
+            "ordinary source prefix must retain authority checkpoint"
+        );
+        loop {
+            let result = crate::sync::partial_upload_cycle::upload_partial_once(
+                &storage,
+                &old,
+                branch,
+                uuid::Uuid::now_v7().to_string(),
+                32,
+                wire_budget,
+                |request| {
+                    let (storage, old, transport, lost) =
+                        (&storage, &old, &transport, &mut lost_checkpoint_ack);
+                    async move {
+                        assert!(request.commits.len() <= 32);
+                        assert!(serde_json::to_vec(&request).unwrap().len() <= wire_budget);
+                        let changes_checkpoint = request
+                            .ref_updates
+                            .iter()
+                            .any(|r| r.checkpoint_commit_id != r.expected_checkpoint_commit_id);
+                        let response = crate::sync::partial_blob_upload::push_partial_with_blobs(
+                            storage, old, transport, &request,
+                        )
+                        .await?;
+                        if changes_checkpoint && !*lost {
+                            *lost = true;
+                            return Err(LixError::new(
+                                "TEST_LOST_CHECKPOINT_ACK",
+                                "lost checkpoint wave ACK",
+                            ));
+                        }
+                        Ok(response)
+                    }
+                },
+            )
+            .await;
+            match result {
+                Ok(false) => break,
+                Ok(true) => {}
+                Err(error) if error.code == "TEST_LOST_CHECKPOINT_ACK" => {
+                    // The worker refreshes descriptors between retries. Exact
+                    // authority coordinates recover this ACK before refusing to
+                    // replace the still-newer local working state.
+                    let refreshed = prepare_descriptor_with_merge(
+                        engine.clone(),
+                        old.clone(),
+                        &transport,
+                        transport.partial_replica_descriptor(None).await.unwrap(),
+                        crate::sync::partial_publication::PartialRecoveryPolicy::Normal,
+                    )
+                    .await;
+                    assert_eq!(
+                        refreshed
+                            .err()
+                            .expect("newer local state remains pending")
+                            .code,
+                        "LIX_PARTIAL_REPLICA_REBASE_REQUIRED"
+                    );
+                    let read = storage.begin_read(Default::default()).await.unwrap();
+                    let (recovered, _, _) =
+                        crate::sync::partial_push_state::load_partial_push_state(
+                            &read, &old, branch,
+                        )
+                        .await
+                        .unwrap();
+                    assert!(
+                        recovered.prepared.is_none(),
+                        "descriptor retry settles the exact accepted wave"
+                    );
+                }
+                Err(error) => panic!("paged checkpoint upload: {error}"),
+            }
+            let excluded = authority
+                .execute(
+                    "SELECT value FROM lix_key_value WHERE key='checkpoint-excluded'",
+                    &[],
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                excluded.rows()[0]
+                    .get::<serde_json::Value>("value")
+                    .unwrap(),
+                serde_json::json!("still-pending"),
+                "intermediate selected checkpoints must preserve excluded working rows"
+            );
+            extra_waves += 1;
+            assert!(
+                extra_waves < 128,
+                "checkpoint upload must make bounded progress"
+            );
+        }
+        assert!(extra_waves >= 3);
+        assert_eq!(lost_checkpoint_ack, !ordinary_only);
+        if ordinary_only {
+            assert_eq!(
+                captured.target.checkpoint,
+                old.descriptor().selected_branch.checkpoint.commit_id
+            );
+        }
+    }
     let read = storage.begin_read(Default::default()).await.unwrap();
     let (settled, _, _) =
         crate::sync::partial_push_state::load_partial_push_state(&read, &old, branch)
             .await
             .unwrap();
     assert!(settled.prepared.is_none());
-    assert_eq!(settled.confirmed, captured.target);
+    if !paging {
+        assert_eq!(settled.confirmed, captured.target);
+    }
+    let control = crate::branch::BranchHeadControlContext::new()
+        .reader(&read)
+        .load(branch)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(settled.confirmed.head, control.head_commit_id.to_string());
+    assert_eq!(
+        Some(settled.confirmed.checkpoint.clone()),
+        control
+            .working_diff_checkpoint_commit_id
+            .map(|id| id.to_string())
+    );
     drop(read);
     let descriptor = authority
         .partial_replica_descriptor(Some(branch))
@@ -369,7 +576,7 @@ async fn file_checkpoint_upload_retries_lost_ack_with_original_content() {
         .unwrap();
     assert_eq!(
         descriptor.selected_branch.checkpoint.commit_id,
-        captured.target.checkpoint
+        settled.confirmed.checkpoint
     );
     let result = authority
         .execute(

--- a/packages/lix/src/sync/partial_upload.rs
+++ b/packages/lix/src/sync/partial_upload.rs
@@ -48,7 +48,7 @@ impl std::io::Write for ByteBudget {
 
 /// Locally authored graph records must remain durable until upload. A missing
 /// one is not a demand for an object the authority has never received.
-async fn local_record(
+pub(super) async fn local_record(
     read: &(impl StorageAdapterRead + ?Sized),
     commit: CommitId,
 ) -> Result<CommitRecord, LixError> {
@@ -124,6 +124,94 @@ pub(super) async fn prepare_partial_ordinary_upload(
     max_commits: usize,
     max_wire_bytes: usize,
 ) -> Result<Option<PreparedPartialPush>, LixError> {
+    prepare_partial_ordinary_budgeted(
+        read,
+        state,
+        branch_id,
+        attempt_id,
+        max_commits,
+        max_wire_bytes,
+        None,
+    )
+    .await
+}
+
+/// Publish only ordinary ancestors of a locally captured checkpoint source.
+/// The authority's checkpoint remains unchanged until its full closure fits.
+pub(super) async fn prepare_partial_checkpoint_prefix(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state: &PartialReplicaState,
+    branch_id: &str,
+    attempt_id: String,
+    max_commits: usize,
+    max_wire_bytes: usize,
+    checkpoint: CommitId,
+) -> Result<Option<PreparedPartialPush>, LixError> {
+    prepare_partial_ordinary_budgeted(
+        read,
+        state,
+        branch_id,
+        attempt_id,
+        max_commits,
+        max_wire_bytes,
+        Some(checkpoint),
+    )
+    .await
+}
+
+async fn prepare_partial_ordinary_budgeted(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state: &PartialReplicaState,
+    branch_id: &str,
+    attempt_id: String,
+    max_commits: usize,
+    max_wire_bytes: usize,
+    checkpoint_prefix: Option<CommitId>,
+) -> Result<Option<PreparedPartialPush>, LixError> {
+    let can_shrink = load_partial_push_state(read, state, branch_id)
+        .await?
+        .0
+        .prepared
+        .is_none();
+    let mut limit = max_commits;
+    loop {
+        match prepare_partial_ordinary_upload_inner(
+            read,
+            state,
+            branch_id,
+            attempt_id.clone(),
+            limit,
+            max_wire_bytes,
+            checkpoint_prefix,
+        )
+        .await
+        {
+            Err(error)
+                if error.code == "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED" && can_shrink && limit > 1 =>
+            {
+                limit = (limit / 2).max(1);
+            }
+            Err(error) if error.code == "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED" => {
+                return Err(blocked(if can_shrink {
+                    "one native commit exceeds the upload request budget; multipart body preparation is required"
+                } else {
+                    "captured upload exceeds the requested byte budget; retry the immutable attempt with its original supported budget"
+                }));
+            }
+            result => return result,
+        }
+    }
+}
+
+async fn prepare_partial_ordinary_upload_inner(
+    read: &(impl StorageAdapterRead + ?Sized),
+    state: &PartialReplicaState,
+    branch_id: &str,
+    attempt_id: String,
+    max_commits: usize,
+    max_wire_bytes: usize,
+    checkpoint_prefix: Option<CommitId>,
+) -> Result<Option<PreparedPartialPush>, LixError> {
     if max_commits == 0 || max_commits > super::MAX_SYNC_REQUEST_ITEMS || max_wire_bytes == 0 {
         return Err(blocked("invalid partial upload work budget"));
     }
@@ -155,6 +243,21 @@ pub(super) async fn prepare_partial_ordinary_upload(
             head: control.head_commit_id.to_string(),
             checkpoint: checkpoint.to_string(),
         });
+    if let Some(checkpoint) = checkpoint_prefix {
+        if resumed.is_some() {
+            return Err(blocked(
+                "checkpoint prefix cannot replace a durable upload attempt",
+            ));
+        }
+        let (source_branch, source) = super::commit::load_sync_checkpoint_source(read, checkpoint)
+            .await?
+            .ok_or_else(|| blocked("checkpoint prefix requires its captured native source"))?;
+        if source_branch != branch_id {
+            return Err(blocked("checkpoint source belongs to another branch"));
+        }
+        target.head = source.to_string();
+        target.checkpoint = branch_state.confirmed.checkpoint.clone();
+    }
     if target == branch_state.confirmed {
         return Ok(None);
     }
@@ -264,8 +367,12 @@ pub(super) async fn prepare_partial_ordinary_upload(
                 "local commit requires physical source closure preparation",
             ));
         }
-        serde_json::to_writer(&mut budget, &commit)
-            .map_err(|_| blocked("local suffix exceeds wire byte budget"))?;
+        serde_json::to_writer(&mut budget, &commit).map_err(|_| {
+            LixError::new(
+                "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED",
+                "local suffix exceeds wire byte budget",
+            )
+        })?;
         known.insert(record.commit_id);
         commits.push(commit);
     }
@@ -324,8 +431,12 @@ pub(super) async fn prepare_partial_ordinary_upload(
         remaining: max_wire_bytes,
         written: 0,
     };
-    serde_json::to_writer(&mut budget, &request)
-        .map_err(|_| blocked("partial upload request exceeds wire byte budget"))?;
+    serde_json::to_writer(&mut budget, &request).map_err(|_| {
+        LixError::new(
+            "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED",
+            "partial upload request exceeds wire byte budget",
+        )
+    })?;
     Ok(Some(PreparedPartialPush {
         upload,
         request,
@@ -1028,7 +1139,7 @@ mod created_ref_prefix_tests {
 
 /// Only ancestry of the confirmed authority GLOBAL coordinate can extend the
 /// tiny known-base frontier. Local presence alone is not an upload proof.
-async fn is_confirmed_global_base(
+pub(super) async fn is_confirmed_global_base(
     read: &(impl StorageAdapterRead + ?Sized),
     base: CommitId,
     confirmed: CommitId,

--- a/packages/lix/src/sync/partial_upload_cycle.rs
+++ b/packages/lix/src/sync/partial_upload_cycle.rs
@@ -44,15 +44,31 @@ where
         })
         .ok_or_else(|| LixError::unknown("partial upload branch checkpoint disappeared"))?;
     let prepared = if target_checkpoint != push.confirmed.checkpoint {
-        super::partial_checkpoint_upload::prepare_partial_checkpoint_upload(
+        let checkpoint = super::partial_checkpoint_upload::prepare_partial_checkpoint_upload(
             &read,
             state,
             branch_id,
-            attempt_id,
+            attempt_id.clone(),
             max_commits,
             max_wire_bytes,
         )
-        .await?
+        .await;
+        match checkpoint {
+            Err(error)
+                if error.code == "LIX_PARTIAL_UPLOAD_PAGE_REQUIRED" && push.prepared.is_none() =>
+            {
+                super::partial_checkpoint_upload::prepare_partial_checkpoint_page(
+                    &read,
+                    state,
+                    branch_id,
+                    attempt_id,
+                    max_commits,
+                    max_wire_bytes,
+                )
+                .await?
+            }
+            result => result?,
+        }
     } else {
         prepare_partial_ordinary_upload(
             &read,

--- a/packages/lix/src/sync/runtime.rs
+++ b/packages/lix/src/sync/runtime.rs
@@ -294,24 +294,8 @@ impl SyncRuntime {
     }
 }
 
-fn demand_replay_is_forbidden(error: &LixError) -> bool {
-    error.code == LixError::CODE_STORAGE_COMMIT_OUTCOME_UNKNOWN
-        || error
-            .details
-            .as_ref()
-            .and_then(|details| details.get("nonRetryableAfterCommit"))
-            .and_then(serde_json::Value::as_bool)
-            == Some(true)
-        || error
-            .details
-            .as_ref()
-            .and_then(|details| details.get("nonRetryableAfterExecution"))
-            .and_then(serde_json::Value::as_bool)
-            == Some(true)
-}
-
 fn sync_demand_request_for_error(error: &LixError) -> Result<Option<SyncDemandRequest>, LixError> {
-    if demand_replay_is_forbidden(error) {
+    if error.automatic_retry_is_forbidden() {
         return Ok(None);
     }
     let (field, context, constructor): (_, _, fn(Vec<String>) -> _) = match error.code.as_str() {
@@ -370,7 +354,7 @@ fn sync_demand_request_for_error(error: &LixError) -> Result<Option<SyncDemandRe
 pub(super) fn native_sync_demand_request_for_error(
     error: &LixError,
 ) -> Result<Option<SyncDemandRequest>, LixError> {
-    if demand_replay_is_forbidden(error) {
+    if error.automatic_retry_is_forbidden() {
         return Ok(None);
     }
     if let Some(crate::binary_cas::BlobManifestRequired(hash)) =
@@ -441,7 +425,7 @@ pub(crate) struct SyncDemandRetry {
 
 impl SyncDemandRetry {
     fn admit(&mut self, error: LixError) -> Result<SyncDemandRequest, LixError> {
-        if demand_replay_is_forbidden(&error) {
+        if error.automatic_retry_is_forbidden() {
             return Err(error);
         }
         let Some(request) = native_sync_demand_request_for_error(&error)? else {
@@ -514,6 +498,10 @@ where
 }
 
 fn is_retryable_authority_validation_error(error: &LixError) -> bool {
+    if error.automatic_retry_is_forbidden() {
+        return false;
+    }
+
     error.code == LixError::CODE_STORAGE_READ_EXPIRED
 }
 
@@ -910,6 +898,10 @@ fn is_permanent_push_rejection(error: &LixError) -> bool {
 }
 
 fn is_retryable_sync_transport_error(error: &LixError) -> bool {
+    if error.automatic_retry_is_forbidden() {
+        return false;
+    }
+
     if error.code == super::http::SYNC_TRANSPORT_ERROR_CODE {
         return true;
     }
@@ -922,6 +914,10 @@ fn is_retryable_sync_transport_error(error: &LixError) -> bool {
 }
 
 fn is_retryable_sync_demand_error(error: &LixError) -> bool {
+    if error.automatic_retry_is_forbidden() {
+        return false;
+    }
+
     // A durable browser replica can briefly have two publication workers while
     // an old page is closing. If the sibling commits first, this worker's
     // coherent read expires. The authority operation is already identified and
@@ -932,6 +928,10 @@ fn is_retryable_sync_demand_error(error: &LixError) -> bool {
 }
 
 fn retry_sync_iteration_without_reconnect(error: &LixError) -> bool {
+    if error.automatic_retry_is_forbidden() {
+        return false;
+    }
+
     error.code == LixError::CODE_STORAGE_READ_EXPIRED
 }
 

--- a/packages/storage-opfs/README.md
+++ b/packages/storage-opfs/README.md
@@ -19,6 +19,15 @@ offline, and local commits upload in the background. The default `"remote"` mode
 rejects local storage. See
 [Collaboration and Sync](https://lix.dev/docs/collaboration-and-sync).
 
+Partial replicas coordinate one Lix engine per physical OPFS database through an
+SDK-owned SharedWorker. Each tab receives an independent session on that engine,
+so loaded data and pending offline edits are shared. Closing one tab releases its
+sessions without closing the other tabs' engine. This is automatic with the
+existing `openLix()` options and requires SharedWorker support in addition to
+OPFS and Web Locks. The physical engine-owner lock remains the final fence across
+different SDK builds. Sessions still obey the partial replica's admitted branch
+scope; sharing an engine does not admit every repository branch.
+
 `OpfsStorage` starts one package-owned dedicated worker in the page. The Lix
 engine workers use a package-internal `BroadcastChannel` RPC client, while the
 owner worker holds the SQLite Wasm OPFS SAH-pool connection. This keeps the
@@ -26,10 +35,10 @@ SQLite connection and OPFS sync handles in one worker, while multiple tabs and
 multiple Lix workers attach to the same repository. Writes are batched before
 crossing the channel and commits are serialized by the owner.
 
-The owner is deliberately a dedicated worker rather than a SharedWorker:
+The SQLite owner is deliberately a dedicated worker rather than a SharedWorker:
 SQLite's OPFS sync-access-handle VFS is only available in dedicated workers.
-A SharedWorker coordinator can be added later without changing this provider
-protocol, but it must not host the SQLite connection itself.
+The partial-engine SharedWorker uses this provider protocol and does not host
+the SQLite connection itself.
 
 After every committed write, the owner broadcasts a package-private storage
 position. Each attached provider turns a changed position into the SDK's

--- a/packages/storage-opfs/js/index.ts
+++ b/packages/storage-opfs/js/index.ts
@@ -3,6 +3,7 @@ import type {
 	LixStorageProviderRegistration,
 } from "@lix-js/sdk";
 import { OPFS_RPC_CHANNEL } from "./rpc.js";
+import { physicalName } from "./physical-name.js";
 
 export type OpfsStorageOptions = {
 	/** Identifies one persistent Lix database within the current origin. */
@@ -38,6 +39,9 @@ export class OpfsStorage implements LixStorage {
 				name: this.name,
 				mode: shared ? "shared" : "direct",
 				channelName: shared ? OPFS_RPC_CHANNEL : undefined,
+				// Internal SDK coordination; all engines for this physical file
+				// attach to one broker while the native owner fence stays intact.
+				sharedEngineKey: shared ? `lix:opfs:${physicalName(this.name)}` : undefined,
 			},
 		};
 	}

--- a/packages/storage-opfs/js/partial-owner.ts
+++ b/packages/storage-opfs/js/partial-owner.ts
@@ -1,3 +1,5 @@
+import { physicalName } from "./physical-name.js";
+
 /** A synchronous acquisition handle makes cancellation safe before ready settles. */
 export function acquirePartialOwner(name: string): { ready: Promise<void>; close(): void } {
  let closed = false;
@@ -20,8 +22,7 @@ export function acquirePartialOwner(name: string): { ready: Promise<void>; close
  }
  // The OPFS filename is derived from TextEncoder bytes. Use those same bytes
  // so lone-surrogate aliases cannot acquire distinct locks for one file.
- const physicalName = Array.from(new TextEncoder().encode(name), byte => byte.toString(16).padStart(2,"0")).join("");
- void navigator.locks.request(`lix:partial-engine:${physicalName}`, {mode:"exclusive",ifAvailable:true}, async lock => {
+ void navigator.locks.request(`lix:partial-engine:${physicalName(name)}`, {mode:"exclusive",ifAvailable:true}, async lock => {
   if (closed) return;
   if (!lock) {
    rejectReady(Object.assign(new Error("This OPFS database already has a partial engine owner"), {code:"LIX_STORAGE_IN_USE"}));

--- a/packages/storage-opfs/js/physical-name.ts
+++ b/packages/storage-opfs/js/physical-name.ts
@@ -1,0 +1,6 @@
+/** Package-private identity shared by the physical owner fence and SDK broker. */
+export function physicalName(name: string): string {
+	return Array.from(new TextEncoder().encode(name), (byte) =>
+		byte.toString(16).padStart(2, "0"),
+	).join("");
+}

--- a/packages/storage-opfs/tests/partial-owner.browser.test.ts
+++ b/packages/storage-opfs/tests/partial-owner.browser.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "vitest";
 import { acquirePartialOwner } from "../js/partial-owner.js";
+import { physicalName } from "../js/physical-name.js";
+
+test("shared engine identity follows physical UTF-8 filenames", () => {
+ expect(physicalName("replica\ud800")).toBe(physicalName("replica\ud801"));
+ expect(physicalName("replica-a")).not.toBe(physicalName("replica-b"));
+});
 
 async function reacquire(name: string) {
  for (let i=0;i<100;i++) {


### PR DESCRIPTION
Opening the same OPFS partial replica in two browser tabs currently starts competing engines and rejects the second tab with `LIX_STORAGE_IN_USE`. An internal SharedWorker now owns one engine per physical database and gives each client an independent session. Tabs share resident data and pending offline edits, while the existing native ownership fence remains intact. No public API or cache-name change is required.

The broker isolates client requests, observations and transactions, drains accepted work on disconnect, and releases sessions when a page disappears. Initial admission freezes the credentials used by native opening; new clients probe their identity, with bounded in-memory offline reuse for previously admitted explicit credentials. HTTP/auth failures never trigger that fallback. The SQLite OPFS owner remains a dedicated worker. The first client retains the native opening report; later clients do not repeat initialization claims.

Checkpoint history had a separate failure: missing graph nodes from the mainline reader reached the partial runtime without typed native addresses. Both graph readers now preserve those addresses so SQL can hydrate the missing metadata and subsequently read the same history offline.

File checkpoints had an obsolete rejection of binary references before the upload transport could prepare their manifests and chunks. Checkpoint uploads now use the existing bounded blob preparation path before publishing refs. A real HTTP regression exercises a blob-backed selected checkpoint, a lost acknowledgment, exact retry, and authority content convergence.

Long offline edit sequences and checkpoint dependencies now upload in bounded waves. Fresh ordinary uploads reduce their commit count to fit the byte budget; checkpoint uploads advance through captured native sources and original working children. Durable attempts keep their exact request target after lost replies. Tests cover multiple offline checkpoints, excluded rows, byte-budget paging, and lost acknowledgments. A single commit or minimal checkpoint closure larger than 1 MiB remains pending until multipart preparation is supported; binary content uses the separate blob uploader.

SQL retry loops now honor existing `nonRetryableAfterCommit` and `nonRetryableAfterExecution` markers before classifying transient errors. A durable Memory mutation followed by an injected completion failure verifies that the error cannot cause another execution. Read-interest journal flushing retries its own expired snapshots, so a concurrent publication does not turn completed SQL into a startup failure. Canonical Memory faults and a strict INSERT/reopen regression verify that bookkeeping can recover without replaying the statement.

Each attached session now receives its own telemetry sink and independent trace parent. Nested sessions inherit their caller's sink. Shared engine background spans reach live subscribers, including clients attached after an initial client without telemetry. This addresses the PR review's first-tab callback finding.

Validation: the final combined native source passed all 4,011 tests with all simulations and server-protocol coverage, plus 10 doctests. The final release WASM build and 22 browser tests passed (one unrelated skip), including real WASM telemetry isolation and the real SharedWorker regression. The production Lixray history scenario passed in 50 seconds, covering shared-tab editing, offline checkpoint/reconnect, concurrent file creation, reopen and selective history. A separate reproduction of the startup race passed all 12 opens across six fresh paired-tab trials. Matched-source profiling passed all six fresh runs (three per arm): median SDK opening 283 ms small / 287 ms with 320 MiB, with two requests and about 2.3 KB in both cases. Session readiness including navigation SQL was 467/469 ms; warm offline writes 8.6/9.75 ms. All 180 offline writes and 360 reads passed with zero native-input requests. These local measurements exclude module import/downloads, HTTP headers, full UI rendering, and server startup. The 693 ms small-run outlier remains in the data; cold SELECT was 64/116 ms.

Independent reviews approved authentication/ownership, per-session telemetry, completion retry boundaries, ordinary/checkpoint paging, immutable upload retries, excluded-row preservation, journal durability and explicit oversized-body handling. The unchanged TypeScript layer previously passed 11 focused SDK tests and typechecks. A real OPFS diagnostic also verified initiating-tab closure, surviving-tab edits and durable offline reopen. Worker-process crash during an accepted mutation was not separately profiled.

This unblocks the partial-replica integration in opral/lixray#376. Sessions continue to obey the engine's admitted branch scope; this does not add arbitrary simultaneous branch admission.
