### PR TITLE
Support scalar SQL UPDATE on current partial-replica main

### DIFF
--- a/.changenotes/scalar-write-expressions.md
+++ b/.changenotes/scalar-write-expressions.md
@@ -2,6 +2,8 @@
 type: patch
 ---
 
-SQL updates now support scalar expressions such as `replace`, `concat`, `coalesce`, and string concatenation in file and row mutations.
+SQL `UPDATE` statements now support scalar expressions such as `replace`, `concat`, `coalesce`, and string concatenation in file and row mutations.
 
-Assignments, filters, and returned expressions use the same scalar function rules as reads. Invalid expressions reject the mutation atomically. Partial replicas can use resident file content in an exact-path expression update while offline.
+Update assignments, filters, and returned expressions use the same scalar function rules as reads. Invalid expressions reject the mutation atomically. Partial replicas can use resident file content in an exact-path expression update while offline.
+
+These additional scalar expressions, such as `upper` and `concat`, remain unsupported in registered-row `INSERT` values, upsert assignments, and insert `RETURNING`; those statements fail without changing rows.

--- a/.changenotes/scalar-write-expressions.md
+++ b/.changenotes/scalar-write-expressions.md
@@ -1,0 +1,7 @@
+---
+type: patch
+---
+
+SQL updates now support scalar expressions such as `replace`, `concat`, `coalesce`, and string concatenation in file and row mutations.
+
+Assignments, filters, and returned expressions use the same scalar function rules as reads. Invalid expressions reject the mutation atomically. Partial replicas can use resident file content in an exact-path expression update while offline.

