### PR TITLE
Retry transient storage reads before publishing child sessions

### DIFF
--- a/.changenotes/partial-replica-browser-tabs.md
+++ b/.changenotes/partial-replica-browser-tabs.md
@@ -20,3 +20,5 @@ error reported after execution or commit cannot replay the operation.
 
 Read-interest journal flushing retries expired snapshots internally, so concurrent
 tab startup can complete without replaying the SQL that registered its inputs.
+
+Opening an additional session retries transient read invalidation during branch and admission validation, so another tab or background synchronization can commit while the session opens. Real admission and storage errors still propagate.

--- a/packages/lix/src/handle.rs
+++ b/packages/lix/src/handle.rs
@@ -1560,29 +1560,35 @@ where
         active_branch_id: impl Into<String>,
         active_account_id: impl Into<String>,
     ) -> Result<Self, LixError> {
-        if self.session.is_closed() {
-            return Err(LixError::new(
-                LixError::CODE_CLOSED,
-                "cannot open a session from a closed Lix handle",
-            ));
-        }
         let active_branch_id = active_branch_id.into();
-        if self
-            .engine
-            .load_branch_head_commit_id(&active_branch_id)
-            .await?
-            .is_none()
-        {
-            return Err(LixError::branch_not_found(
-                active_branch_id,
-                "open_another_session",
-                "target",
-            ));
-        }
-        let session = self
-            .engine
-            .open_session_at_with_account(active_branch_id, active_account_id)
-            .await?;
+        let active_account_id = active_account_id.into();
+        // Admission reads can expire while another session or background sync
+        // commits. Restart only this read/validation unit; the child handle and
+        // sync lease are published once, after it succeeds.
+        let session = retry_expired_read(|| async {
+            if self.session.is_closed() {
+                return Err(LixError::new(
+                    LixError::CODE_CLOSED,
+                    "cannot open a session from a closed Lix handle",
+                ));
+            }
+            if self
+                .engine
+                .load_branch_head_commit_id(&active_branch_id)
+                .await?
+                .is_none()
+            {
+                return Err(LixError::branch_not_found(
+                    active_branch_id.clone(),
+                    "open_another_session",
+                    "target",
+                ));
+            }
+            self.engine
+                .open_session_at_with_account(active_branch_id.clone(), active_account_id.clone())
+                .await
+        })
+        .await?;
         Ok(Self {
             engine: self.engine.clone(),
             session: Arc::new(session),
@@ -3896,3 +3902,7 @@ where
 {
     partial::retry_partial_migration_cleanup(storage, server).await
 }
+
+#[cfg(test)]
+#[path = "handle/session_open_retry_tests.rs"]
+mod session_open_retry_tests;

--- a/packages/lix/src/handle/session_open_retry_tests.rs
+++ b/packages/lix/src/handle/session_open_retry_tests.rs
@@ -1,0 +1,105 @@
+use super::*;
+use crate::storage::{MemoryRead, MemoryWrite, ReadOptions, StorageError, WriteOptions};
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+#[derive(Clone)]
+struct ReadFaultStorage {
+    inner: Memory,
+    faults: Arc<Mutex<VecDeque<Option<StorageError>>>>,
+    read_calls: Arc<AtomicUsize>,
+    failures: Arc<AtomicUsize>,
+}
+
+impl Storage for ReadFaultStorage {
+    type Read<'a>
+        = MemoryRead
+    where
+        Self: 'a;
+    type Write<'a>
+        = MemoryWrite
+    where
+        Self: 'a;
+
+    async fn acquire_session(&self) -> Result<crate::storage::StorageSessionToken, StorageError> {
+        self.inner.acquire_session().await
+    }
+    async fn begin_read(&self, options: ReadOptions) -> Result<Self::Read<'_>, StorageError> {
+        self.read_calls.fetch_add(1, Ordering::SeqCst);
+        let fault = self.faults.lock().unwrap().pop_front().flatten();
+        if let Some(error) = fault {
+            self.failures.fetch_add(1, Ordering::SeqCst);
+            return Err(error);
+        }
+        self.inner.begin_read(options).await
+    }
+    async fn begin_write(&self, options: WriteOptions) -> Result<Self::Write<'_>, StorageError> {
+        self.inner.begin_write(options).await
+    }
+}
+
+#[tokio::test]
+async fn child_session_retries_expired_admission_reads_without_retaining_failed_children() {
+    let storage = ReadFaultStorage {
+        inner: Memory::new(),
+        faults: Arc::default(),
+        read_calls: Arc::default(),
+        failures: Arc::default(),
+    };
+    let root = open_lix().with_storage(storage.clone()).await.unwrap();
+    let baseline = Arc::strong_count(&root.engine);
+    // Expire both the first branch read and a later validation read. Each
+    // attempt owns fresh canonical Memory reads and constructs no failed child.
+    for before_failure in [0, 1] {
+        let mut faults = vec![None; before_failure];
+        faults.extend([
+            Some(StorageError::ReadExpired),
+            Some(StorageError::ReadExpired),
+        ]);
+        *storage.faults.lock().unwrap() = faults.into();
+        let child = root.open_another_session().await.unwrap();
+        assert!(
+            storage.faults.lock().unwrap().is_empty(),
+            "admission consumed every injected read failure before child publication"
+        );
+        assert_eq!(
+            child.active_branch_id().await.unwrap(),
+            root.active_branch_id().await.unwrap()
+        );
+        child.execute("SELECT 1", &[]).await.unwrap();
+        child.close().await.unwrap();
+        drop(child);
+        assert_eq!(Arc::strong_count(&root.engine), baseline);
+    }
+    assert_eq!(storage.failures.load(Ordering::SeqCst), 4);
+    root.execute("SELECT 1", &[]).await.unwrap();
+    root.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn child_session_preserves_real_storage_errors_and_parent_lifecycle() {
+    let storage = ReadFaultStorage {
+        inner: Memory::new(),
+        faults: Arc::default(),
+        read_calls: Arc::default(),
+        failures: Arc::default(),
+    };
+    let root = open_lix().with_storage(storage.clone()).await.unwrap();
+    let baseline = Arc::strong_count(&root.engine);
+    storage.read_calls.store(0, Ordering::SeqCst);
+    *storage.faults.lock().unwrap() =
+        [Some(StorageError::Corruption("admission-corrupt".into()))].into();
+    let error = root
+        .open_another_session()
+        .await
+        .err()
+        .expect("real storage failure must escape");
+    assert_eq!(error.code, LixError::CODE_STORAGE_ERROR);
+    assert!(error.message.contains("admission-corrupt"));
+    assert_eq!(storage.read_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(Arc::strong_count(&root.engine), baseline);
+    let child = root.open_another_session().await.unwrap();
+    child.close().await.unwrap();
+    root.execute("SELECT 1", &[]).await.unwrap();
+    root.close().await.unwrap();
+}


### PR DESCRIPTION
Opening two browser tabs against one partial replica can fail before the UI loads: another session or background sync commits while the child session reads branch/admission metadata, and `LIX_STORAGE_READ_EXPIRED` escapes from `openAnotherSession`.

Retry the existing read-and-validation unit using Lix's bounded expired-read policy. Each attempt rechecks the parent handle, branch and partial admission. The child handle and sync lease are published only after success; real storage/admission errors retain their existing behavior. No SQL or writes are replayed, and no public API changes.

The production-image Lixray conflict test exposed this opening race before editing began. Canonical Memory fault tests cover expiry at multiple read points, nonretryable errors and parent/child cleanup. Independent review approved the final retry boundary and tests. All 4,043 native tests passed (80 skipped), as did all-features/all-targets Clippy. All 10 documentation tests passed. The source-stable native build proof is archived; the production-image two-tab/four-editor test passed in 42.8 seconds, including both offline conflict acceptance orders. The previous candidate failed during child-session opening; the exact reviewed artifact now opens and converges successfully.