--- a/packages/e2e/tests/sync_mode.rs
+++ b/packages/e2e/tests/sync_mode.rs
@@ -3441,6 +3441,15 @@ mod plugin_merge;
 
 #[tokio::test]
 async fn content_only_path_read_prepares_first_offline_opaque_update() {
+    content_only_path_read_prepares_offline_update(false).await;
+}
+
+#[tokio::test]
+async fn content_only_path_read_prepares_first_offline_scalar_expression_update() {
+    content_only_path_read_prepares_offline_update(true).await;
+}
+
+async fn content_only_path_read_prepares_offline_update(scalar_expression: bool) {
     let (storage, authority) = open_authority().await;
     for index in 0..16 {
         put_value(&authority, &format!("unrelated-{index}"), "untouched").await;
@@ -3479,15 +3488,21 @@ async fn content_only_path_read_prepares_first_offline_opaque_update() {
         Some(original)
     );
     probe.set_offline(true);
-    let updated = vec![65u8; 96 * 1024];
-    replica
-        .execute(
-            "UPDATE lix_file SET content=$1 WHERE path=$2",
-            &[
-                Value::Blob(updated.clone().into()),
-                Value::Text("/content-only.bin".into()),
-            ],
+    let mut updated = vec![65u8; 96 * 1024];
+    let (sql, value) = if scalar_expression {
+        updated.extend_from_slice("-β".as_bytes());
+        (
+            "UPDATE lix_file SET content=CAST(concat(replace(CAST(content AS TEXT), '0', 'A'), $1) AS BYTEA) WHERE path=$2",
+            Value::Text("-β".into()),
         )
+    } else {
+        (
+            "UPDATE lix_file SET content=$1 WHERE path=$2",
+            Value::Blob(updated.clone().into()),
+        )
+    };
+    replica
+        .execute(sql, &[value, Value::Text("/content-only.bin".into())])
         .await
         .expect("content SELECT alone prepares the first local content update");
     assert_eq!(

--- a/packages/lix/src/sql2/bind/expr.rs
+++ b/packages/lix/src/sql2/bind/expr.rs
@@ -30,6 +30,7 @@ pub(crate) enum BoundBinaryOperator {
     Multiply,
     Divide,
     Modulo,
+    StringConcat,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/packages/lix/src/sql2/bind/statement.rs
+++ b/packages/lix/src/sql2/bind/statement.rs
@@ -1047,6 +1047,7 @@ fn bind_arithmetic_operator(op: &BinaryOperator) -> Result<BoundBinaryOperator, 
         BinaryOperator::Multiply => Ok(BoundBinaryOperator::Multiply),
         BinaryOperator::Divide => Ok(BoundBinaryOperator::Divide),
         BinaryOperator::Modulo => Ok(BoundBinaryOperator::Modulo),
+        BinaryOperator::StringConcat => Ok(BoundBinaryOperator::StringConcat),
         _ => Err(super::error::unsupported(format!(
             "unsupported SQL binary operator '{op}'"
         ))),
@@ -1163,7 +1164,7 @@ fn bind_function(
     mut bind_arg_expr: impl FnMut(&Expr, &mut ParamBinder) -> Result<BoundExpr, LixError>,
 ) -> Result<BoundExpr, LixError> {
     reject_unsupported_function_modifiers(function)?;
-    let name = bind_lix_function_name(function)?;
+    let name = bind_scalar_function_name(function)?;
     let raw_args = function_args(&function.args)?;
     let args = raw_args
         .iter()
@@ -1208,9 +1209,8 @@ fn validate_bound_function_arity(name: &str, actual: usize) -> Result<(), LixErr
         | "__lix_json_contains"
         | "__lix_json_exists" => expect_exact_function_arity(name, actual, 2),
         "__lix_jsonb" => expect_exact_function_arity(name, actual, 1),
-        _ => Err(super::error::unsupported(format!(
-            "unsupported SQL function '{name}'"
-        ))),
+        // DataFusion validates the signatures of its scalar functions.
+        _ => Ok(()),
     }
 }
 
@@ -1223,7 +1223,7 @@ fn expect_exact_function_arity(name: &str, actual: usize, expected: usize) -> Re
     Ok(())
 }
 
-fn bind_lix_function_name(function: &Function) -> Result<String, LixError> {
+fn bind_scalar_function_name(function: &Function) -> Result<String, LixError> {
     if function.name.0.len() != 1 {
         return Err(super::error::unsupported(
             "qualified SQL function names are not supported by bound writes",
@@ -1239,22 +1239,9 @@ fn bind_lix_function_name(function: &Function) -> Result<String, LixError> {
     } else {
         ident.value.to_ascii_lowercase()
     };
-    match name.as_str() {
-        "__lix_current_timestamp"
-        | "uuidv7"
-        | "lix_active_branch_id"
-        | "lix_active_branch_commit_id"
-        | "__lix_json_get"
-        | "__lix_json_get_text"
-        | "__lix_json_path_get"
-        | "__lix_json_path_get_text"
-        | "__lix_json_contains"
-        | "__lix_json_exists"
-        | "__lix_jsonb" => Ok(name),
-        _ => Err(super::error::unsupported(format!(
-            "unsupported SQL function '{name}'"
-        ))),
-    }
+    // Resolve ordinary scalar functions against the DataFusion registry during planning.
+    // The optimized row evaluator declines functions it cannot evaluate.
+    Ok(name)
 }
 
 fn function_args(args: &FunctionArguments) -> Result<Vec<&Expr>, LixError> {

--- a/packages/lix/src/sql2/exec/datafusion.rs
+++ b/packages/lix/src/sql2/exec/datafusion.rs
@@ -1515,6 +1515,40 @@ fn write_provider_selection(plan: &LogicalWritePlan, target_table_name: &str) ->
     }
 }
 
+/// Bound mutations bypass the SQL planner, so apply the same coercion and
+/// function rewrites as SessionState::create_physical_expr before providers
+/// inspect or compile these expressions (including their scan filters).
+fn prepare_write_expr(
+    session: &SessionContext,
+    schema: &DFSchema,
+    expr: Expr,
+) -> Result<Expr, LixError> {
+    use datafusion::logical_expr::simplify::SimplifyContext;
+    use datafusion::optimizer::simplify_expressions::ExprSimplifier;
+
+    let state = session.state();
+    let config = state.config_options();
+    let context = SimplifyContext::default()
+        .with_schema(std::sync::Arc::new(schema.clone()))
+        .with_config_options(std::sync::Arc::clone(config))
+        .with_query_execution_start_time(state.execution_props().query_execution_start_time);
+    let simplifier = ExprSimplifier::new(context);
+    let mut expr = simplifier
+        .coerce(expr, schema)
+        .map_err(datafusion_error_to_lix_error)?;
+    for rewrite in state.analyzer().function_rewrites() {
+        expr = expr
+            .transform_up(|expr| rewrite.rewrite(expr, schema, config))
+            .map_err(datafusion_error_to_lix_error)?
+            .data;
+    }
+    // Some scalar functions (for example COALESCE) lower to executable
+    // expressions during simplification rather than physical planning.
+    simplifier
+        .simplify(expr)
+        .map_err(datafusion_error_to_lix_error)
+}
+
 fn datafusion_dml_returning(
     session: &SessionContext,
     table_schema: &Schema,
@@ -1532,7 +1566,11 @@ fn datafusion_dml_returning(
     let mut required_columns = BTreeSet::new();
 
     for item in &returning.items {
-        let expr = datafusion_expr_from_bound_expr(session, &item.expr, params)?;
+        let expr = prepare_write_expr(
+            session,
+            &df_schema,
+            datafusion_expr_from_bound_expr(session, &item.expr, params)?,
+        )?;
         let (_, inferred_field) = expr
             .to_field(&df_schema)
             .map_err(datafusion_error_to_lix_error)?;
@@ -1644,9 +1682,13 @@ fn datafusion_assignments(
             let field = schema
                 .field_with_name(&assignment.column.name)
                 .map_err(|error| LixError::unknown(format!("unknown update column: {error}")))?;
-            let expr = datafusion_expr_from_bound_expr(session, &assignment.value, params)?
-                .cast_to(field.data_type(), &df_schema)
-                .map_err(datafusion_error_to_lix_error)?;
+            let expr = prepare_write_expr(
+                session,
+                &df_schema,
+                datafusion_expr_from_bound_expr(session, &assignment.value, params)?,
+            )?
+            .cast_to(field.data_type(), &df_schema)
+            .map_err(datafusion_error_to_lix_error)?;
             Ok((assignment.column.name.clone(), expr))
         })
         .collect()
@@ -1690,9 +1732,13 @@ fn datafusion_conflict_assignments(
             let field = schema
                 .field_with_name(&assignment.column.name)
                 .map_err(|error| LixError::unknown(format!("unknown conflict column: {error}")))?;
-            let expr = datafusion_expr_from_bound_expr(session, &assignment.value, params)?
-                .cast_to(field.data_type(), &df_schema)
-                .map_err(datafusion_error_to_lix_error)?;
+            let expr = prepare_write_expr(
+                session,
+                &df_schema,
+                datafusion_expr_from_bound_expr(session, &assignment.value, params)?,
+            )?
+            .cast_to(field.data_type(), &df_schema)
+            .map_err(datafusion_error_to_lix_error)?;
             let physical =
                 datafusion::physical_expr::create_physical_expr(&expr, &df_schema, &props)
                     .map_err(datafusion_error_to_lix_error)?;
@@ -1707,8 +1753,12 @@ fn datafusion_write_filters(
     plan: &LogicalWritePlan,
     params: &[Value],
 ) -> Result<Vec<Expr>, LixError> {
+    let df_schema = DFSchema::try_from(schema.clone()).map_err(datafusion_error_to_lix_error)?;
     let mut filters =
-        datafusion_filters_from_predicate(session, schema, &plan.bound.predicate, params)?;
+        datafusion_filters_from_predicate(session, schema, &plan.bound.predicate, params)?
+            .into_iter()
+            .map(|expr| prepare_write_expr(session, &df_schema, expr))
+            .collect::<Result<Vec<_>, _>>()?;
     if plan.bound.branch_scope == BranchScope::Global {
         let branch_column = schema
             .field_with_name("branch_id")
@@ -1983,6 +2033,7 @@ fn datafusion_expr_from_bound_expr(
                 BoundBinaryOperator::Multiply => Operator::Multiply,
                 BoundBinaryOperator::Divide => Operator::Divide,
                 BoundBinaryOperator::Modulo => Operator::Modulo,
+                BoundBinaryOperator::StringConcat => Operator::StringConcat,
             },
             Box::new(datafusion_expr_from_bound_expr(session, right, params)?),
         ))),
@@ -2038,7 +2089,7 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
     match &plan.bound.target {
         BoundWriteTarget::Row(crate::sql2::bind::write::RowWriteSurface::Base { schema_key })
             if bound_predicate_contains_like(&plan.bound.predicate)
-                || bound_update_contains_binary(plan) =>
+                || bound_update_requires_datafusion(plan) =>
         {
             Ok(schema_key.clone())
         }
@@ -2068,27 +2119,42 @@ fn write_target_table_name(plan: &LogicalWritePlan) -> Result<String, LixError> 
     }
 }
 
-fn bound_update_contains_binary(plan: &LogicalWritePlan) -> bool {
+fn bound_update_requires_datafusion(plan: &LogicalWritePlan) -> bool {
     matches!(plan.bound.op, BoundWriteOp::Update)
         && (plan
             .bound
             .assignments
             .iter()
-            .any(|assignment| bound_expr_contains_binary(&assignment.value))
-            || bound_predicate_contains_binary(&plan.bound.predicate)
+            .any(|assignment| bound_expr_requires_datafusion(&assignment.value))
+            || bound_predicate_requires_datafusion(&plan.bound.predicate)
             || plan.bound.returning.as_ref().is_some_and(|returning| {
                 returning
                     .items
                     .iter()
-                    .any(|item| bound_expr_contains_binary(&item.expr))
+                    .any(|item| bound_expr_requires_datafusion(&item.expr))
             }))
 }
 
-fn bound_expr_contains_binary(expr: &BoundExpr) -> bool {
+fn bound_expr_requires_datafusion(expr: &BoundExpr) -> bool {
     match expr {
         BoundExpr::Binary { .. } => true,
-        BoundExpr::Cast { expr, .. } => bound_expr_contains_binary(expr),
-        BoundExpr::Function { args, .. } => args.iter().any(bound_expr_contains_binary),
+        BoundExpr::Cast { expr, .. } => bound_expr_requires_datafusion(expr),
+        BoundExpr::Function { name, args } => {
+            !matches!(
+                name.as_str(),
+                "uuidv7"
+                    | "__lix_current_timestamp"
+                    | "lix_active_branch_id"
+                    | "lix_active_branch_commit_id"
+                    | "__lix_json_get"
+                    | "__lix_json_get_text"
+                    | "__lix_json_path_get"
+                    | "__lix_json_path_get_text"
+                    | "__lix_json_contains"
+                    | "__lix_json_exists"
+                    | "__lix_jsonb"
+            ) || args.iter().any(bound_expr_requires_datafusion)
+        }
         BoundExpr::Column(_)
         | BoundExpr::ExcludedColumn(_)
         | BoundExpr::Param(_)
@@ -2096,22 +2162,23 @@ fn bound_expr_contains_binary(expr: &BoundExpr) -> bool {
     }
 }
 
-fn bound_predicate_contains_binary(predicate: &BoundPredicate) -> bool {
+fn bound_predicate_requires_datafusion(predicate: &BoundPredicate) -> bool {
     match predicate {
         BoundPredicate::Eq(left, right) => {
-            bound_expr_contains_binary(left) || bound_expr_contains_binary(right)
+            bound_expr_requires_datafusion(left) || bound_expr_requires_datafusion(right)
         }
         BoundPredicate::Like { expr, pattern, .. } => {
-            bound_expr_contains_binary(expr) || bound_expr_contains_binary(pattern)
+            bound_expr_requires_datafusion(expr) || bound_expr_requires_datafusion(pattern)
         }
         BoundPredicate::IsNull(expr) | BoundPredicate::IsNotNull(expr) => {
-            bound_expr_contains_binary(expr)
+            bound_expr_requires_datafusion(expr)
         }
         BoundPredicate::In { expr, values, .. } => {
-            bound_expr_contains_binary(expr) || values.iter().any(bound_expr_contains_binary)
+            bound_expr_requires_datafusion(expr)
+                || values.iter().any(bound_expr_requires_datafusion)
         }
         BoundPredicate::And(predicates) | BoundPredicate::Or(predicates) => {
-            predicates.iter().any(bound_predicate_contains_binary)
+            predicates.iter().any(bound_predicate_requires_datafusion)
         }
         BoundPredicate::True | BoundPredicate::False => false,
     }

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -2473,3 +2473,43 @@ simulation_test!(
         );
     }
 );
+
+simulation_test!(
+    scalar_row_insert_and_upsert_remain_atomically_unsupported,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+        session.execute("INSERT INTO lix_registered_schema (value) VALUES (CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"expression_rows\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"value\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB))", &[]).await.unwrap();
+        session
+            .execute(
+                "INSERT INTO expression_rows (id, value) VALUES ('one', 'original')",
+                &[],
+            )
+            .await
+            .unwrap();
+        for sql in [
+            "INSERT INTO expression_rows (id, value) VALUES ('two', 'new') RETURNING upper(value)",
+            "INSERT INTO expression_rows (id, value) VALUES ('one', 'changed'), ('two', 'new') ON CONFLICT (id) DO UPDATE SET value = upper(excluded.value)",
+            "INSERT INTO expression_rows (id, value) VALUES ('two', concat('new', '-row'))",
+        ] {
+            let error = session.execute(sql, &[]).await.expect_err(
+                "scalar row insert and upsert require the existing bound mutation owner's support",
+            );
+            assert_eq!(
+                error.code,
+                LixError::CODE_UNSUPPORTED_SQL,
+                "{sql}: {error:?}"
+            );
+            assert_rows_eq(
+                session
+                    .execute("SELECT id, value FROM expression_rows ORDER BY id", &[])
+                    .await
+                    .unwrap(),
+                vec![vec![
+                    Value::Text("one".into()),
+                    Value::Text("original".into()),
+                ]],
+            );
+        }
+    }
+);

--- a/packages/lix/tests/integration/sql/information_schema.rs
+++ b/packages/lix/tests/integration/sql/information_schema.rs
@@ -602,7 +602,10 @@ simulation_test!(
             )
             .await
             .expect("undescribed.id should be readable");
-        assert_eq!(undescribed.rows()[0].value("description").unwrap(), &Value::Null);
+        assert_eq!(
+            undescribed.rows()[0].value("description").unwrap(),
+            &Value::Null
+        );
     }
 );
 
@@ -2277,8 +2280,8 @@ simulation_test!(
                 format!("lix_diff('{relation}', lix_root_commit_id(), '{commit_id}')"),
                 format!("lix_history('{relation}')"),
             ] {
-                let is_diff = surface.starts_with("lix_diff(")
-                    || surface.starts_with("lix_history(");
+                let is_diff =
+                    surface.starts_with("lix_diff(") || surface.starts_with("lix_history(");
                 // File diffs expose content names but intentionally reject byte projection.
                 let projection = if relation == "lix_file" && is_diff {
                     "id, from_path, to_path"
@@ -2316,7 +2319,10 @@ simulation_test!(
             "SELECT result_column FROM information_schema.table_functions WHERE result_column LIKE '%lixcol_schema_key%'",
         ] {
             assert_rows_eq(
-                session.execute(sql, &[]).await.expect("catalog should load"),
+                session
+                    .execute(sql, &[])
+                    .await
+                    .expect("catalog should load"),
                 vec![],
             );
         }
@@ -2331,12 +2337,139 @@ simulation_test!(
                 .execute(sql, &[])
                 .await
                 .expect_err("removed column must not bind in writes");
-            assert_eq!(error.code, LixError::CODE_COLUMN_NOT_FOUND, "{sql}: {error}");
+            assert_eq!(
+                error.code,
+                LixError::CODE_COLUMN_NOT_FOUND,
+                "{sql}: {error}"
+            );
         }
         let result = session
             .execute("SELECT value FROM lix_key_value WHERE key = 'example'", &[])
             .await
             .expect("row should remain unchanged");
-        assert_rows_eq(result, vec![vec![Value::Jsonb(serde_json::json!("value").into())]]);
+        assert_rows_eq(
+            result,
+            vec![vec![Value::Jsonb(serde_json::json!("value").into())]],
+        );
+    }
+);
+
+simulation_test!(
+    datafusion_scalar_expressions_in_file_updates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+        session.execute("INSERT INTO lix_file (path, content) VALUES ('/expressions.txt', CAST('hello world' AS BYTEA))", &[]).await.unwrap();
+        for expression in [
+            "replace(cast(content as text), 'world', 'DataFusion')",
+            "concat(cast(content as text), '!', '✓')",
+            "concat(cast(content as text), NULL, ' nullable')",
+            "coalesce(NULL, cast(content as text))",
+            "cast(content as text) || ' suffix'",
+            "upper(replace(cast(content as text), 'hello', 'goodbye'))",
+        ] {
+            let expected = session.execute(&format!("SELECT CAST({expression} AS BYTEA) FROM lix_file WHERE path = '/expressions.txt'"), &[]).await.unwrap();
+            session.execute(&format!("UPDATE lix_file SET content = CAST({expression} AS BYTEA) WHERE lower(path) = '/expressions.txt'"), &[]).await.unwrap();
+            let actual = session
+                .execute(
+                    "SELECT content FROM lix_file WHERE path = '/expressions.txt'",
+                    &[],
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                actual.rows()[0].values(),
+                expected.rows()[0].values(),
+                "SELECT/UPDATE mismatch for {expression}"
+            );
+        }
+        session
+            .execute(
+                "UPDATE lix_file SET content = CAST(concat($1, $2) || $3 AS BYTEA) WHERE path = $4",
+                &[
+                    Value::Text("a".into()),
+                    Value::Text("β".into()),
+                    Value::Text("c".into()),
+                    Value::Text("/expressions.txt".into()),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT content FROM lix_file WHERE path = '/expressions.txt'",
+                    &[],
+                )
+                .await
+                .unwrap(),
+            vec![vec![Value::Blob("aβc".as_bytes().to_vec().into())]],
+        );
+
+        let mut tx = session.begin_transaction().await.unwrap();
+        tx.execute("UPDATE lix_file SET content = CAST(replace(CAST(content AS TEXT), 'a', 'changed') AS BYTEA) WHERE path = '/expressions.txt'", &[]).await.unwrap();
+        tx.rollback().await.unwrap();
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT content FROM lix_file WHERE path = '/expressions.txt'",
+                    &[],
+                )
+                .await
+                .unwrap(),
+            vec![vec![Value::Blob("aβc".as_bytes().to_vec().into())]],
+        );
+
+        session.execute("UPDATE lix_file SET content = CAST(replace('a', 'b') AS BYTEA) WHERE path = '/expressions.txt'", &[]).await.expect_err("DataFusion must reject invalid arity");
+        session.execute("UPDATE lix_file SET content = CAST(nonexistent_scalar('a') AS BYTEA) WHERE path = '/expressions.txt'", &[]).await.expect_err("DataFusion must reject unknown functions");
+        assert_rows_eq(
+            session
+                .execute(
+                    "SELECT content FROM lix_file WHERE path = '/expressions.txt'",
+                    &[],
+                )
+                .await
+                .unwrap(),
+            vec![vec![Value::Blob("aβc".as_bytes().to_vec().into())]],
+        );
+    }
+);
+
+simulation_test!(
+    datafusion_scalar_expressions_in_row_updates,
+    |sim| async move {
+        let engine = sim.boot_engine().await;
+        let session = sim.wrap_session(engine.open_session().await.unwrap(), &engine);
+        session.execute("INSERT INTO lix_registered_schema (value) VALUES (CAST('{\"$schema\":\"https://lix.dev/schema-v1.json\",\"key\":\"expression_rows\",\"columns\":[{\"name\":\"id\",\"type\":\"text\",\"nullable\":false},{\"name\":\"value\",\"type\":\"text\",\"nullable\":false}],\"primary_key\":[\"id\"]}' AS JSONB))", &[]).await.unwrap();
+        session.execute("INSERT INTO expression_rows (id, value) VALUES ('one', 'hello world'), ('two', 'unchanged')", &[]).await.unwrap();
+        session.execute("UPDATE expression_rows SET value = upper(replace(value, 'world', 'SQL')) || '!' WHERE lower(id) = 'one'", &[]).await.unwrap();
+        assert_rows_eq(
+            session
+                .execute("SELECT id, value FROM expression_rows ORDER BY id", &[])
+                .await
+                .unwrap(),
+            vec![
+                vec![Value::Text("one".into()), Value::Text("HELLO SQL!".into())],
+                vec![Value::Text("two".into()), Value::Text("unchanged".into())],
+            ],
+        );
+        session
+            .execute(
+                "UPDATE expression_rows SET value = '1' WHERE id = 'one'",
+                &[],
+            )
+            .await
+            .unwrap();
+        session.execute("UPDATE expression_rows SET value = CAST(CAST(replace(value, '1', '2') AS BIGINT) AS TEXT)", &[]).await.expect_err("one invalid row must reject the whole mutation");
+        assert_rows_eq(
+            session
+                .execute("SELECT id, value FROM expression_rows ORDER BY id", &[])
+                .await
+                .unwrap(),
+            vec![
+                vec![Value::Text("one".into()), Value::Text("1".into())],
+                vec![Value::Text("two".into()), Value::Text("unchanged".into())],
+            ],
+        );
     }
 );


### PR DESCRIPTION
Lixray main uses scalar SQL UPDATE expressions for MCP file edits. This integrates that existing change with the latest server-authoritative partial-replica merge implementation, so Lixray can use one merged Lix main revision.

UPDATE assignments, predicates and RETURNING expressions use DataFusion coercion, function rewrites and simplification when native evaluation cannot handle them. Simple writes retain their fast paths. Tests cover file and registered-row updates, string concatenation, scalar functions, and information-schema metadata.

The HTTP regression reads file content with SELECT, disconnects, performs the first exact-path UPDATE using `replace` and `concat`, and reads the complete result locally. Arbitrary predicates can still require broader hydration. The server applies committed row values without reevaluating SQL.

Scope after review: general scalar expressions in registered-row INSERT/UPSERT were already unsupported before this change. Routing them to a raw DataFusion insert would bypass the existing bound mutation owner, which intentionally disables that path. This PR adds UPDATE support only; a canonical regression verifies unsupported INSERT/UPSERT cases reject atomically and leave rows unchanged. Existing supported UUID, timestamp and JSON expressions are unaffected.

Based on d001cb46c, integrated onto main after #1758. Independent reviewers approved the narrowed implementation. Validation: 4,041 native tests passed (80 skipped), all 10 documentation tests passed, and all-features/all-targets Clippy passed with warnings denied. The 31 HTTP/SDK/plugin tests passed against identical production code, including the first offline scalar UPDATE. The exact committed revision also passed all 4,041 native tests; its unchanged-source build proof and binary are archived. Full CI must pass before merge.
